### PR TITLE
BZ #1085547 - Keystone role is created as _member_ instead of Member

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -297,13 +297,14 @@ class quickstack::controller_common (
   }
 
   class {'horizon':
-    secret_key    => $horizon_secret_key,
-    keystone_host => $controller_priv_host,
-    fqdn          => ["$controller_pub_host", "$::fqdn", "$::hostname", 'localhost'],
-    listen_ssl    => str2bool_i("$ssl"),
-    horizon_cert  => $horizon_cert,
-    horizon_key   => $horizon_key,
-    horizon_ca    => $horizon_ca,
+    secret_key            => $horizon_secret_key,
+    keystone_default_role => '_member_',
+    keystone_host         => $controller_priv_host,
+    fqdn                  => ["$controller_pub_host", "$::fqdn", "$::hostname", 'localhost'],
+    listen_ssl            => str2bool_i("$ssl"),
+    horizon_cert          => $horizon_cert,
+    horizon_key           => $horizon_key,
+    horizon_ca            => $horizon_ca,
   }
   # patch our horizon/apache config to avoid duplicate port 80
   # directive.  TODO: remove this once puppet-horizon/apache can


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1085547

Keystone itself creates as the default '_member_', and horizon incorrectly
assumes a default of 'Member'.  However, the horizon config does take a param
called 'keystone_default_role', so we now set that to match the keystone default.
