### PR TITLE
BZ #1055207 - Add localhost and ip access for Horizon UI.

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -204,6 +204,7 @@ class quickstack::controller_common (
   class {'horizon':
     secret_key    => $horizon_secret_key,
     keystone_host => $controller_priv_host,
+    fqdn          => ["$controller_pub_host", "$::fqdn", "$::hostname", 'localhost'],
   }
 
   class {'memcached':}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1055207

Previously we used the default puppet configuration for Horizon, which allows
access only via fqdn.  This BZ request addition of access via public IP and
'localhost'.
