### PR TITLE
Separated  parameters, hostgroups values from code; RSPEC added

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new

--- a/bin/foreman_server.sh
+++ b/bin/foreman_server.sh
@@ -22,7 +22,7 @@ fi
 # FOREMAN_PROVISIONING determines whether configure foreman for bare
 # metal provisioning including installing dns and dhcp servers.
 if [ "x$FOREMAN_PROVISIONING" = "x" ]; then
-  FOREMAN_PROVISIONING=true
+  FOREMAN_PROVISIONING=$(ruby -r /usr/share/openstack-foreman-installer/lib/configuration -e "puts Setup.new('/usr/share/openstack-foreman-installer/config/install.yaml').foreman_provisioning")
 fi
 
 # FOREMAN_GATEWAY must be set when using foreman for provisioning
@@ -75,8 +75,8 @@ if [ "$FOREMAN_PROVISIONING" = "true" ]; then
 
   PRIMARY_INT=$(route|grep default|awk ' { print ( $(NF) ) }')
   PRIMARY_PREFIX=$(facter network_${PRIMARY_INT} | cut -d. -f1-3)
- 
-  # If no provisioning interface specified, guess it's "the next one" 
+
+  # If no provisioning interface specified, guess it's "the next one"
   if [ "x$PROVISIONING_INTERFACE" = "x" ]; then
     PROVISIONING_INTERFACE=$(facter -p|grep ipaddress_|grep -Ev "_lo|$PRIMARY_INT"|awk -F"[_ ]" '{print $2;exit 0}')
   fi
@@ -90,7 +90,7 @@ if [ "$FOREMAN_PROVISIONING" = "true" ]; then
   if [ "x$PROVISIONING_PREFIX" = "x" ]; then
     echo "This installer can not determine the interface to provision over."
     exit 1
-  fi     
+  fi
   PROVISIONING_REVERSE=$(echo "$PROVISIONING_PREFIX" | ( IFS='.' read a b c ; echo "$c.$b.$a.in-addr.arpa" ))
   FORWARDER=$(augtool get /files/etc/resolv.conf/nameserver[1] | awk '{printf $NF}')
 fi

--- a/config/hostgroups.yaml
+++ b/config/hostgroups.yaml
@@ -1,0 +1,42 @@
+---
+- :name: Controller (Nova Network)
+  :class: quickstack::nova_network::controller
+- :name: Compute (Nova Network)
+  :class: quickstack::nova_network::compute
+- :name: Controller (Neutron)
+  :class: quickstack::neutron::controller
+- :name: Compute (Neutron)
+  :class: quickstack::neutron::compute
+- :name: Neutron Networker
+  :class: quickstack::neutron::networker
+- :name: Cinder Block Storage
+  :class: quickstack::storage_backend::cinder
+- :name: Load Balancer
+  :class: quickstack::load_balancer
+- :name: HA Mysql Node
+  :class: quickstack::hamysql::node
+- :name: Swift Storage Node
+  :class: quickstack::swift::storage
+- :name: HA All In One Controller
+  :class:
+  - quickstack::openstack_common
+  - quickstack::pacemaker::common
+  - quickstack::pacemaker::params
+  - quickstack::pacemaker::keystone
+  - quickstack::pacemaker::swift
+  - quickstack::pacemaker::load_balancer
+  - quickstack::pacemaker::memcached
+  - quickstack::pacemaker::qpid
+  - quickstack::pacemaker::glance
+  - quickstack::pacemaker::nova
+  - quickstack::pacemaker::heat
+  - quickstack::pacemaker::cinder
+  - quickstack::pacemaker::horizon
+  - quickstack::pacemaker::mysql
+  - quickstack::pacemaker::neutron
+- :name: Gluster Server
+  :class:
+  - puppet::vardir
+  - quickstack::gluster::server
+- :name: Galera Server
+  :class: quickstack::galera::server

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1,0 +1,7 @@
+---
+debug: false
+quickstack: /usr/share/openstack-foreman-installer/config/quickstack.yaml.erb
+hostgroups: /usr/share/openstack-foreman-installer/config/hostgroups.yaml
+foreman_provisioning: true
+# for the sub-network foreman owns
+secondary_int: SECONDARY_INT

