### PR TITLE
BZ #1064056 - Foreman Heat ports not opened

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -323,6 +323,12 @@ class quickstack::controller_common (
     action   => 'accept',
   }
 
+  firewall { '001 controller incoming pt2':
+    proto    => 'tcp',
+    dport    => ['8000', '8003', '8004'],
+    action   => 'accept',
+  }
+
   if $ssl {
     firewall { '002 ssl controller incoming':
       proto    => 'tcp',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1064056

Open ports on the controller node for Heat:
- 8000 for opehstack-heat-api-cfn
- 8003 for opehstack-heat-api-cloudwatch
- 8004 for openstack-heat-api

A new firewall rule has to be added, because if the ports would be
added to the existing one, the port count would be greater than the
maximum for iptables multiport extension (maximum is 15), and creating
the rule would fail with a message "iptables v1.4.7: too many ports
specified".
