### PR TITLE
BZ #1063514 -  cinder_gluster_servers default value in controller host groups is confusing

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -242,6 +242,7 @@ params = {
   "cinder_gluster_peers"          => [],
   "cinder_gluster_volume"         => "cinder",
   "cinder_gluster_replica_count"  => '3',
+  "cinder_gluster_servers"        => [ '192.168.0.4', '192.168.0.5', '192.168.0.6' ],
   "glance_db_password"            => SecureRandom.hex,
   "glance_user_password"          => SecureRandom.hex,
   "glance_gluster_peers"          => [],


### PR DESCRIPTION
in either controller host group UI should display as an array of IPs,
not ${$quickstack::params:cinder_gluster_servers}
