### PR TITLE
added gluster-server using purpleidea/puppet-gluster

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -345,6 +345,29 @@ params = {
   "use_qemu_for_poc"              => "false",
   "secret_key"                    => SecureRandom.hex,
   "admin_token"                   => SecureRandom.hex,
+  "gluster_device1"               => '/dev/vdb',
+  "gluster_device2"               => '/dev/vdc',
+  "gluster_device3"               => '/dev/vdd',
+  "gluster_fqdn1"                 => 'gluster-server1.example.com',
+  "gluster_fqdn2"                 => 'gluster-server2.example.com',
+  "gluster_fqdn3"                 => 'gluster-server3.example.com',
+  "gluster_port_count"            => '9',
+  "gluster_replica_count"         => '3',
+  "gluster_uuid1"                 => 'e27f2849-6f69-4900-b348-d7b0ae497509',
+  "gluster_uuid2"                 => '746dc27e-b9bd-46d7-a1a6-7b8957528f4c',
+  "gluster_uuid3"                 => '5fe22c7d-dc85-4d81-8c8b-468876852566',
+  "gluster_volume1_gid"           => '165',
+  "gluster_volume1_name"          => 'cinder',
+  "gluster_volume1_path"          => '/cinder',
+  "gluster_volume1_uid"           => '165',
+  "gluster_volume2_gid"           => '161',
+  "gluster_volume2_name"          => 'glance',
+  "gluster_volume2_path"          => '/glance',
+  "gluster_volume2_uid"           => '161',
+  "gluster_volume3_gid"           => '160',
+  "gluster_volume3_name"          => 'swift',
+  "gluster_volume3_path"          => '/swift',
+  "gluster_volume3_uid"           => '160',
 }
 
 hostgroups = [
@@ -383,6 +406,10 @@ hostgroups = [
               "quickstack::pacemaker::mysql",
               "quickstack::pacemaker::neutron",
              ]},
+    {:name=>"Gluster Server",
+     :class=>["puppet::vardir",
+              "quickstack::gluster::server",
+             ]}
 ]
 
 def get_key_type(value)

--- a/puppet/modules/quickstack/manifests/firewall/gluster.pp
+++ b/puppet/modules/quickstack/manifests/firewall/gluster.pp
@@ -1,0 +1,34 @@
+class quickstack::firewall::gluster (
+  $port_rpc      = [ '111' ],
+  $port_glusterd = [ '24007', '24008' ],
+  $port_glusterb = '49152',
+  $port_count
+) {
+
+  include quickstack::firewall::common
+
+  firewall {'001 RPC TCP daemon incoming':
+    proto  => 'tcp',
+    dport  => $port_rpc,
+    action => 'accept',
+  }
+
+  firewall {'001 RPC UDP daemon incoming':
+    proto  => 'udp',
+    dport  => $port_rpc,
+    action => 'accept',
+  }
+
+  firewall {'001 Glusterfs TCP daemon incoming':
+    proto  => 'tcp',
+    dport  => $port_glusterd,
+    action => 'accept',
+  }
+
+  # One port per brick
+  firewall {'001 Glusterfs bricks TCP incoming':
+    proto  => 'tcp',
+    dport  => port_range($port_glusterb, $port_count),
+    action => 'accept',
+  }
+}

