### PR TITLE
BZ #1055852 - HTTP 500 Error using Neutron metadata agent

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -56,7 +56,7 @@ class quickstack::neutron::networker (
   }
 
   class { 'neutron::agents::metadata':
-    auth_password => $admin_password,
+    auth_password => $neutron_user_password,
     shared_secret => $neutron_metadata_proxy_secret,
     auth_url      => "http://${controller_priv_host}:35357/v2.0",
     metadata_ip   => $controller_priv_host,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1055852

metadata agent was using admin password instead of neutron user password
