### PR TITLE
Use booleans to create proxy for optional services

### DIFF
--- a/puppet/modules/quickstack/manifests/load_balancer.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer.pp
@@ -86,13 +86,13 @@ class quickstack::load_balancer (
     listen_options => { 'option' => [ 'httplog' ] },
     member_options => [ 'check' ],
   }
-  # quickstack::load_balancer::proxy { 'swift-proxy':
-  #   addr => [ $lb_public_vip, $lb_private_vip ],
-  #   port => '8080',
-  #   mode => 'http',
-  #   listen_options => { 'option' => [ 'httplog' ] },
-  #   member_options => [ 'check' ],
-  # }
+  quickstack::load_balancer::proxy { 'swift-proxy':
+    addr => [ $lb_public_vip, $lb_private_vip ],
+    port => '8080',
+    mode => 'http',
+    listen_options => { 'option' => [ 'httplog' ] },
+    member_options => [ 'check' ],
+  }
   quickstack::load_balancer::proxy { 'nova-ec2':
     addr => [ $lb_public_vip, $lb_private_vip ],
     port => '8773',


### PR DESCRIPTION
This patch adds boolean parameters to the load balancer manifest such
that optional service (neutron, heat_cfn, heat_cloudwatch) will only
have a proxy created when the associated boolean is set to true.
