### PR TITLE
Update use of ceilometer puppet classes

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer_controller.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer_controller.pp
@@ -37,9 +37,13 @@ class quickstack::ceilometer_controller(
         require => Class['ceilometer::db'],
     }
 
-    class { 'ceilometer::agent::central':
+    class { 'ceilometer::agent::auth':
         auth_url      => "http://${controller_priv_floating_ip}:35357/v2.0",
         auth_password => $ceilometer_user_password,
+    }
+
+    class { 'ceilometer::agent::central':
+        enabled => true,
     }
 
     class { 'ceilometer::api':

--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -69,9 +69,13 @@ class quickstack::compute_common (
     verbose         => $verbose,
   }
 
-  class { 'ceilometer::agent::compute':
+  class { 'ceilometer::agent::auth':
     auth_url      => "http://${controller_priv_floating_ip}:35357/v2.0",
     auth_password => $ceilometer_user_password,
+  }
+
+  class { 'ceilometer::agent::compute':
+    enabled => true,
   }
 
   firewall { '001 nova compute incoming':


### PR DESCRIPTION
This patch updates the ceilometer_controller.pp and compute_common.pp
to work with updated ceilometer puppet module. These manifests now
use the ceilometer::agents::auth class to setup authentication and the
the ceilometer::agents::central and ceilometer::agents::compute
classes to enable the agents.
