### PR TITLE
Fix quickstack::neutron::controller to pass the requisite params to ceilometer, cinder and heat controllers

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -158,6 +158,8 @@ class quickstack::neutron::controller (
       heat_db_password            => $heat_db_password,
       controller_priv_floating_ip => $controller_priv_floating_ip,
       controller_pub_floating_ip  => $controller_pub_floating_ip,
+      mysql_host                  => $mysql_host,
+      qpid_host                   => $qpid_host,
       verbose                     => $verbose,
     }
 


### PR DESCRIPTION
The ceilometer, cinder, and heat classes were missing some params that are in the nova::controller, and would cause the puppet install to fail. This fixes that error.
