### PR TITLE
Adds section for memcached settings in manifests

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -2,6 +2,8 @@
 class quickstack::controller_common (
   $admin_email                   = $quickstack::params::admin_email,
   $admin_password                = $quickstack::params::admin_password,
+  $cache_server_ip               = $quickstack::params::cache_server_ip,
+  $cache_server_port             = $quickstack::params::cache_server_port,
   $ceilometer_metering_secret    = $quickstack::params::ceilometer_metering_secret,
   $ceilometer_user_password      = $quickstack::params::ceilometer_user_password,
   $cinder_backend_gluster        = $quickstack::params::cinder_backend_gluster,
@@ -203,8 +205,10 @@ class quickstack::controller_common (
   }
 
   class {'horizon':
-    secret_key    => $horizon_secret_key,
-    keystone_host => $controller_priv_host,
+    secret_key        => $horizon_secret_key,
+    keystone_host     => $controller_priv_host,
+    cache_server_ip   => $cache_server_ip,
+    cache_server_port => $cache_server_port,
   }
 
   class {'memcached':}

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -2,6 +2,8 @@
 class quickstack::neutron::controller (
   $admin_email                   = $quickstack::params::admin_email,
   $admin_password                = $quickstack::params::admin_password,
+  $cache_server_ip               = $quickstack::params::cache_server_ip,
+  $cache_server_port             = $quickstack::params::cache_server_port,
   $ceilometer_metering_secret    = $quickstack::params::ceilometer_metering_secret,
   $ceilometer_user_password      = $quickstack::params::ceilometer_user_password,
   $cinder_backend_gluster        = $quickstack::params::cinder_backend_gluster,
@@ -58,6 +60,8 @@ class quickstack::neutron::controller (
   class { 'quickstack::controller_common':
     admin_email                   => $admin_email,
     admin_password                => $admin_password,
+    cache_server_ip               => $cache_server_ip,
+    cache_server_port             => $cache_server_port,
     ceilometer_metering_secret    => $ceilometer_metering_secret,
     ceilometer_user_password      => $ceilometer_user_password,
     cinder_backend_gluster        => $cinder_backend_gluster,

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -102,4 +102,8 @@ class quickstack::params {
   $mysql_shared_storage_type     = 'MYSQL_SHARED_STORAGE_TYPE'
   $mysql_clu_member_addrs        = 'SPACE_SEPARATED_IP_ADDRS'
   $mysql_resource_group_name     = 'mysqlgroup'
+
+  # Configure Memcached settings for Horizon
+  $cache_server_ip               = '127.0.0.1'
+  $cache_server_port             = '11211'
 }


### PR DESCRIPTION
The current manifests do not offer the user the chance to
override the default memcached settings. It always defaults
to the localhost. This change updates the manifests to allow
the user to override.

Note that we'll need to update the installer packages to set
a default override parameter.

BZ #1063372 - No option to specify memcache details for Horizon in manifests
https://bugzilla.redhat.com/show_bug.cgi?id=1063372
