### PR TITLE
Use libgfapi for compute access to cinder volumes

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -39,6 +39,10 @@ class quickstack::compute_common (
           persistent => true,
       }
     }
+
+    nova_config {
+      'DEFAULT/qemu_allowed_storage_drivers': value => 'gluster';
+    }
   }
   if str2bool_i("$cinder_backend_nfs") {
     if ($::selinux != "false") {


### PR DESCRIPTION
I've verified this works, in as far as everything gets passed correctly through to nova/libvirt/qemu in order to access a cinder volume via libgfapi when doing 'nova volume-attach'.  However there's a bug somewhere in qemu/libgfapi that causes qemu to hang the VM.  I'm still trying to run that down and file appropriate bugs.

For astapor purposes though, this does what we want.
