### PR TITLE
BZ #1084534 - full nova class paths, avoid HA naming conflict

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -45,7 +45,7 @@ class quickstack::compute_common (
       $nova_sql_connection = "mysql://nova:${nova_db_password}@${mysql_host}/nova"
     }
 
-  class { 'nova':
+  class { '::nova':
     sql_connection     => $nova_sql_connection,
     image_service      => 'nova.image.glance.GlanceImageService',
     glance_api_servers => "http://${controller_priv_host}:9292/v1",
@@ -69,12 +69,12 @@ class quickstack::compute_common (
   #  "libvirt_cpu_mode": value => "none";
   #}
 
-  class { 'nova::compute::libvirt':
+  class { '::nova::compute::libvirt':
     #libvirt_type    => "qemu",  # uncomment if on a vm
     vncserver_listen => $::ipaddress,
   }
 
-  class { 'nova::compute':
+  class { '::nova::compute':
     enabled => true,
     vncproxy_host => $controller_pub_host,
     vncserver_proxyclient_address => $::ipaddress,

--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -207,7 +207,7 @@ class quickstack::controller_common (
   }
 
   # Configure Nova
-  class { 'nova':
+  class { '::nova':
     sql_connection     => $nova_sql_connection,
     image_service      => 'nova.image.glance.GlanceImageService',
     glance_api_servers => "http://${controller_priv_host}:9292/v1",
@@ -226,25 +226,25 @@ class quickstack::controller_common (
   }
 
   if str2bool_i("$neutron") {
-    class { 'nova::api':
+    class { '::nova::api':
       enabled           => true,
       admin_password    => $nova_user_password,
       auth_host         => $controller_priv_host,
       neutron_metadata_proxy_shared_secret => $neutron_metadata_proxy_secret,
     }
   } else {
-    class { 'nova::api':
+    class { '::nova::api':
       enabled           => true,
       admin_password    => $nova_user_password,
       auth_host         => $controller_priv_host,
     }
   }
 
-  class { [ 'nova::scheduler', 'nova::cert', 'nova::consoleauth', 'nova::conductor' ]:
+  class { [ '::nova::scheduler', '::nova::cert', '::nova::consoleauth', '::nova::conductor' ]:
     enabled => true,
   }
 
-  class { 'nova::vncproxy':
+  class { '::nova::vncproxy':
     host    => '0.0.0.0',
     enabled => true,
   }

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -44,7 +44,7 @@ class quickstack::nova_network::compute (
     service_name   => 'openstack-nova-metadata-api',
   }
 
-  class { 'nova::network':
+  class { '::nova::network':
     private_interface => "$network_private_iface",
     public_interface  => "$network_public_iface",
     fixed_range       => "$network_fixed_range",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1084534

Standalone host groups need to use fully qualified nova paths in class
declarations or can end up using quickstack::nova.