--- a/puppet/modules/quickstack/manifests/gluster/server.pp
+++ b/puppet/modules/quickstack/manifests/gluster/server.pp
@@ -1,0 +1,225 @@
+# Quickstack Service for gluster server
+# This could be used when external resources aren't available
+# It must be executed on each gluster server in a round robbin mode
+class quickstack::gluster::server (
+  $device1       = $quickstack::params::gluster_device1,
+  $device2       = $quickstack::params::gluster_device2,
+  $device3       = $quickstack::params::gluster_device3,
+  $fqdn1         = $quickstack::params::gluster_fqdn1,
+  $fqdn2         = $quickstack::params::gluster_fqdn2,
+  $fqdn3         = $quickstack::params::gluster_fqdn3,
+  $port_count    = $quickstack::params::gluster_port_count,
+  $replica_count = $quickstack::params::gluster_replica_count,
+  $uuid1         = $quickstack::params::gluster_uuid1,
+  $uuid2         = $quickstack::params::gluster_uuid2,
+  $uuid3         = $quickstack::params::gluster_uuid3,
+
+  $volume1_gid   = $quickstack::params::gluster_volume1_gid,
+  $volume1_name  = $quickstack::params::gluster_volume1_name,
+  $volume1_path  = $quickstack::params::gluster_volume1_path,
+  $volume1_uid   = $quickstack::params::gluster_volume1_uid,
+
+  $volume2_gid   = $quickstack::params::gluster_volume2_gid,
+  $volume2_name  = $quickstack::params::gluster_volume2_name,
+  $volume2_path  = $quickstack::params::gluster_volume2_path,
+  $volume2_uid   = $quickstack::params::gluster_volume2_uid,
+
+  $volume3_gid   = $quickstack::params::gluster_volume3_gid,
+  $volume3_name  = $quickstack::params::gluster_volume3_name,
+  $volume3_path  = $quickstack::params::gluster_volume3_path,
+  $volume3_uid   = $quickstack::params::gluster_volume3_uid,
+) {
+
+  $vip  = ''
+  $vrrp =  false
+
+  class {'::gluster::server':
+    vip       => $vip,
+    vrrp      => $vrrp,
+    repo      => false,
+    shorewall => false,
+  }
+
+  gluster::host {"${fqdn1}":
+    uuid => "${uuid1}"
+  }
+
+  gluster::host {"${fqdn2}":
+    uuid => "${uuid2}"
+  }
+
+  gluster::host {"${fqdn3}":
+    uuid => "${uuid3}"
+  }
+
+  gluster::brick {"${fqdn1}:${volume1_path}":
+    dev         => "${device1}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  gluster::brick {"${fqdn1}:${volume2_path}":
+    dev         => "${device2}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  gluster::brick {"${fqdn1}:${volume3_path}":
+    dev         => "${device3}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  gluster::brick {"${fqdn2}:${volume1_path}":
+    dev         => "${device1}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  gluster::brick {"${fqdn2}:${volume2_path}":
+    dev         => "${device2}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  gluster::brick {"${fqdn2}:${volume3_path}":
+    dev         => "${device3}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  gluster::brick {"${fqdn3}:${volume1_path}":
+    dev         => "${device1}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  gluster::brick {"${fqdn3}:${volume2_path}":
+    dev         => "${device2}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  gluster::brick {"${fqdn3}:${volume3_path}":
+    dev         => "${device3}",
+    raid_su     => '256',
+    raid_sw     => '10',
+    partition   => true,
+    lvm         => true,
+    fstype      => 'xfs',
+    xfs_inode64 => true,
+    #xfs_nobarrier => true,
+    force       => true,
+    areyousure  => true,
+  }
+
+  $brick_list = [
+    "${fqdn1}:${volume1_path}",
+    "${fqdn2}:${volume1_path}",
+    "${fqdn3}:${volume1_path}",
+    "${fqdn1}:${volume2_path}",
+    "${fqdn2}:${volume2_path}",
+    "${fqdn3}:${volume2_path}",
+    "${fqdn1}:${volume3_path}",
+    "${fqdn2}:${volume3_path}",
+    "${fqdn3}:${volume3_path}",
+  ]
+
+  gluster::volume { ["${volume1_name}", "${volume2_name}", "${volume3_name}"]:
+    replica => "${replica_count}",
+    bricks => $brick_list,
+    vip => "${vip}",
+    ping => false,  # disable fping
+    start => true,
+  }
+
+  gluster::volume::property {"${volume1_name}#storage.owner-uid":
+    value => $volume1_uid,
+  }
+
+  gluster::volume::property {"${volume1_name}#storage.owner-gid":
+    value => $volume1_gid,
+  }
+
+  gluster::volume::property {"${volume2_name}#storage.owner-uid":
+    value => $volume2_uid,
+  }
+
+  gluster::volume::property {"${volume2_name}#storage.owner-gid":
+    value => $volume2_gid,
+  }
+
+  gluster::volume::property {"${volume3_name}#storage.owner-uid":
+    value => $volume3_uid,
+  }
+
+  gluster::volume::property {"${volume3_name}#storage.owner-gid":
+    value => $volume3_gid,
+  }
+
+  gluster::volume::property::group {"${volume1_name}#virt":}
+
+  gluster::volume::property::group {"${volume2_name}#virt":}
+
+  gluster::volume::property::group {"${volume3_name}#virt":}
+
+  class {'quickstack::firewall::gluster':
+    port_count => "${port_count}",
+  }
+}

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -138,4 +138,30 @@ class quickstack::params {
 
   # Nova Compute
   $use_qemu_for_poc              = 'false'
+
+  # Gluster Servers
+  $gluster_device1       = '/dev/vdb'
+  $gluster_device2       = '/dev/vdc'
+  $gluster_device3       = '/dev/vdd'
+  $gluster_fqdn1         = 'gluster-server1.example.com'
+  $gluster_fqdn2         = 'gluster-server2.example.com'
+  $gluster_fqdn3         = 'gluster-server3.example.com'
+  # One port for each brick in a volume
+  $gluster_port_count    = '9'
+  $gluster_replica_count = '3'
+  $gluster_uuid1         = 'e27f2849-6f69-4900-b348-d7b0ae497509'
+  $gluster_uuid2         = '746dc27e-b9bd-46d7-a1a6-7b8957528f4c'
+  $gluster_uuid3         = '5fe22c7d-dc85-4d81-8c8b-468876852566'
+  $gluster_volume1_gid   = '165',
+  $gluster_volume1_name  = 'cinder'
+  $gluster_volume1_path  = '/cinder'
+  $gluster_volume1_uid   = '165',
+  $gluster_volume2_gid   = '161',
+  $gluster_volume2_name  = 'glance'
+  $gluster_volume2_path  = '/glance'
+  $gluster_volume2_uid   = '161',
+  $gluster_volume3_gid   = '160',
+  $gluster_volume3_name  = 'swift'
+  $gluster_volume3_path  = '/swift'
+  $gluster_volume3_uid   = '160',
 }


### PR DESCRIPTION
Used roles -> profiles -> services (svc) approach to pave a road for more scenarios flexibility.
seed.rb is the only existing file impacted, in order to add a new hostgroup.
The rest is green.

This is relying on  purpleidea/puppet-gluster submodule which has already been added (yesterday, though!) to openstack-puppet-modules master trunk.
Starting with gluster_server nodes, the gluster client integration with existing cinder_controller and glance to be visited later.
This is partially working, meaning the puppet catalog goes through but the gluster volumes are not completely configured (WIP).
Also because of the different approach with the roles/profiles, I'm pushing this one progressively.
Only one role can be matched by a node, but multiple services should be able to be used by each profile.
(http://www.craigdunn.org/2012/05/239/)
