### PR TITLE
Fix enable/disable of heat_cfg and heat_cloudwatch

### DIFF
--- a/puppet/modules/quickstack/manifests/heat_controller.pp
+++ b/puppet/modules/quickstack/manifests/heat_controller.pp
@@ -10,8 +10,7 @@ class quickstack::heat_controller(
   $verbose,
 ) {
 
-  if str2bool($heat_cfn) == true {
-    class {"heat::keystone::auth":
+  class {"heat::keystone::auth":
       password => $heat_user_password,
       heat_public_address => $controller_pub_floating_ip,
       heat_admin_address => $controller_priv_floating_ip,
@@ -19,15 +18,6 @@ class quickstack::heat_controller(
       cfn_public_address => $controller_pub_floating_ip,
       cfn_admin_address => $controller_priv_floating_ip,
       cfn_internal_address => $controller_priv_floating_ip,
-    }
-  } else {
-    class {"heat::keystone::auth":
-      password => $heat_user_password,
-      heat_public_address => $controller_pub_floating_ip,
-      heat_admin_address => $controller_priv_floating_ip,
-      heat_internal_address => $controller_priv_floating_ip,
-      cfn_auth_name => undef,
-    }
   }
 
   class { 'heat':
@@ -39,14 +29,12 @@ class quickstack::heat_controller(
       verbose           => $verbose,
   }
 
-  if str2bool($heat_cfn) == true {
-    class { 'heat::api_cfn':
-    }
+  class { 'heat::api_cfn':
+      enabled => str2bool($heat_cfn),
   }
 
-  if str2bool($heat_cloudwatch) == true {
-    class { 'heat::api_cloudwatch':
-    }
+  class { 'heat::api_cloudwatch':
+      enabled => str2bool($heat_cloudwatch),
   }
 
   class { 'heat::engine':


### PR DESCRIPTION
This patch modifies the heat_controller.pp manifest such that the
heat_cfn and heat_cloudwatch services are enabled/disabled per the
heat_cfn and heat_cloudwatch boolean parameters. Previously, once
either boolean had been set to true the services would be running on
the controller, but reverting either parameter to false would not
stop/disable the service.

This patch also fixes the call to the heat::keystone::auth class such
that the heat_cfn endpoints are always created with the correct IP
addresses.
