### PR TITLE
Adding the dependency on nc in foreman_client.sh

### DIFF
--- a/bin/foreman_server.sh
+++ b/bin/foreman_server.sh
@@ -228,7 +228,7 @@ fi
 cat >/tmp/foreman_client.sh <<EOF
 
 # start with a subscribed RHEL6 box needs optional channels and epel
-yum install -y augeas puppet
+yum install -y augeas puppet nc
 
 # Puppet configuration
 augtool -s <<EOA


### PR DESCRIPTION
puppet agent --test ends up calling "python
/var/lib/puppet/lib/facter/netns.py" which complains if nc is not
installed.  So, let's add that dependency.  I'm also hoping this
addition will prevent hangs in foreman_client.sh (I found this issue
investigating a hang).
