### PR TITLE
BZ #1062699 - Cinder + GlusterFS on HA Controller, incl. mount options

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder_volume.pp
+++ b/puppet/modules/quickstack/manifests/cinder_volume.pp
@@ -1,10 +1,33 @@
 class quickstack::cinder_volume(
-  $volume_backend    = 'iscsi',
-  $iscsi_bind_addr   = undef,
+  $volume_backend,
+  $iscsi_bind_addr  = '',
+  $glusterfs_shares = [],
 ) {
   class { '::cinder::volume': }
 
-  if $volume_backend == 'iscsi' {
+  if $volume_backend == 'glusterfs' {
+    if defined('gluster::client') {
+      class { 'gluster::client': }
+      ->
+      Class['::cinder::volume']
+    } else {
+      class { 'gluster::mount::base': repo => false }
+      ->
+      Class['::cinder::volume']
+    }
+
+    if ($::selinux != "false") {
+      selboolean {'virt_use_fusefs':
+          value => on,
+          persistent => true,
+      }
+    }
+
+    class { '::cinder::volume::glusterfs':
+      glusterfs_mount_point_base => '/var/lib/cinder/volumes',
+      glusterfs_shares => $glusterfs_shares,
+    }
+  } elsif $volume_backend == 'iscsi' {
     include ::quickstack::firewall::iscsi
 
     class { '::cinder::volume::iscsi':

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -5,6 +5,8 @@ class quickstack::pacemaker::cinder(
   $volume            = false,
   $volume_backend    = 'iscsi',
 
+  $glusterfs_shares  = [],
+
   $db_ssl            = false,
   $db_ssl_ca         = undef,
 
@@ -133,8 +135,9 @@ class quickstack::pacemaker::cinder(
       Class['::quickstack::cinder']
       ->
       class {'::quickstack::cinder_volume':
-        volume_backend  => $volume_backend,
-        iscsi_bind_addr => map_params('local_bind_addr'),
+        volume_backend   => $volume_backend,
+        iscsi_bind_addr  => map_params('local_bind_addr'),
+        glusterfs_shares => $glusterfs_shares,
       }
     }
   }


### PR DESCRIPTION
 BZ #1062699 - Cinder + GlusterFS mount options on HA controller

https://bugzilla.redhat.com/show_bug.cgi?id=1062699

Add GlusterFS support to Cinder on HA Controller and make it possible
to enter also mount options for it. The mount options can be entered
by setting glusterfs_shares parameter to e.g.:

```
["gluster1:/cinder -o backupvolfile-server=gluster2"]
```

Changed cinder-volume related parameters and default values on the HA
Controller - especially important is defaulting glusterfs_shares to []
so that Foreman registers the parameter type as array.
