### PR TITLE
BZ #1073087 - [RFE] Use subscription-manager

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -138,11 +138,26 @@ m.save!
 
 # OS parameters for RHN(S) registration, see redhat_register snippet
 {
+  # use Subscription Manager, not Satellite
+  "subscription_manager" => "true",
+
+  "subscription_manager_username" => "username",
+  "subscription_manager_password" => "password",
+  # for load balancer also enable "rhel-lb-for-rhel-6-server-rpms"
+  "subscription_manager_repos" => "rhel-6-server-rpms,rhel-6-server-openstack-4.0-rpms",
+
+  # if using SAM/Katello
+  # "subscription_manager_host" => "katello.example.com",
+  # "subscription_manager_org" => "organization",
+
+  # if using Satellite
   # "site" for local Satellite, "hosted" for RHN
-  "satellite_type" => "site",
-  "satellite_host" => "satellite.example.com",
+  # "satellite_type" => "site",
+  # "satellite_host" => "satellite.example.com",
+
+  # if using Satellite or SAM/Katello
   # Activation key must have OpenStack child channel
-  "activation_key" => "1-example",
+  # "activation_key" => "1-example",
 }.each do |k,v|
   p=OsParameter.find_or_create_by_name(k)
   p.value = v


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1073087

Use subscription-manager by default instead of rhnreg_ks to subscribe
the system for Red Hat repositories.

Only parameters for username/password registration are present by
default, but more subscription options are available (including the
original rhnreg_ks). Those parameters are commented out, not populated
by default, not to confuse users what params to fill in. (Creating a
parameter with an empty string as value is not allowed.)

This commit depends on Foreman having a redhat_register snippet that
supports subscription-manager and also has a workaround for correctly
enabling repositories on RHEL 6.4 [1].

[1] https://github.com/theforeman/community-templates/commit/6a66f3908b2c8729d311507ec5e56ee2f34e01c7
