### PR TITLE
Replaced wrongly set Neutron user password 

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -28,7 +28,7 @@ class quickstack::neutron::controller (
   $cisco_nexus_plugin           = $quickstack::params::cisco_nexus_plugin,
   $nexus_credentials            = $quickstack::params::nexus_credentials,
   $provider_vlan_auto_create    = $quickstack::params::provider_vlan_auto_create,
-  $provider_vlan_auto_trunk     = $quickstack::params::provider_vlan_auto_trunk,  
+  $provider_vlan_auto_trunk     = $quickstack::params::provider_vlan_auto_trunk,
   $nova_db_password             = $quickstack::params::nova_db_password,
   $nova_user_password           = $quickstack::params::nova_user_password,
   $controller_priv_floating_ip  = $quickstack::params::controller_priv_floating_ip,
@@ -132,7 +132,7 @@ class quickstack::neutron::controller (
         'keystone_authtoken/admin_tenant_name': value => 'admin';
         'keystone_authtoken/admin_user':        value => 'admin';
         'keystone_authtoken/admin_password':    value => $admin_password;
-        'keystone_authtoken/auth_host':         value => '127.0.0.1';  
+        'keystone_authtoken/auth_host':         value => '127.0.0.1';
     }
 
     class { [ 'nova::scheduler', 'nova::cert', 'nova::consoleauth', 'nova::conductor' ]:
@@ -206,7 +206,7 @@ class quickstack::neutron::controller (
     }
 
     class { '::neutron::keystone::auth':
-        password         => $admin_password,
+        password         => $neutron_user_password,
         public_address   => $controller_pub_floating_ip,
         admin_address    => $controller_priv_floating_ip,
         internal_address => $controller_priv_floating_ip,
@@ -214,7 +214,7 @@ class quickstack::neutron::controller (
 
     class { '::neutron::server':
         auth_host        => $::ipaddress,
-        auth_password    => $admin_password,
+        auth_password    => $neutron_user_password,
      }
 
     if $neutron_core_plugin == 'neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2' {
@@ -232,7 +232,7 @@ class quickstack::neutron::controller (
     }
 
     if $neutron_core_plugin == 'neutron.plugins.cisco.network_plugin.PluginV2' {
-        class { 'quickstack::neutron::plugins::cisco': 
+        class { 'quickstack::neutron::plugins::cisco':
             neutron_db_password          => $neutron_db_password,
             neutron_user_password        => $neutron_user_password,
             bridge_interface             => $external_interface,
@@ -247,14 +247,14 @@ class quickstack::neutron::controller (
             tenant_network_type          => $tenant_network_type,
         }
     }
-    
+
     class { '::nova::network::neutron':
         neutron_admin_password    => $neutron_user_password,
     }
 
     firewall { '001 controller incoming':
         proto    => 'tcp',
-        dport    => ['80', '443', '3260', '3306', '5000', '35357', '5672', '8773', '8774', '8775', '8776', '9292', '6080', '9696'],   
+        dport    => ['80', '443', '3260', '3306', '5000', '35357', '5672', '8773', '8774', '8775', '8776', '9292', '6080', '9696'],
         action   => 'accept',
     }
 

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -20,13 +20,12 @@ class quickstack::neutron::networker (
         rpc_backend           => 'neutron.openstack.common.rpc.impl_qpid',
         qpid_hostname         => $qpid_host,
     }
-    
+
     neutron_config {
         'database/connection': value => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron";
-
-        'keystone_authtoken/admin_tenant_name': value => 'admin';
-        'keystone_authtoken/admin_user':        value => 'admin';
-        'keystone_authtoken/admin_password':    value => $admin_password;
+        'keystone_authtoken/admin_tenant_name': value => 'services';
+        'keystone_authtoken/admin_user':        value => 'neutron';
+        'keystone_authtoken/admin_password':    value => $neutron_user_password;
         'keystone_authtoken/auth_host':         value => $controller_priv_floating_ip;
     }
 


### PR DESCRIPTION
There is some mismatches where neutron user password was wrongly assigned to admin_password.
Nova could not communicate with neutron providing an authentication error.

Also, notice some lines containing trailing white space(s) got replaced (automatically by my editor!) but I think it's a good thing anyway.
