### PR TITLE
Parameters+automation1

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -297,6 +297,17 @@ class quickstack::controller_common (
     horizon_key   => $horizon_key,
     horizon_ca    => $horizon_ca,
   }
+  # patch our horizon/apache config to avoid duplicate port 80
+  # directive.  TODO: remove this once puppet-horizon/apache can
+  # handle it.
+  file_line { 'undo_httpd_listen_on_bind_address_80':
+    path    => $::horizon::params::httpd_listen_config_file,
+    match   => '^.*Listen 0.0.0.0:?80$',
+    line    => "#Listen 0.0.0.0:80",
+    require => Package['horizon'],
+    notify  => Service[$::horizon::params::http_service],
+  }
+  File_line['httpd_listen_on_bind_address_80'] -> File_line['undo_httpd_listen_on_bind_address_80']
 
   class {'memcached':}
 


### PR DESCRIPTION
The idea, to provide a way to manage quickstack parameters and hostgroups decoupled from the source.
And could help maintain the values which also, eventually, could be managed externally by another programs.
If this is merged, then params.pp could also be generated from the same quickstack.yaml.erb template.
I realized, even though we use foreman to populate variables in the hostgroups which overrides params.pp, that keeping params.pp is vital for pure puppet environments. (for some reason it took me a while before thinking that :-\

I also used Rspec in order to get started with unit testing. I suppose this doesn't need to go into packages but I don't know how to signal it.
