### PR TITLE
BZ #1042933 - neutron-server fails to start

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -62,6 +62,18 @@ class quickstack::neutron::controller (
     sql_connection   => false,
   }
 
+  # FIXME: This really should be handled by the neutron-puppet module, which has
+  # a review request open right now: https://review.openstack.org/#/c/50162/
+  # If and when that is merged (or similar), the below can be removed.
+  exec { 'neutron-db-manage upgrade':
+    command     => 'neutron-db-manage --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head',
+    path        => '/usr/bin',
+    user        => 'neutron',
+    logoutput   => 'on_failure',
+    before      => Service['neutron-server'],
+    require     => [Neutron_config['database/connection'], Neutron_config['DEFAULT/core_plugin']],
+  }
+
   if $neutron_core_plugin == 'neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2' {
     neutron_plugin_ovs {
       'OVS/enable_tunneling': value => $enable_tunneling;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1042933

Neutron-server fails to start when deploying Neutron controller host group via
Foreman.

This is due to a new neutron-db-manage command that needs to be run, but is not
yet included in puppet-neutron.  This patch mimics what was done in
packstack[1], fixing this until the proper fix is added to the puppet module we
depend on.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1037675
