### PR TITLE
Provisioning setup easier to configure via explicitly define provisioning interface

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -11,7 +11,7 @@ require 'facter'
 require 'securerandom'
 
 # for the sub-network foreman owns
-secondary_int = 'SECONDARY_INT'
+secondary_int = 'PROVISIONING_INTERFACE'
 
 # Changes from upstream:
 #  - EPEL removed


### PR DESCRIPTION
This modifies the installer script to accept an environment variable `PROVISIONING_INTERFACE` to use, instead of guessing the interface. If no interface specified, defaults to guessing.

This also allows the installer to use the same interface for provisioning as the gateway interface.

Lastly, tweaks the default dhcp range to 50-100, since this interferes with /25 nets. Ideally there should be logic to derive the proper range.
