### PR TITLE
Separated parameters, hostgroups values from code; RSPEC added along

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -297,6 +297,17 @@ class quickstack::controller_common (
     horizon_key   => $horizon_key,
     horizon_ca    => $horizon_ca,
   }
+  # patch our horizon/apache config to avoid duplicate port 80
+  # directive.  TODO: remove this once puppet-horizon/apache can
+  # handle it.
+  file_line { 'undo_httpd_listen_on_bind_address_80':
+    path    => $::horizon::params::httpd_listen_config_file,
+    match   => '^.*Listen 0.0.0.0:?80$',
+    line    => "#Listen 0.0.0.0:80",
+    require => Package['horizon'],
+    notify  => Service[$::horizon::params::http_service],
+  }
+  File_line['httpd_listen_on_bind_address_80'] -> File_line['undo_httpd_listen_on_bind_address_80']
 
   class {'memcached':}
 


### PR DESCRIPTION
The idea is provide a way to manage quickstack parameters and hostgroups decoupled from the source.
This way values could also be managed externally by another program.

I also added Rspec in order to get started with unit testing.
