### PR TITLE
Add options for SSL support either via files or FreeIPA

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -300,6 +300,18 @@ params = {
   "lb_member_addrs"               => '',
   "configure_ovswitch"            => "true",
   "neutron"                       => "false",
+  "ssl"                           => "false",
+  "freeipa"                       => "false",
+  "mysql_ca"                      => "/etc/ipa/ca.crt",
+  "mysql_cert"                    => "/etc/pki/tls/certs/PRIV_IP-mysql.crt",
+  "mysql_key"                     => "/etc/pki/tls/private/PRIV_IP-mysql.key",
+  "qpid_ca"                       => "/etc/ipa/ca.crt",
+  "qpid_cert"                     => "/etc/pki/tls/certs/PRIV_IP-qpid.crt",
+  "qpid_key"                      => "/etc/pki/tls/private/PRIV_IP-qpid.key",
+  "horizon_ca"                    => "/etc/ipa/ca.crt",
+  "horizon_cert"                  => "/etc/pki/tls/certs/PUB_IP-horizon.crt",
+  "horizon_key"                   => "/etc/pki/tls/private/PUB_IP-horizon.key",
+  "qpid_nssdb_password"           => SecureRandom.hex,
 }
 
 hostgroups = [

--- a/puppet/modules/quickstack/manifests/ceilometer_controller.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer_controller.pp
@@ -4,6 +4,8 @@ class quickstack::ceilometer_controller(
   $controller_priv_host,
   $controller_pub_host,
   $qpid_host,
+  $qpid_port = '5672',
+  $qpid_protocol = 'tcp',
   $verbose,
 ) {
 
@@ -22,6 +24,8 @@ class quickstack::ceilometer_controller(
     class { 'ceilometer':
         metering_secret => $ceilometer_metering_secret,
         qpid_hostname   => $qpid_host,
+        qpid_port       => $qpid_port,
+        qpid_protocol   => $qpid_protocol,
         rpc_backend     => 'ceilometer.openstack.common.rpc.impl_qpid',
         verbose         => $verbose,
     }
@@ -52,7 +56,10 @@ class quickstack::ceilometer_controller(
         require           => Class['mongodb'],
     }
 
-    glance_api_config {
-        'DEFAULT/notifier_strategy': value => 'qpid'
+    class { 'glance::notify::qpid':
+        qpid_password => 'guest',
+        qpid_hostname => $qpid_host,
+        qpid_port     => $qpid_port,
+        qpid_protocol => $qpid_protocol
     }
 }

--- a/puppet/modules/quickstack/manifests/cinder_controller.pp
+++ b/puppet/modules/quickstack/manifests/cinder_controller.pp
@@ -7,7 +7,11 @@ class quickstack::cinder_controller(
   $cinder_user_password        = $quickstack::params::cinder_user_password,
   $controller_priv_host        = $quickstack::params::controller_priv_host,
   $mysql_host                  = $quickstack::params::mysql_host,
+  $mysql_ca                    = $quickstack::params::mysql_ca,
+  $ssl                         = $quickstack::params::ssl,
   $qpid_host                   = $quickstack::params::qpid_host,
+  $qpid_port                   = "5672",
+  $qpid_protocol               = "tcp",
   $verbose                     = $quickstack::params::verbose,
 ) inherits quickstack::params {
 
@@ -16,11 +20,19 @@ class quickstack::cinder_controller(
     'DEFAULT/notification_driver': value => 'cinder.openstack.common.notifier.rpc_notifier'
   }
 
+  if str2bool($ssl) {
+    $sql_connection = "mysql://cinder:${cinder_db_password}@${mysql_host}/cinder?ssl_ca=${mysql_ca}"
+  } else {
+    $sql_connection = "mysql://cinder:${cinder_db_password}@${mysql_host}/cinder"
+  }
+
   class {'cinder':
     rpc_backend    => 'cinder.openstack.common.rpc.impl_qpid',
     qpid_hostname  => $qpid_host,
+    qpid_protocol  => $qpid_protocol,
+    qpid_port      => $qpid_port,
     qpid_password  => 'guest',
-    sql_connection => "mysql://cinder:${cinder_db_password}@${mysql_host}/cinder",
+    sql_connection => $sql_connection,
     verbose        => $verbose,
     require        => Class['openstack::db::mysql', 'qpid::server'],
   }

--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -11,6 +11,8 @@ class quickstack::compute_common (
   $nova_user_password          = $quickstack::params::nova_user_password,
   $qpid_host                   = $quickstack::params::qpid_host,
   $verbose                     = $quickstack::params::verbose,
+  $ssl                         = $quickstack::params::ssl,
+  $mysql_ca                    = $quickstack::params::mysql_ca,
 ) inherits quickstack::params {
 
   if str2bool($cinder_backend_gluster) == true {
@@ -28,12 +30,25 @@ class quickstack::compute_common (
     'DEFAULT/libvirt_inject_partition':     value => '-1';
   }
 
+    if str2bool($ssl) == true {
+      $qpid_protocol = 'ssl'
+      $qpid_port = '5671'
+      $nova_sql_connection = "mysql://nova:${nova_db_password}@${mysql_host}/nova?ssl_ca=${mysql_ca}"
+
+    } else {
+      $qpid_protocol = 'tcp'
+      $qpid_port = '5672'
+      $nova_sql_connection = "mysql://nova:${nova_db_password}@${mysql_host}/nova"
+    }
+
   class { 'nova':
-    sql_connection     => "mysql://nova:${nova_db_password}@${mysql_host}/nova",
+    sql_connection     => $nova_sql_connection,
     image_service      => 'nova.image.glance.GlanceImageService',
     glance_api_servers => "http://${controller_priv_host}:9292/v1",
     rpc_backend        => 'nova.openstack.common.rpc.impl_qpid',
     qpid_hostname      => $qpid_host,
+    qpid_protocol      => $qpid_protocol,
+    qpid_port          => $qpid_port,
     verbose            => $verbose,
   }
 
@@ -62,6 +77,8 @@ class quickstack::compute_common (
   class { 'ceilometer':
     metering_secret => $ceilometer_metering_secret,
     qpid_hostname   => $qpid_host,
+    qpid_port       => $qpid_port,
+    qpid_protocol   => $qpid_protocol,
     rpc_backend     => 'ceilometer.openstack.common.rpc.impl_qpid',
     verbose         => $verbose,
   }

--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -34,7 +34,60 @@ class quickstack::controller_common (
   $swift_admin_password          = $quickstack::params::swift_admin_password,
   $qpid_host                     = $quickstack::params::qpid_host,
   $verbose                       = $quickstack::params::verbose,
+  $ssl                           = $quickstack::params::ssl,
+  $freeipa                       = $quickstack::params::freeipa,
+  $mysql_ca                      = $quickstack::params::mysql_ca,
+  $mysql_cert                    = $quickstack::params::mysql_cert,
+  $mysql_key                     = $quickstack::params::mysql_key,
+  $qpid_ca                       = $quickstack::params::qpid_ca,
+  $qpid_cert                     = $quickstack::params::qpid_cert,
+  $qpid_key                      = $quickstack::params::qpid_key,
+  $horizon_ca                    = $quickstack::params::horizon_ca,
+  $horizon_cert                  = $quickstack::params::horizon_cert,
+  $horizon_key                   = $quickstack::params::horizon_key,
+  $qpid_nssdb_password           = $quickstack::params::qpid_nssdb_password,
 ) inherits quickstack::params {
+
+  if str2bool($ssl) == true {
+    $qpid_protocol = 'ssl'
+    $qpid_port = '5671'
+    $nova_sql_connection = "mysql://nova:${nova_db_password}@${mysql_host}/nova?ssl_ca=${mysql_ca}"
+
+    if str2bool($freeipa) == true {
+      certmonger::request_ipa_cert { 'mysql':
+        seclib => "openssl",
+        principal => "mysql/${controller_priv_host}",
+        key => $mysql_key,
+        cert => $mysql_cert,
+        owner_id => 'mysql',
+        group_id => 'mysql',
+      }
+      certmonger::request_ipa_cert { 'horizon':
+        seclib => "openssl",
+        principal => "horizon/${controller_pub_host}",
+        key => $horizon_key,
+        cert => $horizon_cert,
+        owner_id => 'apache',
+        group_id => 'apache',
+        hostname => $controller_pub_host,
+      }
+    } else {
+      if $mysql_ca == undef or $mysql_cert == undef or $mysql_key == undef {
+        fail('The mysql CA, cert and key are all required.')
+      }
+      if $qpid_ca == undef or $qpid_cert == undef or $qpid_key == undef {
+        fail('The qpid CA, cert and key are all required.')
+      }
+      if $horizon_ca == undef or $horizon_cert == undef or
+         $horizon_key == undef {
+        fail('The horizon CA, cert and key are all required.')
+      }
+    }
+  } else {
+      $qpid_protocol = 'tcp'
+      $qpid_port = '5672'
+      $nova_sql_connection = "mysql://nova:${nova_db_password}@${mysql_host}/nova"
+  }
 
   class {'openstack::db::mysql':
     mysql_root_password  => $mysql_root_password,
@@ -47,6 +100,10 @@ class quickstack::controller_common (
     # MySQL
     mysql_bind_address     => '0.0.0.0',
     mysql_account_security => true,
+    mysql_ssl              => str2bool($ssl),
+    mysql_ca               => $mysql_ca,
+    mysql_cert             => $mysql_cert,
+    mysql_key              => $mysql_key,
 
     allowed_hosts          => ['%',$controller_priv_host],
     enabled                => true,
@@ -56,12 +113,20 @@ class quickstack::controller_common (
   }
 
   class {'qpid::server':
-    auth => "no"
+    auth => "no",
+    ssl      => str2bool($ssl),
+    freeipa  => str2bool($freeipa),
+    ssl_ca   => $qpid_ca,
+    ssl_cert => $qpid_cert,
+    ssl_key  => $qpid_key,
+    ssl_database_password => $qpid_nssdb_password
   }
 
   class {'openstack::keystone':
     db_host                 => $mysql_host,
     db_password             => $keystone_db_password,
+    db_ssl                  => str2bool($ssl),
+    db_ssl_ca               => $mysql_ca,
     admin_token             => $keystone_admin_token,
     admin_email             => $admin_email,
     admin_password          => $admin_password,
@@ -104,6 +169,8 @@ class quickstack::controller_common (
 
   class {'openstack::glance':
     db_host        => $mysql_host,
+    db_ssl         => str2bool($ssl),
+    db_ssl_ca      => $mysql_ca,
     user_password  => $glance_user_password,
     db_password    => $glance_db_password,
     require        => Class['openstack::db::mysql'],
@@ -111,11 +178,14 @@ class quickstack::controller_common (
 
   # Configure Nova
   class { 'nova':
-    sql_connection     => "mysql://nova:${nova_db_password}@${mysql_host}/nova",
+    sql_connection     => $nova_sql_connection,
     image_service      => 'nova.image.glance.GlanceImageService',
     glance_api_servers => "http://${controller_priv_host}:9292/v1",
     rpc_backend        => 'nova.openstack.common.rpc.impl_qpid',
     verbose            => $verbose,
+    qpid_protocol      => $qpid_protocol,
+    qpid_port          => $qpid_port,
+    qpid_hostname      => $qpid_host,
     require            => Class['openstack::db::mysql', 'qpid::server'],
   }
 
@@ -149,6 +219,8 @@ class quickstack::controller_common (
     controller_priv_host        => $controller_priv_host,
     controller_pub_host         => $controller_pub_host,
     qpid_host                   => $qpid_host,
+    qpid_protocol               => $qpid_protocol,
+    qpid_port                   => $qpid_port,
     verbose                     => $verbose,
   }
 
@@ -167,7 +239,11 @@ class quickstack::controller_common (
     cinder_user_password        => $cinder_user_password,
     controller_priv_host        => $controller_priv_host,
     mysql_host                  => $mysql_host,
+    mysql_ca                    => $mysql_ca,
+    ssl                         => $ssl,
     qpid_host                   => $qpid_host,
+    qpid_port                   => $qpid_port,
+    qpid_protocol               => $qpid_protocol,
     verbose                     => $verbose,
   }
 
@@ -179,7 +255,11 @@ class quickstack::controller_common (
     controller_priv_host        => $controller_priv_host,
     controller_pub_host         => $controller_pub_host,
     mysql_host                  => $mysql_host,
+    mysql_ca                    => $mysql_ca,
+    ssl                         => $ssl,
     qpid_host                   => $qpid_host,
+    qpid_port                   => $qpid_port,
+    qpid_protocol               => $qpid_protocol,
     verbose                     => $verbose,
   }
 
@@ -201,6 +281,10 @@ class quickstack::controller_common (
   class {'horizon':
     secret_key    => $horizon_secret_key,
     keystone_host => $controller_priv_host,
+    listen_ssl    => str2bool($ssl),
+    horizon_cert  => $horizon_cert,
+    horizon_key   => $horizon_key,
+    horizon_ca    => $horizon_ca,
   }
 
   class {'memcached':}
@@ -209,6 +293,14 @@ class quickstack::controller_common (
     proto    => 'tcp',
     dport    => ['80', '443', '3260', '3306', '5000', '35357', '5672', '8773', '8774', '8775', '8776', '8777', '9292', '6080'],
     action   => 'accept',
+  }
+
+  if $ssl {
+    firewall { '002 ssl controller incoming':
+      proto    => 'tcp',
+      dport    => ['443',],
+      action   => 'accept',
+    }
   }
 
   if ($::selinux != "false"){

--- a/puppet/modules/quickstack/manifests/heat_controller.pp
+++ b/puppet/modules/quickstack/manifests/heat_controller.pp
@@ -6,7 +6,11 @@ class quickstack::heat_controller(
   $controller_priv_host,
   $controller_pub_host,
   $mysql_host,
+  $mysql_ca,
+  $ssl,
   $qpid_host,
+  $qpid_port,
+  $qpid_protocol,
   $verbose,
 ) {
 
@@ -26,6 +30,8 @@ class quickstack::heat_controller(
       auth_uri          => "http://${controller_priv_host}:35357/v2.0",
       rpc_backend       => 'heat.openstack.common.rpc.impl_qpid',
       qpid_hostname     => $qpid_host,
+      qpid_port         => $qpid_port,
+      qpid_protocol     => $qpid_protocol,
       verbose           => $verbose,
   }
 
@@ -48,8 +54,14 @@ class quickstack::heat_controller(
       allowed_hosts => "%%",
   }
 
+  if str2bool($ssl) {
+    $sql_connection = "mysql://heat:${heat_db_password}@${mysql_host}/heat?ssl_ca=${mysql_ca}"
+  } else {
+    $sql_connection = "mysql://heat:${heat_db_password}@${mysql_host}/heat"
+  }
+
   class { 'heat::db':
-      sql_connection => "mysql://heat:${heat_db_password}@${mysql_host}/heat",
+      sql_connection => $sql_connection,
   }
 
   class { 'heat::api':

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -21,6 +21,8 @@ class quickstack::neutron::compute (
   $tenant_network_type         = $quickstack::params::tenant_network_type,
   $tunnel_id_ranges            = '1:1000',
   $verbose                     = $quickstack::params::verbose,
+  $ssl                         = $quickstack::params::ssl,
+  $mysql_ca                    = $quickstack::params::mysql_ca,
 ) inherits quickstack::params {
 
   # str2bool expects the string to already be downcased.  all-righty.
@@ -31,15 +33,27 @@ class quickstack::neutron::compute (
       default => str2bool("$enable_tunneling"),
   }
 
+  if str2bool($ssl) == true {
+    $qpid_protocol = 'ssl'
+    $qpid_port = '5671'
+    $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron?ssl_ca=${mysql_ca}"
+  } else {
+    $qpid_protocol = 'tcp'
+    $qpid_port = '5672'
+    $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron"
+  }
+
   class { '::neutron':
     allow_overlapping_ips => true,
     rpc_backend           => 'neutron.openstack.common.rpc.impl_qpid',
     qpid_hostname         => $qpid_host,
+    qpid_port             => $qpid_port,
+    qpid_protocol         => $qpid_protocol,
     core_plugin           => $neutron_core_plugin
   }
 
   neutron_config {
-    'database/connection': value => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron";
+    'database/connection': value => $sql_connection;
     'keystone_authtoken/auth_host':         value => $controller_priv_host;
     'keystone_authtoken/admin_tenant_name': value => 'services';
     'keystone_authtoken/admin_user':        value => 'neutron';
@@ -47,7 +61,7 @@ class quickstack::neutron::compute (
   }
 
   class { '::neutron::plugins::ovs':
-    sql_connection      => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron",
+    sql_connection      => $sql_connection,
     tenant_network_type => $tenant_network_type,
     network_vlan_ranges => $ovs_vlan_ranges,
     tunnel_id_ranges    => $tunnel_id_ranges,
@@ -79,5 +93,7 @@ class quickstack::neutron::compute (
     nova_user_password          => $nova_user_password,
     qpid_host                   => $qpid_host,
     verbose                     => $verbose,
+    ssl                         => $ssl,
+    mysql_ca                    => $mysql_ca,
   }
 }

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -43,7 +43,29 @@ class quickstack::neutron::controller (
   $swift_admin_password          = $quickstack::params::swift_admin_password,
   $tenant_network_type           = $quickstack::params::tenant_network_type,
   $verbose                       = $quickstack::params::verbose,
+  $ssl                           = $quickstack::params::ssl,
+  $freeipa                       = $quickstack::params::freeipa,
+  $mysql_ca                      = $quickstack::params::mysql_ca,
+  $mysql_cert                    = $quickstack::params::mysql_cert,
+  $mysql_key                     = $quickstack::params::mysql_key,
+  $qpid_ca                       = $quickstack::params::qpid_ca,
+  $qpid_cert                     = $quickstack::params::qpid_cert,
+  $qpid_key                      = $quickstack::params::qpid_key,
+  $horizon_ca                    = $quickstack::params::horizon_ca,
+  $horizon_cert                  = $quickstack::params::horizon_cert,
+  $horizon_key                   = $quickstack::params::horizon_key,
+  $qpid_nssdb_password           = $quickstack::params::qpid_nssdb_password,
 ) inherits quickstack::params {
+
+  if str2bool($ssl) == true {
+    $qpid_protocol = 'ssl'
+    $qpid_port = '5671'
+    $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron?ssl_ca=${mysql_ca}"
+  } else {
+    $qpid_protocol = 'tcp'
+    $qpid_port = '5672'
+    $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron"
+  }
 
   class { 'quickstack::controller_common':
     admin_email                   => $admin_email,
@@ -80,6 +102,18 @@ class quickstack::neutron::controller (
     swift_shared_secret           => $swift_shared_secret,
     swift_admin_password          => $swift_admin_password,
     verbose                       => $verbose,
+    ssl                           => $ssl,
+    freeipa                       => $freeipa,
+    mysql_ca                      => $mysql_ca,
+    mysql_cert                    => $mysql_cert,
+    mysql_key                     => $mysql_key,
+    qpid_ca                       => $qpid_ca,
+    qpid_cert                     => $qpid_cert,
+    qpid_key                      => $qpid_key,
+    horizon_ca                    => $horizon_ca,
+    horizon_cert                  => $horizon_cert,
+    horizon_key                   => $horizon_key,
+    qpid_nssdb_password           => $qpid_nssdb_password,
   }
   ->
   class { '::neutron':
@@ -88,6 +122,8 @@ class quickstack::neutron::controller (
     allow_overlapping_ips => true,
     rpc_backend           => 'neutron.openstack.common.rpc.impl_qpid',
     qpid_hostname         => $qpid_host,
+    qpid_port             => $qpid_port,
+    qpid_protocol         => $qpid_protocol,
     core_plugin           => $neutron_core_plugin
   }
   ->
@@ -106,7 +142,7 @@ class quickstack::neutron::controller (
   class { '::neutron::server':
     auth_host        => $::ipaddress,
     auth_password    => $neutron_user_password,
-    connection       => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron",
+    connection       => $sql_connection,
     sql_connection   => false,
   }
 
@@ -119,7 +155,7 @@ class quickstack::neutron::controller (
     }
 
     class { '::neutron::plugins::ovs':
-      sql_connection      => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron",
+      sql_connection      => $sql_connection,
       tenant_network_type => $tenant_network_type,
       network_vlan_ranges => $ovs_vlan_ranges,
       tunnel_id_ranges    => $tunnel_id_ranges,
@@ -138,6 +174,7 @@ class quickstack::neutron::controller (
       provider_vlan_auto_create    => $provider_vlan_auto_create,
       provider_vlan_auto_trunk     => $provider_vlan_auto_trunk,
       mysql_host                   => $mysql_host,
+      mysql_ca                     => $mysql_ca,
       tenant_network_type          => $tenant_network_type,
     }
   }

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -18,6 +18,8 @@ class quickstack::neutron::networker (
   $tunnel_id_ranges              = '1:1000',
   $enable_tunneling              = $quickstack::params::enable_tunneling,
   $verbose                       = $quickstack::params::verbose,
+  $ssl                           = $quickstack::params::ssl,
+  $mysql_ca                      = $quickstack::params::mysql_ca,
 ) inherits quickstack::params {
 
   # str2bool expects the string to already be downcased.  all-righty.
@@ -28,15 +30,27 @@ class quickstack::neutron::networker (
       default => str2bool("$enable_tunneling"),
   }
 
+  if str2bool($ssl) == true {
+    $qpid_protocol = 'ssl'
+    $qpid_port = '5671'
+    $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron?ssl_ca=${mysql_ca}"
+  } else {
+    $qpid_protocol = 'tcp'
+    $qpid_port = '5672'
+    $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron"
+  }
+
   class { '::neutron':
     verbose               => true,
     allow_overlapping_ips => true,
     rpc_backend           => 'neutron.openstack.common.rpc.impl_qpid',
     qpid_hostname         => $qpid_host,
+    qpid_protocol         => $qpid_protocol,
+    qpid_port             => $qpid_port,
   }
 
   neutron_config {
-    'database/connection': value => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron";
+    'database/connection': value => $sql_connection;
     'keystone_authtoken/admin_tenant_name': value => 'services';
     'keystone_authtoken/admin_user':        value => 'neutron';
     'keystone_authtoken/admin_password':    value => $neutron_user_password;
@@ -44,7 +58,7 @@ class quickstack::neutron::networker (
   }
 
   class { '::neutron::plugins::ovs':
-    sql_connection      => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron",
+    sql_connection      => $sql_connection,
     tenant_network_type => $tenant_network_type,
     network_vlan_ranges => $ovs_vlan_ranges,
     tunnel_id_ranges    => $tunnel_id_ranges,

--- a/puppet/modules/quickstack/manifests/neutron/plugins/cisco.pp
+++ b/puppet/modules/quickstack/manifests/neutron/plugins/cisco.pp
@@ -25,17 +25,25 @@ class quickstack::neutron::plugins::cisco (
   $provider_vlan_auto_create    = $quickstack::params::provider_vlan_auto_create,
   $provider_vlan_auto_trunk     = $quickstack::params::provider_vlan_auto_trunk,
   $mysql_host                   = $quickstack::params::mysql_host,
+  $mysql_ca                     = $quickstack::params::mysql_ca,
   $enable_server                = true,
   $enable_ovs_agent             = false,
   $tenant_network_type          = 'vlan',
+  $ssl                          = $quickstack::params::ssl,
 ) inherits quickstack::params {
 
+
+  if str2bool($ssl) {
+    $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron?ssl_ca=${mysql_ca}"
+  } else {
+    $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron"
+  }
 
   if $cisco_vswitch_plugin == 'neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2' {
     # vswitch plugin is ovs, setup the ovs plugin
 
     class { '::neutron::plugins::ovs':
-      sql_connection      => "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron",
+      sql_connection      => $sql_connection,
       tenant_network_type => $tenant_network_type,
       network_vlan_ranges => $ovs_vlan_ranges,
     }

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -15,6 +15,8 @@ class quickstack::nova_network::compute (
   $nova_network_public_iface    = 'em2',
   $qpid_host                    = $quickstack::params::qpid_host,
   $verbose                      = $quickstack::params::verbose,
+  $ssl                          = $quickstack::params::ssl,
+  $mysql_ca                     = $quickstack::params::mysql_ca,
 
   $auto_assign_floating_ip
 ) inherits quickstack::params {
@@ -58,5 +60,7 @@ class quickstack::nova_network::compute (
     nova_user_password          => $nova_user_password,
     qpid_host                   => $qpid_host,
     verbose                     => $verbose,
+    ssl                         => $ssl,
+    mysql_ca                    => $mysql_ca,
   }
 }

--- a/puppet/modules/quickstack/manifests/nova_network/controller.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/controller.pp
@@ -29,6 +29,18 @@ class quickstack::nova_network::controller (
   $swift_shared_secret           = $quickstack::params::swift_shared_secret,
   $swift_admin_password          = $quickstack::params::swift_admin_password,
   $verbose                       = $quickstack::params::verbose,
+  $ssl                           = $quickstack::params::ssl,
+  $freeipa                       = $quickstack::params::freeipa,
+  $mysql_ca                      = $quickstack::params::mysql_ca,
+  $mysql_cert                    = $quickstack::params::mysql_cert,
+  $mysql_key                     = $quickstack::params::mysql_key,
+  $qpid_ca                       = $quickstack::params::qpid_ca,
+  $qpid_cert                     = $quickstack::params::qpid_cert,
+  $qpid_key                      = $quickstack::params::qpid_key,
+  $horizon_ca                    = $quickstack::params::horizon_ca,
+  $horizon_cert                  = $quickstack::params::horizon_cert,
+  $horizon_key                   = $quickstack::params::horizon_key,
+  $qpid_nssdb_password           = $quickstack::params::qpid_nssdb_password,
 
   $auto_assign_floating_ip
 ) inherits quickstack::params {
@@ -70,5 +82,18 @@ class quickstack::nova_network::controller (
     swift_shared_secret          => $swift_shared_secret,
     swift_admin_password         => $swift_admin_password,
     verbose                      => $verbose,
+
+    ssl                          => $ssl,
+    freeipa                      => $freeipa,
+    mysql_ca                     => $mysql_ca,
+    mysql_cert                   => $mysql_cert,
+    mysql_key                    => $mysql_key,
+    qpid_ca                      => $qpid_ca,
+    qpid_cert                    => $qpid_cert,
+    qpid_key                     => $qpid_key,
+    horizon_ca                   => $horizon_ca,
+    horizon_cert                 => $horizon_cert,
+    horizon_key                  => $horizon_key,
+    qpid_nssdb_password          => $qpid_nssdb_password,
   }
 }

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -96,4 +96,18 @@ class quickstack::params {
   $mysql_shared_storage_type     = 'MYSQL_SHARED_STORAGE_TYPE'
   $mysql_clu_member_addrs        = 'SPACE_SEPARATED_IP_ADDRS'
   $mysql_resource_group_name     = 'mysqlgroup'
+
+  # SSL
+  $ssl                           = 'false'
+  $freeipa                       = 'false'
+  $mysql_ca                      = '/etc/ipa/ca.crt'
+  $mysql_cert                    = undef
+  $mysql_key                     = undef
+  $qpid_ca                       = undef
+  $qpid_cert                     = undef
+  $qpid_key                      = undef
+  $horizon_ca                    = '/etc/ipa/ca.crt'
+  $horizon_cert                  = undef
+  $horizon_key                   = undef
+  $qpid_nssdb_password           = 'CHANGEME'
 }

--- a/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
+++ b/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
@@ -9,13 +9,26 @@ class quickstack::storage_backend::lvm_cinder(
   $mysql_host                  = $quickstack::params::mysql_host,
   $qpid_host                   = $quickstack::params::qpid_host,
   $verbose                     = $quickstack::params::verbose,
+  $ssl                         = $quickstack::params::ssl,
+  $mysql_ca                    = $quickstack::params::mysql_ca,
 ) inherits quickstack::params {
 
+  if str2bool($ssl) == true {
+    $qpid_protocol = 'ssl'
+    $qpid_port = '5671'
+    $sql_connection = "mysql://cinder:${cinder_db_password}@${mysql_host}/cinder?ssl_ca=${mysql_ca}"
+  } else {
+    $qpid_protocol = 'tcp'
+    $qpid_port = '5672'
+    $sql_connection = "mysql://cinder:${cinder_db_password}@${mysql_host}/cinder"
+  }
   class { 'cinder':
     rpc_backend    => 'cinder.openstack.common.rpc.impl_qpid',
     qpid_hostname  => $qpid_host,
+    qpid_port      => $qpid_port,
+    qpid_protocol  => $qpid_protocol,
     qpid_password  => 'guest',
-    sql_connection => "mysql://cinder:${cinder_db_password}@${mysql_host}/cinder",
+    sql_connection => $sql_connection,
     verbose        => $verbose,
   }
 


### PR DESCRIPTION
If ssl and freeipa are true then certificates are obtained using
certmonger.

If ssl is true and freeipa is false then the the mysql and qpid
certificates and keys need to be passed in as arguments.

Horizon is configured to use ssl on the public interface FQDN if
ssl is true.

Secure qpid and mysql with SSL for nova, keystone, glance, ceilometer,
cinder and heat.

The following Foreman hostgroups support SSL:

Compute (Neutron)
Compute (Nova Network)
Controller (Neutron)
Controller (Nova Network)
LVM Block Storage
Neutron Networker
