### PR TITLE
Add options for SSL support either via files or FreeIPA

### DIFF
--- a/bin/foreman_server.sh
+++ b/bin/foreman_server.sh
@@ -29,6 +29,9 @@ if [ "x$FOREMAN_PROVISIONING" = "x" ]; then
 fi
 
 # openstack networking configs.  These must be set to something sensible.
+
+# For each controller, only the IP or FQDN value should be provided. If you
+# intend to enable SSL then setting the FQDN values is required.
 #PRIVATE_CONTROLLER_IP=10.0.0.10
 #PRIVATE_INTERFACE=eth1
 #PRIVATE_NETMASK=10.0.0.0/23
@@ -36,8 +39,11 @@ fi
 #PUBLIC_INTERFACE=eth2
 #PUBLIC_NETMASK=10.9.9.0/24
 #FOREMAN_GATEWAY=10.0.0.1 (or false for no gateway)
-if [ "x$PRIVATE_CONTROLLER_IP" = "x" ]; then
-  echo "You must define PRIVATE_CONTROLLER_IP before running this script"
+#PRIVATE_CONTROLLER_FQDN=private.example.com
+#PUBLIC_CONTROLLER_FQDN=public.example.com
+if [ "x$PRIVATE_CONTROLLER_FQDN" = "x" -a "x$PRIVATE_CONTROLLER_IP" = "x" ];
+then
+  echo "You must define either PRIVATE_CONTROLLER_IP or PRIVATE_CONTROLLER_FQDN before running this script"
   exit 1
 fi
 if [ "x$PRIVATE_INTERFACE" = "x" ]; then
@@ -48,8 +54,9 @@ if [ "x$PRIVATE_NETMASK" = "x" ]; then
   echo "You must define PRIVATE_NETMASK before running this script"
   exit 1
 fi
-if [ "x$PUBLIC_CONTROLLER_IP" = "x" ]; then
-  echo "You must define PUBLIC_CONTROLLER_IP before running this script"
+if [ "x$PUBLIC_CONTROLLER_FQDN" = "x" -a "x$PUBLIC_CONTROLLER_IP" = "x" ];
+then
+  echo "You must define either PRIVATE_CONTROLLER_IP or PUBLIC_CONTROLLER_FQDN before running this script"
   exit 1
 fi
 if [ "x$PUBLIC_INTERFACE" = "x" ]; then
@@ -90,6 +97,18 @@ fi
 if [ ! -d $FOREMAN_INSTALLER_DIR ]; then
   echo "$FOREMAN_INSTALLER_DIR does not exist.  exiting"
   exit 1
+fi
+
+if [ "x$PUBLIC_CONTROLLER_IP" != "x" ]; then
+  PUBLIC_CONTROLLER_NAME=$PUBLIC_CONTROLLER_IP
+else
+  PUBLIC_CONTROLLER_NAME=$PUBLIC_CONTROLLER_FQDN
+fi
+
+if [ "x$PRIVATE_CONTROLLER_IP" != "x" ]; then
+  PRIVATE_CONTROLLER_NAME=$PRIVATE_CONTROLLER_IP
+else
+  PRIVATE_CONTROLLER_NAME=$PRIVATE_CONTROLLER_FQDN
 fi
 
 if [ ! -f foreman_server.sh ]; then
@@ -204,8 +223,8 @@ cp ./seeds.rb $FOREMAN_DIR/db/.
 sed -i "s#SECONDARY_INT#$SECONDARY_INT#" $FOREMAN_DIR/db/seeds.rb
 sed -i "s#PRIV_INTERFACE#$PRIVATE_INTERFACE#" $FOREMAN_DIR/db/seeds.rb
 sed -i "s#PUB_INTERFACE#$PUBLIC_INTERFACE#" $FOREMAN_DIR/db/seeds.rb
-sed -i "s#PRIV_IP#$PRIVATE_CONTROLLER_IP#" $FOREMAN_DIR/db/seeds.rb
-sed -i "s#PUB_IP#$PUBLIC_CONTROLLER_IP#" $FOREMAN_DIR/db/seeds.rb
+sed -i "s#PRIV_IP#$PRIVATE_CONTROLLER_NAME#" $FOREMAN_DIR/db/seeds.rb
+sed -i "s#PUB_IP#$PUBLIC_CONTROLLER_NAME#" $FOREMAN_DIR/db/seeds.rb
 sed -i "s#PRIV_RANGE#$PRIVATE_NETMASK#" $FOREMAN_DIR/db/seeds.rb
 sed -i "s#PUB_RANGE#$PUBLIC_NETMASK#" $FOREMAN_DIR/db/seeds.rb
 sudo -u foreman scl enable ruby193 "cd $FOREMAN_DIR; rake db:seed RAILS_ENV=production FOREMAN_PROVISIONING=$FOREMAN_PROVISIONING"

