### PR TITLE
BZ #1054181 - Set OS description consistently, install LSB

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -48,6 +48,7 @@ yum
 dhclient
 ntp
 wget
+redhat-lsb-core
 @Core
 
 <% if @dynamic -%>
@@ -123,7 +124,7 @@ Setting[:foreman_url] = Facter.fqdn
 os = Operatingsystem.where(:name => "RedHat", :major => "6", :minor => "4").first
 os ||= Operatingsystem.create(:name => "RedHat", :major => "6", :minor => "4")
 os.type = "Redhat"
-os.description = "RHEL 6.4" if os.respond_to? :description=
+os.description = "RHEL Server 6.4" if os.respond_to? :description=
 os.save!
 
 # Installation Media - comes as standard, just need to associate it


### PR DESCRIPTION
OS descriptions are filled in by LSB, which relies on lsb_release (supplied by
redhat-lsb-core).  On RHEL, they usually contain the variant string "Server",
so also update the description we preset to match that supplied by lsb_release.
