### PR TITLE
BZ #1056055 --  [RFE] create cinder-volumes VG backed by a loopback file

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder_controller.pp
+++ b/puppet/modules/quickstack/manifests/cinder_controller.pp
@@ -51,4 +51,18 @@ class quickstack::cinder_controller(
       glusterfs_shares           => suffix($cinder_gluster_servers, ":/${cinder_gluster_volume}")
     }
   }
+
+  if !str2bool_i("$cinder_backend_gluster") and !str2bool_i("$cinder_backend_iscsi") {
+    class { 'cinder::volume': }
+
+    class { 'cinder::volume::iscsi':
+      iscsi_ip_address => $controller_priv_host,
+    }
+
+    firewall { '010 cinder iscsi':
+      proto  => 'tcp',
+      dport  => ['3260'],
+      action => 'accept',
+    }
+  }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1056055

The default behavior most customers expect for small to medium installations
is to run cinder-volume on the controller node. Packstack does this but
Foreman only allows a dedicated storage backend backed by iSCSI or RHS.
This patch deploys cinder-volume on the Nova or Neutron controller node if
cinder_backend_{iscsi,gluster} are both set to false. It will detect a VG
named cinder-volumes (whether backed by an iSCSI target or loopback device)
and share it via tgtd. The user must create the VG, which is also the case
with the cinder_backend_iscsi parameter for the LVM backend storage group. In
a sense this patch replicates functionality customers expect from packstack.
I tested it against the RHEL OSP 01.31.2014-1 puddle for both iSCSI and LVM
bakced Cinder from the controller node.