--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -287,6 +287,18 @@ params = {
   "lb_member_names"              => '',
   "lb_member_addrs"              => '',
   "configure_ovswitch"           => "true",
+  "ssl"                          => false,
+  "freeipa"                      => false,
+  "mysql_ca"                     => "/etc/ipa/ca.crt",
+  "mysql_cert"                   => "/etc/pki/tls/certs/PRIV_IP-mysql.crt",
+  "mysql_key"                    => "/etc/pki/tls/private/PRIV_IP-mysql.key",
+  "qpid_ca"                      => "/etc/ipa/ca.crt",
+  "qpid_cert"                    => "/etc/pki/tls/certs/PRIV_IP-qpid.crt",
+  "qpid_key"                     => "/etc/pki/tls/private/PRIV_IP-qpid.key",
+  "horizon_ca"                   => "/etc/ipa/ca.crt",
+  "horizon_cert"                 => "/etc/pki/tls/certs/PUB_IP-horizon.crt",
+  "horizon_key"                  => "/etc/pki/tls/private/PUB_IP-horizon.key",
+  "qpid_nssdb_password"          => SecureRandom.hex,
 }
 
 hostgroups = [

--- a/puppet/modules/quickstack/manifests/ceilometer_controller.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer_controller.pp
@@ -4,6 +4,8 @@ class quickstack::ceilometer_controller(
   $controller_priv_floating_ip,
   $controller_pub_floating_ip,
   $qpid_host,
+  $qpid_port = '5672',
+  $qpid_protocol = 'tcp',
   $verbose,
 ) {
 
@@ -48,7 +50,11 @@ class quickstack::ceilometer_controller(
         require           => Class['mongodb'],
     }
 
-    glance_api_config {
-        'DEFAULT/notifier_strategy': value => 'qpid'
+    class { 'glance::notify::qpid':
+        qpid_username => '',
+        qpid_password => '',
+        qpid_host     => $qpid_host,
+        qpid_port     => $qpid_port,
+        qpid_protocol => $qpid_protocol
     }
 }

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -12,8 +12,11 @@ class quickstack::nova_network::compute (
   $mysql_host                  = $quickstack::params::mysql_host,
   $qpid_host                   = $quickstack::params::qpid_host,
   $verbose                     = $quickstack::params::verbose,
+  $ssl                         = $quickstack::params::ssl,
+  $mysql_ca                    = $quickstack::params::mysql_ca,
 ) inherits quickstack::params {
 
+    }
     # Configure Nova
     nova_config{
         'DEFAULT/auto_assign_floating_ip':  value => 'True';
@@ -25,12 +28,25 @@ class quickstack::nova_network::compute (
         "DEFAULT/multi_host":               value => "True";
     }
 
+    if str2bool($ssl) == true {
+      $qpid_protocol = 'ssl'
+      $qpid_port = '5671'
+      $nova_sql_connection = "mysql://nova:${nova_db_password}@${mysql_host}/nova?ssl_ca=${mysql_ca}"
+
+    } else {
+      $qpid_protocol = 'tcp'
+      $qpid_port = '5672'
+      $nova_sql_connection = "mysql://nova:${nova_db_password}@${mysql_host}/nova"
+    }
+
     class { 'nova':
-        sql_connection     => "mysql://nova:${nova_db_password}@${mysql_host}/nova",
+        sql_connection     => $nova_sql_connection,
         image_service      => 'nova.image.glance.GlanceImageService',
         glance_api_servers => "http://$controller_priv_floating_ip:9292/v1",
         rpc_backend        => 'nova.openstack.common.rpc.impl_qpid',
         qpid_hostname      => $qpid_host,
+        qpid_protocol      => $qpid_protocol,
+        qpid_port          => $qpid_port,
         verbose            => $verbose,
     }
 

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -71,4 +71,18 @@ class quickstack::params {
   $mysql_resource_group_name     = 'mysqlgroup'
   # Logs
   $admin_email                = "admin@${::domain}"
+
+  # SSL
+  $ssl                        = false
+  $freeipa                    = false
+  $mysql_ca                   = '/etc/ipa/ca.crt'
+  $mysql_cert                 = undef
+  $mysql_key                  = undef
+  $qpid_ca                    = undef
+  $qpid_cert                  = undef
+  $qpid_key                   = undef
+  $horizon_ca                 = '/etc/ipa/ca.crt'
+  $horizon_cert               = undef
+  $horizon_key                = undef
+  $qpid_nssdb_password        = 'CHANGEME'
 }


### PR DESCRIPTION
Adds options to configure qpid, mysql and horizon with SSL on a basic nova controller and compute node.

In order to use SSL you need FQDNs so I added two not options to foreman_server.sh, so if you don't want to use SSL then continue to user IP addresses. Otherwise configure using a FQDN. I left the puppet variables still named floating_ip.

This relies on some upstream work in the puppet-qpid and mysql modules and requires puppet-certmonger and puppet-nssdb on github.
