### PR TITLE
BZ #1049633 - Foreman should support VXLAN

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -80,6 +80,6 @@ class quickstack::neutron::compute (
   }
 
   class {'quickstack::neutron::firewall::vxlan':
-    port => $vxlan_udp_port,
+    port => $ovs_vxlan_udp_port,
   }
 }

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -16,7 +16,7 @@ class quickstack::neutron::networker (
   $ovs_bridge_uplinks            = $quickstack::params::ovs_bridge_uplinks,
   $ovs_vlan_ranges               = $quickstack::params::ovs_vlan_ranges,
   $tunnel_id_ranges              = '1:1000',
-  $vxlan_udp_port                = $quickstack::params::ovs_vxlan_udp_port,
+  $ovs_vxlan_udp_port            = $quickstack::params::ovs_vxlan_udp_port,
   $ovs_tunnel_types              = $quickstack::params::ovs_tunnel_types,
   $enable_tunneling              = $quickstack::params::enable_tunneling,
   $verbose                       = $quickstack::params::verbose,
@@ -46,10 +46,10 @@ class quickstack::neutron::networker (
   }
 
   class { '::neutron::agents::ovs':
-    bridge_uplinks      => $ovs_bridge_uplinks,
-    local_ip            => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '[.-]', '_', 'G')),
-    bridge_mappings     => $ovs_bridge_mappings,
-    enable_tunneling    => str2bool_i("$enable_tunneling"),
+    bridge_uplinks   => $ovs_bridge_uplinks,
+    local_ip         => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '[.-]', '_', 'G')),
+    bridge_mappings  => $ovs_bridge_mappings,
+    enable_tunneling => str2bool_i("$enable_tunneling"),
     tunnel_types     => $ovs_tunnel_types,
     vxlan_udp_port   => $ovs_vxlan_udp_port,
   }
@@ -72,6 +72,6 @@ class quickstack::neutron::networker (
   #class { 'neutron::agents::fwaas': }
 
   class {'quickstack::neutron::firewall::vxlan':
-    port => $vxlan_udp_port,
+    port => $ovs_vxlan_udp_port,
   }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1049633

A couple of the variables inside the compute and networker classes were missing
the 'ovs_' part of the param name.
