### PR TITLE
Enable qemu libvirt_type on kvm compute nodes

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -340,6 +340,7 @@ params = {
   "horizon_key"                   => "/etc/pki/tls/private/PUB_HOST-horizon.key",
   "qpid_nssdb_password"           => SecureRandom.hex,
   "fence_xvm_key_file_password"   => SecureRandom.hex,
+  "use_qemu_for_poc"              => "false",
 }
 
 hostgroups = [

--- a/puppet/modules/quickstack/manifests/compute/qemu.pp
+++ b/puppet/modules/quickstack/manifests/compute/qemu.pp
@@ -1,0 +1,11 @@
+class quickstack::compute::qemu {
+  file { "/usr/bin/qemu-system-x86_64":
+   ensure => link,
+   target => "/usr/libexec/qemu-kvm",
+   notify => Service["nova-compute"],
+  }
+
+  nova_config{
+    "DEFAULT/libvirt_cpu_mode": value => "none";
+  }
+}

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -27,6 +27,7 @@ class quickstack::neutron::compute (
   $verbose                     = $quickstack::params::verbose,
   $ssl                         = $quickstack::params::ssl,
   $mysql_ca                    = $quickstack::params::mysql_ca,
+  $use_qemu_for_poc            = $quickstack::params::use_qemu_for_poc,
 ) inherits quickstack::params {
 
   if str2bool_i("$ssl") {
@@ -97,6 +98,7 @@ class quickstack::neutron::compute (
     verbose                     => $verbose,
     ssl                         => $ssl,
     mysql_ca                    => $mysql_ca,
+    use_qemu_for_poc            => $use_qemu_for_poc,
   }
 
   class {'quickstack::neutron::firewall::vxlan':

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -26,7 +26,7 @@ class quickstack::nova_network::compute (
   $verbose                      = $quickstack::params::verbose,
   $ssl                          = $quickstack::params::ssl,
   $mysql_ca                     = $quickstack::params::mysql_ca,
-
+  $use_qemu_for_poc             = $quickstack::params::use_qemu_for_poc,
 ) inherits quickstack::params {
 
   # Configure Nova
@@ -74,5 +74,6 @@ class quickstack::nova_network::compute (
     verbose                     => $verbose,
     ssl                         => $ssl,
     mysql_ca                    => $mysql_ca,
+    use_qemu_for_poc            => $use_qemu_for_poc,
   }
 }

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -135,4 +135,7 @@ class quickstack::params {
   $fence_ipmilan_username        = ''
   $fence_ipmilan_password        = ''
   $fence_ipmilan_interval        = '60s'
+
+  # Nova Compute
+  $use_qemu_for_poc              = 'false'
 }


### PR DESCRIPTION
For kvm compute nodes, libvirt_type must be set to 'qemu'. The
default is 'kvm'. quickstack::params::libvirt_type must be changed
to activate this patch.