--- a/config/quickstack.yaml.erb
+++ b/config/quickstack.yaml.erb
@@ -1,0 +1,158 @@
+# By default all passwords are generated when using erb passwd_auto stanza
+# Replacing passwd_auto content by a string will make it the same everywhere
+# Alternatively static values can be used directly
+<%  require 'facter'
+    require 'securerandom'
+
+    mail_auto = "admin@#{Facter.domain}"
+
+    def passwd_auto
+      SecureRandom.hex
+    end
+%>
+---
+verbose: true
+heat_cfn: false
+heat_cloudwatch: false
+admin_email: <%= mail_auto %>
+admin_password: <%= passwd_auto %>
+ceilometer_metering_secret: <%= passwd_auto %>
+ceilometer_user_password: <%= passwd_auto %>
+cinder_db_password: <%= passwd_auto %>
+cinder_user_password: <%= passwd_auto %>
+cinder_backend_gluster: false
+cinder_backend_iscsi: false
+cinder_gluster_peers:
+- 192.168.0.4
+- 192.168.0.5
+- 192.168.0.6
+cinder_gluster_volume: cinder
+cinder_gluster_replica_count: 3
+glance_db_password: <%= passwd_auto %>
+glance_user_password: <%= passwd_auto %>
+glance_gluster_peers: []
+glance_gluster_volume: glance
+glance_gluster_replica_count: 3
+gluster_open_port_count: 10
+heat_auth_encryption_key: <%= passwd_auto %>
+heat_db_password: <%= passwd_auto %>
+heat_user_password: <%= passwd_auto %>
+heat_cfn_user_password: <%= passwd_auto %>
+heat_auth_encrypt_key: <%= passwd_auto %>
+horizon_secret_key: <%= passwd_auto %>
+keystone_admin_token: <%= passwd_auto %>
+keystone_db_password: <%= passwd_auto %>
+keystone_user_password: <%= passwd_auto %>
+mysql_root_password: <%= passwd_auto %>
+neutron_db_password: <%= passwd_auto %>
+neutron_user_password: <%= passwd_auto %>
+nova_db_password: <%= passwd_auto %>
+nova_user_password: <%= passwd_auto %>
+nova_default_floating_pool: nova
+swift_admin_password: <%= passwd_auto %>
+swift_shared_secret: <%= passwd_auto %>
+swift_user_password: <%= passwd_auto %>
+swift_all_ips:
+- 192.168.203.1
+- 192.168.203.2
+- 192.168.203.3
+- 192.168.203.4
+swift_ext4_device: /dev/sdc2
+swift_local_interface: eth3
+swift_loopback: true
+swift_ring_server: 192.168.203.1
+fixed_network_range: 10.0.0.0/24
+floating_network_range: 10.0.1.0/24
+controller_admin_host: 172.16.0.1
+controller_priv_host: 172.16.0.1
+controller_pub_host: 172.16.1.1
+mysql_host: 172.16.0.1
+mysql_virtual_ip: 192.168.200.220
+mysql_bind_address: 0.0.0.0
+mysql_virt_ip_nic: eth1
+mysql_virt_ip_cidr_mask: 24
+mysql_shared_storage_device: 192.168.203.200:/mnt/mysql
+mysql_shared_storage_options: ''
+mysql_shared_storage_type: nfs
+mysql_resource_group_name: mysqlgrp
+mysql_clu_member_addrs: 192.168.203.11 192.168.203.12 192.168.203.13
+amqp_server: rabbitmq
+amqp_host: 172.16.0.1
+amqp_username: openstack
+amqp_password: <%= passwd_auto %>
+neutron_metadata_proxy_secret: <%= passwd_auto %>
+enable_ovs_agent: true
+ovs_vlan_ranges: ''
+ovs_bridge_mappings: []
+ovs_bridge_uplinks: []
+tenant_network_type: gre
+enable_tunneling: true
+ovs_vxlan_udp_port: 4789
+ovs_tunnel_types: []
+auto_assign_floating_ip: True
+neutron_core_plugin: neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2
+cisco_vswitch_plugin: neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2
+cisco_nexus_plugin: neutron.plugins.cisco.nexus.cisco_nexus_plugin_v2.NexusPlugin
+nexus_config: {}
+nexus_credentials: []
+provider_vlan_auto_create: false
+provider_vlan_auto_trunk: false
+backend_server_names: []
+backend_server_addrs: []
+lb_backend_server_names: []
+lb_backend_server_addrs: []
+configure_ovswitch: true
+neutron: false
+ssl: false
+freeipa: false
+mysql_ca: /etc/ipa/ca.crt
+mysql_cert: /etc/pki/tls/certs/PRIV_HOST-mysql.crt
+mysql_key: /etc/pki/tls/private/PRIV_HOST-mysql.key
+amqp_ca: /etc/ipa/ca.crt
+amqp_cert: /etc/pki/tls/certs/PRIV_HOST-amqp.crt
+amqp_key: /etc/pki/tls/private/PRIV_HOST-amqp.key
+horizon_ca: /etc/ipa/ca.crt
+horizon_cert: /etc/pki/tls/certs/PUB_HOST-horizon.crt
+horizon_key: /etc/pki/tls/private/PUB_HOST-horizon.key
+amqp_nssdb_password: <%= passwd_auto %>
+fence_xvm_key_file_password: <%= passwd_auto %>
+use_qemu_for_poc: false
+secret_key: <%= passwd_auto %>
+admin_token: <%= passwd_auto %>
+gluster_device1: /dev/vdb
+gluster_device2: /dev/vdc
+gluster_device3: /dev/vdd
+gluster_fqdn1: gluster-server1.example.com
+gluster_fqdn2: gluster-server2.example.com
+gluster_fqdn3: gluster-server3.example.com
+gluster_port_count: 9
+gluster_replica_count: 3
+gluster_uuid1: e27f2849-6f69-4900-b348-d7b0ae497509
+gluster_uuid2: 746dc27e-b9bd-46d7-a1a6-7b8957528f4c
+gluster_uuid3: 5fe22c7d-dc85-4d81-8c8b-468876852566
+gluster_volume1_gid: 165
+gluster_volume1_name: cinder
+gluster_volume1_path: /cinder
+gluster_volume1_uid: 165
+gluster_volume2_gid: 161
+gluster_volume2_name: glance
+gluster_volume2_path: /glance
+gluster_volume2_uid: 161
+gluster_volume3_gid: 160
+gluster_volume3_name: swift
+gluster_volume3_path: /swift
+gluster_volume3_uid: 160
+galera_bootstrap: false
+galera_monitor_username: monitor_user
+galera_monitor_password: <%= passwd_auto %>
+wsrep_cluster_name: galera_cluster
+wsrep_cluster_members:
+- 192.168.203.11
+- 192.168.203.12
+- 192.168.203.13
+wsrep_sst_method: rsync
+wsrep_sst_username: sst_user
+wsrep_sst_password: <%= passwd_auto %>
+wsrep_ssl: true
+wsrep_ssl_key: /etc/pki/galera/galera.key
+wsrep_ssl_cert: /etc/pki/galera/galera.crt

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,0 +1,50 @@
+require 'erb'
+require 'yaml'
+
+class Configuration
+  def initialize(filename)
+    @options = YAML.load(File.open(filename))
+  end
+
+  def get
+    @options
+  end
+
+  def to_s
+    list=''
+    @options.each { |k,v|  list << "#{k.to_s} => #{v.to_s}\n" }
+    list
+  end
+end
+
+class Hostgroups < Configuration
+end
+
+class Quickstack < Configuration
+  def initialize(filename)
+    template = ERB.new(File.new(filename).read, nil, '%-')
+    @options  = YAML.load(template.result(binding))
+  end
+end
+
+class Setup < Configuration
+  def debug
+    @options['debug']
+  end
+
+  def hostgroups
+    @options['hostgroups']
+  end
+
+  def quickstack
+    @options['quickstack']
+  end
+
+ def foreman_provisioning
+    @options['foreman_provisioning']
+  end
+
+  def secondary_int
+    @options['secondary_int']
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,78 @@
+# For manual test user:
+# rspec spec/configuration_spec.rb --format doc
+require './spec/spec_helper'
+
+describe Configuration do
+  describe Hostgroups do
+    before :all do
+      @hostgroups = Hostgroups.new('./config/hostgroups.yaml')
+    end
+
+    it 'responds to #get' do
+      expect(@hostgroups).to respond_to(:get)
+    end
+
+    it 'responds to #to_s' do
+      expect(@config).to respond_to(:to_s)
+    end
+
+    it '#get produces an Array of right size' do
+      expect(@hostgroups.get.size).to equal(12)
+    end
+  end
+
+  describe Setup do
+    before :all do
+      @setup = Setup.new('./config/install.yaml')
+    end
+
+    it 'responds to #get' do
+      expect(@setup).to respond_to(:get)
+    end
+
+    it 'responds to #to_s' do
+      expect(@config).to respond_to(:to_s)
+    end
+
+    it '#debug provides a boolean' do
+      expect(@setup.debug).to equal(false)
+    end
+
+    it 'responds to #quickstack ' do
+      expect(@setup).to respond_to(:quickstack)
+    end
+
+    it 'responds to #foreman_provisioning ' do
+      expect(@setup).to respond_to(:foreman_provisioning)
+    end
+
+    it 'responds to #hostgroups ' do
+      expect(@setup).to respond_to(:hostgroups)
+    end
+  end
+
+  describe Quickstack do
+    before :all do
+      @config = Quickstack.new('./config/quickstack.yaml.erb')
+    end
+
+    it 'responds to #get' do
+      expect(@config).to respond_to(:get)
+    end
+
+    it 'responds to #to_s' do
+      expect(@config).to respond_to(:to_s)
+    end
+
+    it '#get produces a Hash of right size' do
+      expect(@config.get.size).to equal(135)
+    end
+
+    context 'with automatic password assigned' do
+      it "must be different" do
+        params = @config.get
+        expect(params['ceilometer_user_password']).not_to eq(params['cinder_db_password'])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require './lib/configuration'


### PR DESCRIPTION
The idea, to provide a way to manage quickstack parameters and hostgroups decoupled from the source.
And could help maintain the values which also, eventually, could be managed externally by other programs.
If this is merged, then params.pp could also be generated from the same quickstack.yaml.erb template.
I realized, even though we use foreman to populate variables in the hostgroups which overrides params.pp, that keeping params.pp is vital for pure puppet environments. (for some reason it took me a while before thinking that :-\ )

I also used Rspec in order to get started with unit testing. I suppose this doesn't need to go into packages but I don't know how to signal it.
