### PR TITLE
BZ #1083781 - HA Glance small fix

### DIFF
--- a/puppet/modules/quickstack/manifests/glance.pp
+++ b/puppet/modules/quickstack/manifests/glance.pp
@@ -84,8 +84,8 @@ class quickstack::glance (
     # TODO qpid auth
     qpid_password => 'guest',
     qpid_username => 'guest',
-    qpid_hostname => map_params("qpid_vip"),
-    qpid_port     => map_params("qpid_port"),
+    qpid_hostname => $qpid_host,
+    qpid_port     => $qpid_port,
     qpid_protocol => 'tcp',
   }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1083781

Do not use map_params in quickstack::glance
