### PR TITLE
HA controller strict ordering

### DIFF
--- a/puppet/modules/quickstack/manifests/hamysql/mysql/setup.pp
+++ b/puppet/modules/quickstack/manifests/hamysql/mysql/setup.pp
@@ -128,5 +128,9 @@ class quickstack::hamysql::mysql::setup (
         require    => Database_user["$neutron_db_user@%"]
       }
     }
+    exec {"pcs-mysql-server-set-up":
+      command => "/usr/sbin/pcs property set mysql=running --force",
+    }
+    Database_grant <| |> -> Exec["pcs-mysql-server-set-up"]
   }
 }

--- a/puppet/modules/quickstack/manifests/hamysql/node.pp
+++ b/puppet/modules/quickstack/manifests/hamysql/node.pp
@@ -139,7 +139,6 @@ class quickstack::hamysql::node (
       neutron              => str2bool_i("$neutron"),
       require              => Class['quickstack::hamysql::mysql::rootpw'],
     }
-
     firewall { '002 mysql incoming':
       proto => 'tcp',
       dport => ['3306'],

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -22,6 +22,31 @@ class quickstack::pacemaker::horizon (
         ','
     )
 
+    Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip'] -> Service['httpd']
+    if (map_params('include_mysql') == 'true') {
+       if str2bool_i("$hamysql_is_running") {
+         Exec['mysql-has-users'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+       }
+    }
+    if (map_params('include_keystone') == 'true') {
+      Exec['all-keystone-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+    }
+    if (map_params('include_swift') == 'true') {
+      Exec['all-swift-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+    }
+    if (map_params('include_glance') == 'true') {
+      Exec['all-glance-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+    }
+    if (map_params('include_cinder') == 'true') {
+      Exec['all-cinder-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+    }
+    if (map_params('include_nova') == 'true') {
+      Exec['all-nova-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+    }
+    if (map_params('include_neutron') == 'true') {
+      Exec['all-neutron-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+    }
+
     Class['::quickstack::pacemaker::common']
     ->
     quickstack::pacemaker::vips { "$pcmk_horizon_group":

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -38,6 +38,11 @@ class quickstack::pacemaker::keystone (
     Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip'] -> Service['keystone']
     Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip'] -> Exec['keystone-manage db_sync']
     Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip'] -> Exec['keystone-manage pki_setup']
+    if (map_params('include_mysql') == 'true') {
+       if str2bool_i("$hamysql_is_running") {
+         Exec['mysql-has-users'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
+       }
+    }
 
     Class['::quickstack::pacemaker::common'] ->
 

--- a/puppet/modules/quickstack/manifests/pacemaker/mysql.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/mysql.pp
@@ -28,5 +28,17 @@ class quickstack::pacemaker::mysql (
       mysql_virt_ip_nic            => '',
       mysql_virt_ip_cidr_mask      => '32',
     }
+    if str2bool_i("$hamysql_is_running") {
+      Class ['quickstack::hamysql::node'] ->
+      exec {"mysql-has-users":
+        timeout   => 3600,
+        tries     => 360,
+        try_sleep => 10,
+        command   => "/tmp/ha-all-in-one-util.bash property_exists mysql",
+      }
+      if str2bool_i("$hamysql_active_node") {
+        Exec["pcs-mysql-server-set-up"] -> Exec["mysql-has-users"]
+      }
+    }
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -17,6 +17,27 @@ class quickstack::pacemaker::neutron (
     $neutron_group = map_params("neutron_group")
     $neutron_public_vip = map_params("neutron_public_vip")
 
+    if (map_params('include_mysql') == 'true') {
+       if str2bool_i("$hamysql_is_running") {
+         Exec['mysql-has-users'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+       }
+    }
+    if (map_params('include_keystone') == 'true') {
+      Exec['all-keystone-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (map_params('include_swift') == 'true') {
+      Exec['all-swift-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (map_params('include_cinder') == 'true') {
+      Exec['all-cinder-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (map_params('include_glance') == 'true') {
+      Exec['all-glance-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (map_params('include_nova') == 'true') {
+      Exec['all-nova-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+
     Class['::quickstack::pacemaker::common']
     ->
     quickstack::pacemaker::vips { "$neutron_group":

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -37,7 +37,7 @@ class quickstack::pacemaker::params (
   $include_glance            = 'true',
   $include_horizon           = 'true',
   $include_keystone          = 'true',
-  $include_mysql             = 'false',
+  $include_mysql             = 'true',
   $include_neutron           = 'true',
   $include_nova              = 'true',
   $include_qpid              = 'true',


### PR DESCRIPTION
Add puppet dependencies so that services are added/executed in a sane order.
E.g., never allow a service to run db_sync if the database isn't
ready.

I tested this with all of the include_ flags set to true except for include_neutron.  Everything came up clean after two puppet runs (the first run initialized the mysql db, the second populated the db with users and configured/started all openstack services (except for neutron)).
