### PR TITLE
Don't use arrays in package name attribute

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -183,8 +183,12 @@ class quickstack::controller_common (
     verbose                     => $verbose,
   }
 
-  package {'horizon-packages':
-    name   => ['python-memcached', 'python-netaddr'],
+  # horizon packages
+  package {'python-memcached':
+    ensure => installed,
+  }~>
+  package {'python-netaddr':
+    ensure => installed,
     notify => Class['horizon'],
   }
 


### PR DESCRIPTION
Puppet 3.4 doesn't allow array values for `name` attribute of
`package` resource. We need to specify them one by one.
