### PR TITLE
Swift only has public VIP, make Keystone reflect that

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -114,8 +114,8 @@ class quickstack::pacemaker::keystone (
       swift                       => str2bool_i("$swift"),
       swift_user_password         => map_params("swift_user_password"),
       swift_public_address        => map_params("swift_public_vip"),
-      swift_internal_address      => map_params("swift_private_vip"),
-      swift_admin_address         => map_params("swift_admin_vip"),
+      swift_internal_address      => map_params("swift_public_vip"),
+      swift_admin_address         => map_params("swift_public_vip"),
       use_syslog                  => str2bool_i("$use_syslog"),
       log_facility                => "$log_facility",
       # This will be correct once o-p-m gets a modern heat module


### PR DESCRIPTION
This was the cause of the almost impossible to track "value is a
required option for Puppet::Parser::Resource::Param" error. We're
trying to use map_params on params that don't exist. From reading
previous code it seems that private/admin VIPs for Swift are not
present on purpose (e.g. Swift load balancer also expects only public
VIP), so i'm fixing it by using public VIP for all endpoints instead
of introducing new VIPs.
