### PR TITLE
Add fencing options to quickstack::pacemaker::common

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -318,10 +318,17 @@ params = {
   "qpid_nssdb_password"           => SecureRandom.hex,
   "pacemaker_cluster_name"        => "openstack",
   "pacemaker_cluster_members"     => "192.168.200.10 192.168.200.11 192.168.200.12",
-  "pacemaker_disable_stonith"     => false,
   "ha_loadbalancer_public_vip"    => "192.168.200.50",
   "ha_loadbalancer_private_vip"   => "192.168.201.50",
   "ha_loadbalancer_group"         => "load_balancer",
+  "fencing_type"                  => "disabled",
+  "fence_xvm_clu_iface"           => "eth2",
+  "fence_xvm_manage_key_file"     => "false",
+  "fence_xvm_key_file_password"   => "12345678isTheSecret",
+  "fence_ipmilan_address"         => "10.10.10.1",
+  "fence_ipmilan_username"        => "",
+  "fence_ipmilan_password"        => "",
+  "fence_ipmilan_interval"        => "60s",
 }
 
 hostgroups = [

--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -1,14 +1,53 @@
 class quickstack::pacemaker::common (
-  $pacemaker_cluster_name    = $quickstack::params::pacemaker_cluster_name,
-  $pacemaker_cluster_members = $quickstack::params::pacemaker_cluster_members,
-  $pacemaker_disable_stonith = $quickstack::params::pacemaker_disable_stonith,
+  $pacemaker_cluster_name         = $quickstack::params::pacemaker_cluster_name,
+  $pacemaker_cluster_members      = $quickstack::params::pacemaker_cluster_members,
+  # fencing_type should be either "disabled", "fence_xvm", or "". ""
+  #   means do not disable stonith, but also don't add any fencing
+  $fencing_type                   = $quickstack::params::fencing_type,
+  $fence_ipmilan_address          = $quickstack::params::fence_ipmilan_address,
+  $fence_ipmilan_username         = $quickstack::params::fence_ipmilan_username,
+  $fence_ipmilan_password         = $quickstack::params::fence_ipmilan_password,
+  $fence_ipmilan_interval         = $quickstack::params::fence_ipmilan_interval,
+  $fence_xvm_clu_iface            = $quickstack::params::fence_xvm_clu_iface,
+  $fence_xvm_manage_key_file      = $quickstack::params::fence_xvm_manage_key_file,
+  $fence_xvm_key_file_password    = $quickstack::params::fence_xvm_key_file_password,
+
 ) inherits quickstack::params {
   class {'pacemaker::corosync':
     cluster_name    => $pacemaker_cluster_name,
     cluster_members => $pacemaker_cluster_members,
   }
-  ->
-  class {'pacemaker::stonith':
-    disable => str2bool_i("$pacemaker_disable_stonith"),
+
+  if $fencing_type =~ /(?i-mx:^disabled$)/ {
+    class {'pacemaker::stonith':
+      disable => true }
+    Class['pacemaker::corosync'] -> Class['pacemaker::stonith']
+  }
+  elsif $fencing_type =~ /(?i-mx:^ipmilan$)/ {
+    class {'pacemaker::stonith':
+      disable => false }
+    class {'pacemaker::stonith::ipmilan':
+      address        => $fence_ipmilan_address,
+      username       => $fence_ipmilan_username,
+      password       => $fence_ipmilan_password,
+      interval       => $fence_ipmilan_interval,
+      pcmk_host_list => $pacemaker_cluster_members,
+    }
+    Class['pacemaker::corosync'] -> Class['pacemaker::stonith'] ->
+    Class['pacemaker::stonith::ipmilan']
+  }
+  elsif $fencing_type =~ /(?i-mx:^fence_xvm$)/ {
+    $clu_ip_address = getvar(regsubst("ipaddress_$fence_xvm_clu_iface", '[.-]', '_', 'G'))
+    class {'pacemaker::stonith':
+      disable => false }
+    class {'pacemaker::stonith::fence_xvm':
+      name              => "$::hostname",
+      manage_key_file   => str2bool_i("$fence_xvm_manage_key_file"),
+      key_file_password => $fence_xvm_key_file_password,
+      port              => "$::hostname",    # the name of the vm
+      pcmk_host         => $clu_ip_address,  # the hostname or IP that pacemaker uses
+    }
+    Class['pacemaker::corosync'] -> Class['pacemaker::stonith'] ->
+    Class['pacemaker::stonith::fence_xvm']
   }
 }

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -121,8 +121,15 @@ class quickstack::params {
   # Pacemaker
   $pacemaker_cluster_name        = 'openstack'
   $pacemaker_cluster_members     = ''
-  $pacemaker_disable_stonith     = true
   $ha_loadbalancer_public_vip    = '172.16.1.10'
   $ha_loadbalancer_private_vip   = '172.16.2.10'
   $ha_loadbalancer_group         = 'load_balancer'
+  $fencing_type                  = 'disabled'
+  $fence_xvm_clu_iface           = 'eth2'
+  $fence_xvm_manage_key_file     = false
+  $fence_xvm_key_file_password   = '12345678isTheSecret'
+  $fence_ipmilan_address         = '10.10.10.1'
+  $fence_ipmilan_username        = ''
+  $fence_ipmilan_password        = ''
+  $fence_ipmilan_interval        = '60s'
 }


### PR DESCRIPTION
From my testing, fence resources were created for my three vm's:

```
# pcs status
Cluster name: openstack
Last updated: Fri Mar  7 17:54:57 2014
Last change: Thu Mar  6 18:20:02 2014 via cibadmin on 192.168.200.30
Stack: cman
Current DC: 192.168.200.20 - partition with quorum
Version: 1.1.10-14.el6_5.2-368c726
3 Nodes configured
3 Resources configured


Online: [ 192.168.200.10 192.168.200.20 192.168.200.30 ]

Full list of resources:

 fence_xvm-c1a3 (stonith:fence_xvm):    Started 192.168.200.20
 fence_xvm-c1a2 (stonith:fence_xvm):    Started 192.168.200.30
 fence_xvm-c1a1 (stonith:fence_xvm):    Started 192.168.200.10
```

Using quickstack::pacemaker::common parameter values of fencing_type =
fence_xvm, fence_xvm_clu_iface = eth2, and fence_xvm_manage_key_file =
false ( /etc/cluster/fence_xvm.key was copied onto the VM's before
running the puppet agent, though they could be copied after the
stonith resources are created and the fencing resources would still
work).  Taking down the network interfaces on one of the nodes causes
it to be fenced/rebooted.

Also tested fencing_type = 'disabled', which appropriately set the
stonith-enabled property to false and did not install fence_xvm.

Also tested fencing_type = "", which does _not_ set stonith-enabled to
false (i.e., do nothing at all with respect to fencing).

Also verified that setting fence_xvm_manage_key_file = true and
fence_xvm_key_file_password = 'somesecretpayload' caused
/etc/cluster/fence_xvm.key to be updated with 'somesecretpayload' .

This work depends on https://github.com/radez/puppet-pacemaker/pull/14
