### PR TITLE
Tuned

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -75,6 +75,8 @@ class quickstack::compute_common (
     enabled => true,
   }
 
+  include quickstack::tuned::virtual_host
+
   firewall { '001 nova compute incoming':
     proto  => 'tcp',
     dport  => '5900-5999',

--- a/puppet/modules/quickstack/manifests/tuned/common.pp
+++ b/puppet/modules/quickstack/manifests/tuned/common.pp
@@ -1,0 +1,28 @@
+class quickstack::tuned::common {
+
+  package {'tuned':
+    ensure => present,
+  }
+
+  service {'tuned':
+    ensure  => running,
+    require => Package['tuned'],
+  }
+
+  if $::operatingsystem == 'Fedora' and $::operatingsystemrelease == 19 {
+    # older tuned service is sometimes stuck on Fedora 19
+    exec {'tuned-update':
+      path      => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
+      command   => 'yum update -y tuned',
+      logoutput => 'on_failure',
+    }
+
+    exec {'tuned-restart':
+      path      => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
+      command   => 'systemctl restart tuned.service',
+      logoutput => 'on_failure',
+    }
+
+    Service['tuned'] -> Exec['tuned-update'] -> Exec['tuned-restart']
+  }
+}

--- a/puppet/modules/quickstack/manifests/tuned/virtual_host.pp
+++ b/puppet/modules/quickstack/manifests/tuned/virtual_host.pp
@@ -1,0 +1,10 @@
+class quickstack::tuned::virtual_host {
+  include quickstack::tuned::common
+
+  exec {'tuned-virtual-host':
+    unless  => '/usr/sbin/tuned-adm active | /bin/grep virtual-host',
+    command => '/usr/sbin/tuned-adm profile virtual-host',
+    require => Service['tuned'],
+    subscribe => Service['tuned'],
+  }
+}


### PR DESCRIPTION
This implements an RFE to add tuned virtual-host profile to compute nodes.  This can be later extended to other profiles and added in other locations as  needed.

To test:
- Apply a compute node of any type
- When applying, you should see output similar to:

```
Info: /Stage[main]/Quickstack::Tuned::Common/Service[tuned]: Scheduling refresh of Exec[tuned-virtual-host]
Info: /Stage[main]/Quickstack::Tuned::Common/Service[tuned]: Unscheduling refresh on Service[tuned]
Notice: /Stage[main]/Quickstack::Tuned::Virtual_host/Exec[tuned-virtual-host]/returns: executed successfully
Notice: /Stage[main]/Quickstack::Tuned::Virtual_host/Exec[tuned-virtual-host]: Triggered 'refresh' from 1 events
```
- Look to see if tuned service is installed:

```
service tuned status
tuned (pid  2882) is running…
```
- See if the expected profile is running:

```
# /usr/sbin/tuned-adm active | /bin/grep virtual-host
Current active profile: virtual-host
```
