### PR TITLE
Fix manifests to work with updated puppet modules

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -19,10 +19,6 @@ class quickstack::compute_common (
 
   nova_config {
     'DEFAULT/libvirt_inject_partition':     value => '-1';
-    'keystone_authtoken/admin_tenant_name': value => 'admin';
-    'keystone_authtoken/admin_user':        value => 'admin';
-    'keystone_authtoken/admin_password':    value => $admin_password;
-    'keystone_authtoken/auth_host':         value => $controller_priv_floating_ip;
   }
 
   class { 'nova':
@@ -54,12 +50,6 @@ class quickstack::compute_common (
     enabled => true,
     vncproxy_host => $controller_pub_floating_ip,
     vncserver_proxyclient_address => $::ipaddress,
-  }
-
-  class { 'nova::api':
-    enabled           => true,
-    admin_password    => $nova_user_password,
-    auth_host         => $controller_priv_floating_ip,
   }
 
   class { 'ceilometer':

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -46,13 +46,6 @@ class quickstack::neutron::controller (
   $verbose                       = $quickstack::params::verbose,
 ) inherits quickstack::params {
 
-  nova_config {
-    'keystone_authtoken/admin_tenant_name': value => 'admin';
-    'keystone_authtoken/admin_user':        value => 'admin';
-    'keystone_authtoken/admin_password':    value => $admin_password;
-    'keystone_authtoken/auth_host':         value => '127.0.0.1';
-  }
-
   class { '::neutron':
     enabled               => true,
     verbose               => $verbose,
@@ -62,13 +55,11 @@ class quickstack::neutron::controller (
     core_plugin           => $neutron_core_plugin
   }
 
-  neutron_config {
-    'database/connection': value => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron";
-  }
-
   class { '::neutron::server':
     auth_host        => $::ipaddress,
     auth_password    => $neutron_user_password,
+    connection       => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron",
+    sql_connection   => false,
   }
 
   if $neutron_core_plugin == 'neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2' {

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -22,13 +22,18 @@ class quickstack::nova_network::compute (
   # Configure Nova
   nova_config{
     'DEFAULT/auto_assign_floating_ip':  value => $auto_assign_floating_ip;
-    #"DEFAULT/network_host":            value => ${controller_priv_floating_ip;
     "DEFAULT/network_host":             value => "$::ipaddress";
-    #"DEFAULT/metadata_host":           value => "$controller_priv_floating_ip";
     "DEFAULT/metadata_host":            value => "$::ipaddress";
     "DEFAULT/multi_host":               value => "True";
   }
 
+  nova::generic_service { 'metadata-api':
+    enabled        => true,
+    ensure_package => 'present',
+    package_name   => 'openstack-nova-api',
+    service_name   => 'openstack-nova-metadata-api',
+  }
+  
   class { 'nova::network':
     private_interface => "$private_interface",
     public_interface  => "$public_interface",
@@ -40,7 +45,6 @@ class quickstack::nova_network::compute (
     enabled           => true,
     install_service   => true,
   }
-
 
   class { 'quickstack::compute_common':
     admin_password              => $admin_password,


### PR DESCRIPTION
BZ #1040021 - This patch updates the nova/neutron controller and
compute manifests to work with updated pupet modules. Specifically,
the nova auth setting should now be done via nova::api class, not
nova_config. Also, the neutron database connection should be set via
the neutron::server class, not neutron_config.

In addition, the nova compute manifest does not and should not call
the nova::api class. Instead, install the metadata-api service using
nova::generic_service.

https://bugzilla.redhat.com/show_bug.cgi?id=1040021
