### PR TITLE
Enable selinux boolean virt_use_fusefs on compute nodes

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -15,6 +15,11 @@ class quickstack::compute_common (
 
   if str2bool($cinder_backend_gluster) == true {
     class { 'gluster::client': }
+
+    selboolean {'virt_use_fusefs':
+      persistent => true,
+      value      => on,
+    }
   }
 
   nova_config {


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1015625

I didn't have the bandwidth today to test whether the boolean has the desired final effect, but i did test that it gets set and it persists after reboot.
