### PR TITLE
BZ #1046120 - Unused parameter bridge_keep_ip in Neutron Networker

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -12,7 +12,6 @@ class quickstack::neutron::networker (
   $mysql_host                    = $quickstack::params::mysql_host,
   $qpid_host                     = $quickstack::params::qpid_host,
   $external_network_bridge       = 'br-ex',
-  $bridge_keep_ip                = true,
   $tenant_network_type           = $quickstack::params::tenant_network_type,
   $ovs_bridge_mappings           = $quickstack::params::ovs_bridge_mappings,
   $ovs_bridge_uplinks            = $quickstack::params::ovs_bridge_uplinks,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1046120

Removed unused parameter from the networker.pp manifest.
