### PR TITLE
Add flag to make controllers HA.

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -273,6 +273,7 @@ params = {
   "lb_public_vip"                => '',
   "lb_member_names"              => '',
   "lb_member_addrs"              => '',
+  "is_ha"                        => false,
 }
 
 hostgroups = [

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -24,7 +24,8 @@ class quickstack::neutron::controller (
   $controller_pub_floating_ip   = $quickstack::params::controller_pub_floating_ip,
   $mysql_host                   = $quickstack::params::mysql_host,
   $qpid_host                    = $quickstack::params::qpid_host,
-  $verbose                      = $quickstack::params::verbose
+  $verbose                      = $quickstack::params::verbose,
+  $is_ha                        = $quickstack::params::is_ha
 ) inherits quickstack::params {
 
     class {'openstack::db::mysql':
@@ -43,7 +44,7 @@ class quickstack::neutron::controller (
         neutron                => true,
 
         allowed_hosts          => ['%',$controller_priv_floating_ip],
-        enabled                => true,
+        enabled                => $is_ha,
     }
 
     class {'qpid::server':

--- a/puppet/modules/quickstack/manifests/nova_network/controller.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/controller.pp
@@ -25,29 +25,10 @@ class quickstack::nova_network::controller (
   $controller_pub_floating_ip  = $quickstack::params::controller_pub_floating_ip,
   $mysql_host                  = $quickstack::params::mysql_host,
   $qpid_host                   = $quickstack::params::qpid_host,
-  $verbose                     = $quickstack::params::verbose
+  $verbose                     = $quickstack::params::verbose,
+  $is_ha                       = $quickstack::params::is_ha
 ) inherits quickstack::params {
 
-    #controller::corosync { 'quickstack': }
-
-    #controller::corosync::node { '10.100.0.2': }
-    #controller::corosync::node { '10.100.0.3': }
-
-    #controller::resources::ip { '8.21.28.222':
-    #    address => '8.21.28.222',
-    #}
-    #controller::resources::ip { '10.100.0.222':
-    #    address => '10.100.0.222',
-    #}
-
-    #controller::resources::lsb { 'qpidd': }
-
-    #controller::stonith::ipmilan { $ipmi_address:
-    #    address  => $ipmi_address,
-    #    user     => $ipmi_user,
-    #    password => $ipmi_pass,
-    #    hostlist => $ipmi_host_list,
-    #}
 
     class {'openstack::db::mysql':
         mysql_root_password  => $mysql_root_password,
@@ -65,7 +46,7 @@ class quickstack::nova_network::controller (
         neutron                => false,
 
         allowed_hosts          => '%',
-        enabled                => true,
+        enabled                => $is_ha,
     }
 
     class {'qpid::server':

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -1,5 +1,6 @@
 class quickstack::params {
   $verbose                    = 'true'
+  $is_ha                      = false
 
   $heat_cfn                   = 'false'
   $heat_cloudwatch            = 'false'


### PR DESCRIPTION
The idea is that we just dont leave the local db running on the controller, and
point the $mysql_host variable at the cluster VIP.

NOTE: This is totally untested so efinitely don't merge it on a read-only.  I just wanted to get the idea out there, and hopefully @cwolferh can give it a go later to see how it works?
