### PR TITLE
Disable br-ex (or equivalent) to be created on compute nodes

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -15,7 +15,6 @@ class quickstack::neutron::compute (
   $nova_db_password            = $quickstack::params::nova_db_password,
   $nova_user_password          = $quickstack::params::nova_user_password,
   $ovs_bridge_mappings         = $quickstack::params::ovs_bridge_mappings,
-  $ovs_bridge_uplinks          = $quickstack::params::ovs_bridge_uplinks,
   $ovs_vlan_ranges             = $quickstack::params::ovs_vlan_ranges,
   $ovs_tunnel_iface            = 'em1',
   $qpid_host                   = $quickstack::params::qpid_host,
@@ -50,7 +49,6 @@ class quickstack::neutron::compute (
   }
 
   class { '::neutron::agents::ovs':
-    bridge_uplinks      => $ovs_bridge_uplinks,
     bridge_mappings     => $ovs_bridge_mappings,
     local_ip            => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '[.-]', '_', 'G')),
     enable_tunneling    => str2bool_i("$enable_tunneling"),


### PR DESCRIPTION
If $bridge_uplinks contains a value then an ovs bridge (usual default is br-ex) will be created. It's not necessarily a blocker besides the confusion it might generate. 
The external bridge is only needed on a "networker" node (or either a controller if in "all in one") and absolutely not necessary on computes nodes.

I suppose if one wants to create uplink bridge (and therefore l3 agent) on every node that would be a different scenario we'll have to handle - Thinking about multi l3 agents (the one replacing nova network multi agent)...

I've tested this.
