### PR TITLE
Configure qpid_hostname for Controller host groups

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -116,6 +116,7 @@ class quickstack::controller_common (
     image_service      => 'nova.image.glance.GlanceImageService',
     glance_api_servers => "http://${controller_priv_host}:9292/v1",
     rpc_backend        => 'nova.openstack.common.rpc.impl_qpid',
+    qpid_hostname      => $qpid_host,
     verbose            => $verbose,
     require            => Class['openstack::db::mysql', 'qpid::server'],
   }


### PR DESCRIPTION
The default controller common manifest assumes that qpid is
running locally on the machine. This may or may not be the case
and therefore it should take the '$qpid_host' parameter used within
other manifests. Without this change, Nova attempts to use
localhost as it's qpid broker, which obviously breaks if using
multiple controller hosts.
