### PR TITLE
Heat: Added optional components to nova/neutron controller

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -231,6 +231,8 @@ end
 
 params = {
   "verbose"                      => "true",
+  "heat_cfn"                     => "false",
+  "heat_cloudwatch"              => "false",
   "admin_password"               => SecureRandom.hex,
   "ceilometer_metering_secret"   => SecureRandom.hex,
   "ceilometer_user_password"     => SecureRandom.hex,

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -1,6 +1,9 @@
 class quickstack::params {
   $verbose                    = 'true'
 
+  $heat_cfn                   = 'CHANGEME',
+  $heat_cloudwatch            = 'CHANGEME',
+  
   # Passwords are currently changed to decent strings by sed
   # during the setup process. This will move to the Foreman API v2
   # at some point.


### PR DESCRIPTION
This patch will add the support for heat cloudformation and for
heat cloudwatch in the foreman installation based on the boolean
variables $heat_cfn and $heat_cloudformation that when set to true,
will install the components.
