### PR TITLE
More foreman 13 fixes

### DIFF
--- a/bin/foreman_server.sh
+++ b/bin/foreman_server.sh
@@ -159,7 +159,9 @@ class { 'foreman':
 #
 # Check foreman_proxy/manifests/{init,params}.pp for other options
 class { 'foreman_proxy':
-  custom_repo  => true,
+  custom_repo          => true,
+  port                 => '9090',
+  registered_proxy_url => "https://\${::fqdn}:9090",
 EOM
 
 if [ "$FOREMAN_PROVISIONING" = "true" ]; then


### PR DESCRIPTION
Proxy install would fail before because it uses port 8443 by default, which is what mod_nss runs on. Also, the old call to foreman-setup.rb causes an additional error for no reason.  The foreman-installer itself takes care of setting up a new proxy now (it will use the fqdn as the proxy name)
