### PR TITLE
BZ #1052408 - HA Mysql manifest: allow creation of neutron db user.

### DIFF
--- a/puppet/modules/quickstack/manifests/hamysql/mysql/setup.pp
+++ b/puppet/modules/quickstack/manifests/hamysql/mysql/setup.pp
@@ -4,6 +4,7 @@ class quickstack::hamysql::mysql::setup (
   $nova_db_password,
   $cinder_db_password,
   $heat_db_password,
+  $neutron_db_password,
   # Keystone
   $keystone_db_user       = 'keystone',
   $keystone_db_dbname     = 'keystone',
@@ -26,7 +27,7 @@ class quickstack::hamysql::mysql::setup (
   $neutron_db_dbname      = 'neutron',
 ) {
 
-  if str2bool("$hamysql_active_node") {
+  if str2bool_i("$hamysql_active_node") {
     class { 'quickstack::hamysql::mysql::account_security': }
 
     database { $keystone_db_dbname:
@@ -108,6 +109,24 @@ class quickstack::hamysql::mysql::setup (
       privileges => 'all',
       provider   => 'mysql',
       require    => Database_user["$heat_db_user@%"]
+    }
+
+    if str2bool_i("$neutron") {
+      database { $neutron_db_dbname:
+        ensure => 'present',
+        provider => 'mysql',
+      }
+      database_user { "$neutron_db_user@%":
+        ensure => 'present',
+        password_hash => mysql_password($neutron_db_password),
+        provider      => 'mysql',
+        require => Database[$neutron_db_dbname],
+      }
+      database_grant { "$neutron_db_user@%/$neutron_db_dbname":
+        privileges => 'all',
+        provider   => 'mysql',
+        require    => Database_user["$neutron_db_user@%"]
+      }
     }
   }
 }

--- a/puppet/modules/quickstack/manifests/hamysql/node.pp
+++ b/puppet/modules/quickstack/manifests/hamysql/node.pp
@@ -5,6 +5,8 @@ class quickstack::hamysql::node (
   $nova_db_password            = $quickstack::params::nova_db_password,
   $cinder_db_password          = $quickstack::params::cinder_db_password,
   $heat_db_password            = $quickstack::params::heat_db_password,
+  $neutron_db_password         = $quickstack::params::neutron_db_password,
+  $neutron                     = $quickstack::params::neutron,
 
   # these two variables are distinct because you may want to bind on
   # '0.0.0.0' rather than just the floating ip
@@ -100,6 +102,8 @@ class quickstack::hamysql::node (
       nova_db_password     => $nova_db_password,
       cinder_db_password   => $cinder_db_password,
       heat_db_password     => $heat_db_password,
+      neutron_db_password  => $neutron_db_password,
+      neutron              => str2bool_i("$neutron"),
       require              => Class['quickstack::hamysql::mysql::rootpw'],
     }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1052408

Add parameters to allow (optionally) the creation of the neutron db
user and set its db password.
