### PR TITLE
Add proxy for horizon with cookie support

### DIFF
--- a/puppet/modules/quickstack/manifests/load_balancer.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer.pp
@@ -68,12 +68,12 @@ class quickstack::load_balancer (
     listen_options => { 'option' => [ 'httplog' ] },
     member_options => [ 'check' ],
   }
-  quickstack::load_balancer::proxy { 'swift-proxy':
-    addr => [ $lb_public_vip, $lb_private_vip ],
-    port => '8080',
-    listen_options => { 'option' => [ 'httplog' ] },
-    member_options => [ 'check' ],
-  }
+  # quickstack::load_balancer::proxy { 'swift-proxy':
+  #   addr => [ $lb_public_vip, $lb_private_vip ],
+  #   port => '8080',
+  #   listen_options => { 'option' => [ 'httplog' ] },
+  #   member_options => [ 'check' ],
+  # }
   quickstack::load_balancer::proxy { 'nova-ec2':
     addr => [ $lb_public_vip, $lb_private_vip ],
     port => '8773',


### PR DESCRIPTION
This patch adds a proxy for load-balancing horizon. Persistence is
done with a SERVERID cookie. This patch also extends the proxy defined
resource to accept more options (addr, mode, listen_options,
member_options, and define_cookies).
