### PR TITLE
Handle interface names containing "."

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -57,7 +57,7 @@ class quickstack::neutron::compute (
   class { '::neutron::agents::ovs':
     bridge_uplinks      => $ovs_bridge_uplinks,
     bridge_mappings     => $ovs_bridge_mappings,
-    local_ip            => getvar("ipaddress_${ovs_tunnel_iface}"),
+    local_ip            => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '\.', '_', 'G')),
     enable_tunneling    => $enable_tunneling_bool,
   }
 

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -52,7 +52,7 @@ class quickstack::neutron::networker (
 
   class { '::neutron::agents::ovs':
     bridge_uplinks      => $ovs_bridge_uplinks,
-    local_ip            => getvar("ipaddress_${ovs_tunnel_iface}"),
+    local_ip            => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '\.', '_', 'G')),
     bridge_mappings     => $ovs_bridge_mappings,
     enable_tunneling    => $enable_tunneling_bool,
   }

--- a/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
+++ b/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
@@ -39,7 +39,7 @@ class quickstack::storage_backend::lvm_cinder(
 
   if str2bool($cinder_backend_iscsi) {
     class { 'cinder::volume::iscsi':
-      iscsi_ip_address => getvar("ipaddress_${cinder_iscsi_iface}"),
+      iscsi_ip_address => getvar(regsubst("ipaddress_${cinder_iscsi_iface}", '\.', '_', 'G')),
     }
 
     firewall { '010 cinder iscsi':

--- a/puppet/modules/quickstack/manifests/swift/storage.pp
+++ b/puppet/modules/quickstack/manifests/swift/storage.pp
@@ -9,7 +9,7 @@ class quickstack::swift::storage (
 ) inherits quickstack::params {
 
   class { '::swift::storage::all':
-    storage_local_net_ip => getvar("ipaddress_${swift_local_interface}"),
+    storage_local_net_ip => getvar(regsubst("ipaddress_${swift_local_interface}", '\.', '_', 'G')),
     require => Class['swift'],
   }
 


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1057938 for
astapor by calling regsubst() to replace "." with "_" in interface names
when looking up ipaddress_\* facts.
