### PR TITLE
bz 1059417,1056892 -- Handle interface names containing "." or "-"

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -49,7 +49,7 @@ class quickstack::neutron::compute (
   class { '::neutron::agents::ovs':
     bridge_uplinks      => $ovs_bridge_uplinks,
     bridge_mappings     => $ovs_bridge_mappings,
-    local_ip            => getvar("ipaddress_${ovs_tunnel_iface}"),
+    local_ip            => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '[.-]', '_', 'G')),
     enable_tunneling    => str2bool_i("$enable_tunneling"),
   }
 

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -44,7 +44,7 @@ class quickstack::neutron::networker (
 
   class { '::neutron::agents::ovs':
     bridge_uplinks      => $ovs_bridge_uplinks,
-    local_ip            => getvar("ipaddress_${ovs_tunnel_iface}"),
+    local_ip            => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '[.-]', '_', 'G')),
     bridge_mappings     => $ovs_bridge_mappings,
     enable_tunneling    => str2bool_i("$enable_tunneling"),
   }

--- a/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
+++ b/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
@@ -39,7 +39,7 @@ class quickstack::storage_backend::lvm_cinder(
 
   if str2bool_i("$cinder_backend_iscsi") {
     class { 'cinder::volume::iscsi':
-      iscsi_ip_address => getvar("ipaddress_${cinder_iscsi_iface}"),
+      iscsi_ip_address => getvar(regsubst("ipaddress_${cinder_iscsi_iface}", '[.-]', '_', 'G')),
     }
 
     firewall { '010 cinder iscsi':

--- a/puppet/modules/quickstack/manifests/swift/storage.pp
+++ b/puppet/modules/quickstack/manifests/swift/storage.pp
@@ -9,7 +9,7 @@ class quickstack::swift::storage (
 ) inherits quickstack::params {
 
   class { '::swift::storage::all':
-    storage_local_net_ip => getvar("ipaddress_${swift_local_interface}"),
+    storage_local_net_ip => getvar(regsubst("ipaddress_${swift_local_interface}", '[.-]', '_', 'G')),
     require => Class['swift'],
   }
 


### PR DESCRIPTION
Thanks to Rob's comment in #111:

This updates the previous patch to also handle interface names
containing "-".
