### PR TITLE
Add Ceilometer to Quickstack

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -232,6 +232,8 @@ end
 params = {
   "verbose"                    => "true",
   "admin_password"             => SecureRandom.hex,
+  "ceilometer_metering_secret" => SecureRandom.hex,
+  "ceilometer_user_password"   => SecureRandom.hex,
   "cinder_db_password"         => SecureRandom.hex,
   "cinder_user_password"       => SecureRandom.hex,
   "glance_db_password"         => SecureRandom.hex,

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -1,5 +1,7 @@
 # Common quickstack configurations
 class quickstack::nova_network::compute (
+  $ceilometer_metering_secret = $quickstack::params::ceilometer_metering_secret,
+  $ceilometer_user_password   = $quickstack::params::ceilometer_user_password,
   $fixed_network_range        = $quickstack::params::fixed_network_range,
   $floating_network_range     = $quickstack::params::floating_network_range,
   $nova_db_password           = $quickstack::params::nova_db_password,
@@ -76,4 +78,16 @@ class quickstack::nova_network::compute (
         action   => 'accept',
     }
 
+    class { 'ceilometer':
+        metering_secret => $ceilometer_metering_secret,
+        qpid_hostname   => $pacemaker_priv_floating_ip,
+        rpc_backend     => 'ceilometer.openstack.common.rpc.impl_qpid',
+        verbose         => $verbose,
+        debug           => true,
+    }
+
+    class { 'ceilometer::agent::compute':
+        auth_url      => "http://${pacemaker_priv_floating_ip}:35357/v2.0",
+        auth_password => $ceilometer_user_password,
+    }
 }

--- a/puppet/modules/quickstack/manifests/nova_network/controller.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/controller.pp
@@ -5,6 +5,8 @@
 class quickstack::nova_network::controller (
   $admin_email                = $quickstack::params::admin_email,
   $admin_password             = $quickstack::params::admin_password,
+  $ceilometer_metering_secret = $quickstack::params::ceilometer_metering_secret,
+  $ceilometer_user_password   = $quickstack::params::ceilometer_user_password,
   $cinder_db_password         = $quickstack::params::cinder_db_password,
   $cinder_user_password       = $quickstack::params::cinder_user_password,
   $glance_db_password         = $quickstack::params::glance_db_password,
@@ -91,11 +93,56 @@ class quickstack::nova_network::controller (
         address  => $pacemaker_priv_floating_ip,
     }
 
+    class { 'ceilometer::keystone::auth':
+        password => $ceilometer_user_password,
+        public_address => $pacemaker_priv_floating_ip,
+        admin_address => $pacemaker_priv_floating_ip,
+        internal_address => $pacemaker_priv_floating_ip,
+    }
+
     class {'openstack::glance':
         db_host               => $pacemaker_priv_floating_ip,
         user_password  => $glance_user_password,
         db_password    => $glance_db_password,
         require               => Class['openstack::db::mysql'],
+    }
+
+    # Configure Ceilometer
+    class { 'mongodb':
+       enable_10gen => false,
+       port         => '27017',
+    }
+
+    class { 'ceilometer':
+        metering_secret => $ceilometer_metering_secret,
+        qpid_hostname   => $pacemaker_priv_floating_ip,
+        rpc_backend     => 'ceilometer.openstack.common.rpc.impl_qpid',
+        verbose         => $verbose,
+        debug           => true,
+    }
+
+    class { 'ceilometer::db':
+        database_connection => 'mongodb://localhost:27017/ceilometer',
+        require             => Class['mongodb'],
+    }
+
+    class { 'ceilometer::collector':
+        require => Class['ceilometer::db'],
+    }
+
+    class { 'ceilometer::agent::central':
+        auth_url      => "http://${pacemaker_priv_floating_ip}:35357/v2.0",
+        auth_password => $ceilometer_user_password,
+    }
+
+    class { 'ceilometer::api':
+        keystone_host     => $pacemaker_priv_floating_ip,
+        keystone_password => $ceilometer_user_password,
+        require           => Class['mongodb'],
+    }
+
+    glance_api_config {
+        'DEFAULT/notifier_strategy': value => 'qpid'
     }
 
     # Configure Nova

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -5,6 +5,8 @@ class quickstack::params {
   # during the setup process. This will move to the Foreman API v2
   # at some point.
   $admin_password             = 'CHANGEME'
+  $ceilometer_metering_secret = 'CHANGEME'
+  $ceilometer_user_password   = 'CHANGEME'
   $cinder_db_password         = 'CHANGEME'
   $cinder_user_password       = 'CHANGEME'
   $glance_db_password         = 'CHANGEME'


### PR DESCRIPTION
- All services install fine, but `mongodb` and `ceilometer` Puppet modules need to be manually added to Foreman host currently.
- To solve the manual ^^ installation `packstack-modules-puppet` package in http://repos.fedorapeople.org/repos/openstack/openstack-havana/epel-6/ needs `mongodb` and `ceilometer` modules, as added here: https://review.openstack.org/#/c/41245
- I couldn't get any metering data on the Ceilometer master, but neither any complaints in the compute agent log. I need to investigate what's wrong.
