### PR TITLE
Fix double port 80 directives in apache.

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -214,6 +214,17 @@ class quickstack::controller_common (
     keystone_host => $controller_priv_host,
     fqdn          => ["$controller_pub_host", "$::fqdn", "$::hostname", 'localhost'],
   }
+  # patch our horizon/apache config to avoid duplicate port 80
+  # directive.  TODO: remove this once puppet-horizon/apache can
+  # handle it.
+  file_line { 'undo_httpd_listen_on_bind_address_80':
+    path    => $::horizon::params::httpd_listen_config_file,
+    match   => '^.*Listen 0.0.0.0:?80$',
+    line    => "#Listen 0.0.0.0:80",
+    require => Package['horizon'],
+    notify  => Service[$::horizon::params::http_service],
+  }
+  File_line['httpd_listen_on_bind_address_80'] -> File_line['undo_httpd_listen_on_bind_address_80']
 
   class {'memcached':}
 


### PR DESCRIPTION
Without this patch, apache/hoizon fails to start.
However, should be able to remove this patch once
puppet-horizon/apache better handles this case.
