### PR TITLE
remove clusterlabs repo, use rhel ha channel instead

### DIFF
--- a/puppet/modules/quickstack/manifests/hamysql/node.pp
+++ b/puppet/modules/quickstack/manifests/hamysql/node.pp
@@ -20,13 +20,6 @@ class quickstack::hamysql::node (
 
 ) inherits quickstack::params {
 
-    yumrepo { 'clusterlabs' :
-      baseurl => "http://clusterlabs.org/64z.repo",
-      enabled => 1,
-      priority => 1,
-      gpgcheck => 0, # since the packages (eg pcs) don't appear to be signed
-    }
-
     package { 'mysql-server':
       ensure => installed,
     }
@@ -47,7 +40,7 @@ class quickstack::hamysql::node (
     class {'pacemaker::corosync':
       cluster_name => "hamysql",
       cluster_members => $mysql_clu_member_addrs,
-      require => [Yumrepo['clusterlabs'],Package['mysql-server'],
+      require => [Package['mysql-server'],
                   Package['MySQL-python'],Package['ccs'],
                   Class['quickstack::hamysql::mysql::config']],
     }


### PR DESCRIPTION
Do not merge until latest pacemaker bits land in the Red Hat HA channel.
