### PR TITLE
Add *_network params and logic.

### DIFF
--- a/puppet/modules/quickstack/lib/puppet/parser/functions/find_ip.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/find_ip.rb
@@ -1,0 +1,23 @@
+require 'facter/util/ip' 
+module Puppet::Parser::Functions
+    newfunction(:find_ip, :type => :rvalue, :doc => <<-EOS
+This returns the ip associated with the given network or nic. 
+                EOS
+) do |arguments|
+    Puppet::Parser::Functions.autoloader.loadall
+    raise(Puppet::ParseError, "find_ip(): Wrong number of arguments " +
+      "given (#{arguments.size} for 3)") if arguments.size < 3
+
+    the_network= arguments[0] ||= ''
+    the_nic = arguments[1] ||= ''
+    the_ip = arguments[2] ||= ''
+
+    if (the_network != '')
+      function_get_ip_from_network([the_network])
+    elsif (the_nic != '')
+      function_get_ip_from_nic([the_nic])
+    else
+      the_ip
+    end
+  end
+end

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/find_nic.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/find_nic.rb
@@ -1,0 +1,23 @@
+require 'facter/util/ip' 
+module Puppet::Parser::Functions
+    newfunction(:find_nic, :type => :rvalue, :doc => <<-EOS
+This returns the nic associated with the given network or ip. 
+                EOS
+) do |arguments|
+    Puppet::Parser::Functions.autoloader.loadall
+    raise(Puppet::ParseError, "find_nic(): Wrong number of arguments " +
+      "given (#{arguments.size} for 3)") if arguments.size < 3
+
+    the_network= arguments[0] ||= ''
+    the_nic = arguments[1] ||= ''
+    the_ip = arguments[2] ||= ''
+
+    if (the_network != '')
+      function_get_nic_from_network([the_network])
+    elsif (the_ip != '')
+      function_get_nic_from_ip([the_ip])
+    else
+      the_nic
+    end
+  end
+end

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/get_ip_from_network.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/get_ip_from_network.rb
@@ -1,0 +1,16 @@
+require 'facter/util/ip' 
+module Puppet::Parser::Functions
+    newfunction(:get_ip_from_network, :type => :rvalue, :doc => <<-EOS
+This returns the ip associatd with the given network. 
+                EOS
+) do |arguments|
+    Puppet::Parser::Functions.autoloader.loadall
+    raise(Puppet::ParseError, "get_ip_from_network(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    the_network= arguments[0]
+    ip = function_get_ip_from_nic([function_get_nic_from_network([the_network])])
+
+    return ip
+  end
+end

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/get_ip_from_nic.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/get_ip_from_nic.rb
@@ -1,0 +1,16 @@
+require 'facter/util/ip' 
+module Puppet::Parser::Functions
+  newfunction(:get_ip_from_nic, :type => :rvalue, :doc => <<-EOS
+This returns the ip associatd with the given interface name.
+EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "get_ip_from_nic(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    the_nic = arguments[0].gsub(/[.:-]+/,'_')
+    ip = lookupvar("ipaddress_#{the_nic}")
+
+    return ip
+  end 
+end

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/get_nic_from_ip.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/get_nic_from_ip.rb
@@ -1,0 +1,25 @@
+require 'facter/util/ip' 
+module Puppet::Parser::Functions
+  newfunction(:get_nic_from_ip, :type => :rvalue, :doc => <<-EOS
+This returns the nic associatd with the given ip.
+EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "get_nic_from_ip(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    the_ip= arguments[0]
+    ifaces = lookupvar("interfaces").split(",")
+
+    our_nic = nil 
+
+    ifaces.each do |interface|
+        cur_ip = lookupvar("ipaddress_#{interface}")
+        if (cur_ip == the_ip)
+            our_nic = interface 
+            break
+        end 
+    end 
+    return our_nic 
+  end 
+end

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/get_nic_from_network.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/get_nic_from_network.rb
@@ -1,0 +1,25 @@
+require 'facter/util/ip' 
+module Puppet::Parser::Functions
+  newfunction(:get_nic_from_network, :type => :rvalue, :doc => <<-EOS
+This returns the nic associatd with the given network.
+EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "get_nic_from_network(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    the_network= arguments[0]
+    ifaces = lookupvar("interfaces").split(",")
+
+    our_nic = nil 
+
+    ifaces.each do |interface|
+        cur_network = Facter::Util::IP.get_network_value(interface)
+        if (cur_network == the_network)
+            our_nic = interface 
+            break
+        end 
+    end 
+    return our_nic 
+  end 
+end

--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -29,6 +29,7 @@ class quickstack::neutron::all (
   $ovs_bridge_mappings           = [],
   $ovs_bridge_uplinks            = [],
   $ovs_tunnel_iface              = '',
+  $ovs_tunnel_network            = '',
   $ovs_vlan_ranges               = '',
   $ovs_vxlan_udp_port            = '4789',
   $ovs_tunnel_types              = [],
@@ -172,9 +173,11 @@ class quickstack::neutron::all (
     neutron_admin_password    => $neutron_user_password,
   }
 
+  $local_ip = find_ip("$ovs_tunnel_network","$ovs_tunnel_iface","")
+
   class { '::neutron::agents::ovs':
     bridge_uplinks   => $ovs_bridge_uplinks,
-    local_ip         => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '[.-]', '_', 'G')),
+    local_ip         => $local_ip,
     bridge_mappings  => $ovs_bridge_mappings,
     enable_tunneling => str2bool_i("$enable_tunneling"),
     tunnel_types     => $ovs_tunnel_types,

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -16,7 +16,8 @@ class quickstack::neutron::compute (
   $nova_user_password          = $quickstack::params::nova_user_password,
   $ovs_bridge_mappings         = $quickstack::params::ovs_bridge_mappings,
   $ovs_vlan_ranges             = $quickstack::params::ovs_vlan_ranges,
-  $ovs_tunnel_iface            = 'em1',
+  $ovs_tunnel_iface            = 'eth1',
+  $ovs_tunnel_network          = '',
   $qpid_host                   = $quickstack::params::qpid_host,
   $qpid_username               = $quickstack::params::qpid_username,
   $qpid_password               = $quickstack::params::qpid_password,
@@ -66,10 +67,10 @@ class quickstack::neutron::compute (
     tunnel_id_ranges    => $tunnel_id_ranges,
     vxlan_udp_port      => $ovs_vxlan_udp_port,
   }
-
+  $local_ip = find_ip("$ovs_tunnel_network","$ovs_tunnel_iface","")
   class { '::neutron::agents::ovs':
     bridge_mappings     => $ovs_bridge_mappings,
-    local_ip            => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '[.-]', '_', 'G')),
+    local_ip            => $local_ip,
     enable_tunneling    => str2bool_i("$enable_tunneling"),
     tunnel_types     => $ovs_tunnel_types,
     vxlan_udp_port   => $ovs_vxlan_udp_port,

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -7,7 +7,8 @@ class quickstack::neutron::networker (
   $nova_db_password              = $quickstack::params::nova_db_password,
   $nova_user_password            = $quickstack::params::nova_user_password,
   $controller_priv_host          = $quickstack::params::controller_priv_host,
-  $ovs_tunnel_iface              = 'em1',
+  $ovs_tunnel_iface              = 'eth1',
+  $ovs_tunnel_network            = '',
   $mysql_host                    = $quickstack::params::mysql_host,
   $qpid_host                     = $quickstack::params::qpid_host,
   $external_network_bridge       = 'br-ex',
@@ -65,9 +66,11 @@ class quickstack::neutron::networker (
     vxlan_udp_port      => $ovs_vxlan_udp_port,
   }
 
+  $local_ip = find_ip("$ovs_tunnel_network","$ovs_tunnel_iface","")
+
   class { '::neutron::agents::ovs':
     bridge_uplinks   => $ovs_bridge_uplinks,
-    local_ip         => getvar(regsubst("ipaddress_${ovs_tunnel_iface}", '[.-]', '_', 'G')),
+    local_ip         => $local_ip,
     bridge_mappings  => $ovs_bridge_mappings,
     enable_tunneling => str2bool_i("$enable_tunneling"),
     tunnel_types     => $ovs_tunnel_types,

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -11,8 +11,10 @@ class quickstack::nova_network::compute (
   $nova_multi_host              = 'True',
   $nova_db_password             = $quickstack::params::nova_db_password,
   $nova_user_password           = $quickstack::params::nova_user_password,
-  $network_private_iface        = 'em1',
-  $network_public_iface         = 'em2',
+  $network_private_iface        = 'eth1',
+  $network_private_network      = '192.168.200.0',
+  $network_public_iface         = 'eth2',
+  $network_public_network       = '192.168.201.0',
   $network_manager              = 'FlatDHCPManager',
   $network_create_networks      = true,
   $network_num_networks         = 1,
@@ -44,9 +46,12 @@ class quickstack::nova_network::compute (
     service_name   => 'openstack-nova-metadata-api',
   }
 
+  $priv_nic = find_nic("$network_private_network","$network_private_iface","")
+  $pub_nic = find_nic("$network_public_network","$network_public_iface","")
+
   class { '::nova::network':
-    private_interface => "$network_private_iface",
-    public_interface  => "$network_public_iface",
+    private_interface => "$priv_nic",
+    public_interface  => "$pub_nic",
     fixed_range       => "$network_fixed_range",
     num_networks      => $network_num_networks,
     network_size      => $network_network_size,

--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -21,6 +21,8 @@
 #
 # [*fence_xvm_clu_iface*]
 #
+# [*fence_xvm_clu_network*]
+#
 # [*fence_xvm_manage_key_file*]
 #
 # [*fence_xvm_key_file_password*]
@@ -35,6 +37,7 @@ class quickstack::pacemaker::common (
   $fence_ipmilan_password         = "",
   $fence_ipmilan_interval         = "60s",
   $fence_xvm_clu_iface            = "eth2",
+  $fence_xvm_clu_network          = "",
   $fence_xvm_manage_key_file      = "false",
   $fence_xvm_key_file_password    = "",
 
@@ -68,7 +71,9 @@ class quickstack::pacemaker::common (
     Class['pacemaker::stonith::ipmilan']
   }
   elsif $fencing_type =~ /(?i-mx:^fence_xvm$)/ {
-    $clu_ip_address = getvar(regsubst("ipaddress_$fence_xvm_clu_iface", '[.-]', '_', 'G'))
+    $clu_ip_address = find_ip("$fence_xvm_clu_network",
+                              "$fence_xvm_clu_iface",
+                              "")
     class {'pacemaker::stonith':
       disable => false,
     }

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -5,6 +5,7 @@ class quickstack::pacemaker::neutron (
   $ovs_bridge_mappings           = [],
   $ovs_bridge_uplinks            = [],
   $ovs_tunnel_iface              = '',
+  $ovs_tunnel_network            = '',
   $ovs_vlan_ranges               = '',
   $ovs_tunnel_types              = [],
   $tenant_network_type           = 'vlan',
@@ -16,11 +17,12 @@ class quickstack::pacemaker::neutron (
   if (map_params('include_neutron') == 'true') {
     $neutron_group = map_params("neutron_group")
     $neutron_public_vip = map_params("neutron_public_vip")
+    $ovs_nic = find_nic("$ovs_tunnel_network","$ovs_tunnel_iface","")
 
     if (map_params('include_mysql') == 'true') {
-       if str2bool_i("$hamysql_is_running") {
-         Exec['mysql-has-users'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
-       }
+      if str2bool_i("$hamysql_is_running") {
+        Exec['mysql-has-users'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+      }
     }
     if (map_params('include_keystone') == 'true') {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
@@ -66,7 +68,7 @@ class quickstack::pacemaker::neutron (
       neutron_metadata_proxy_secret => map_params("neutron_metadata_proxy_secret"),
       ovs_bridge_mappings           => $ovs_bridge_mappings,
       ovs_bridge_uplinks            => $ovs_bridge_uplinks,
-      ovs_tunnel_iface              => $ovs_tunnel_iface,
+      ovs_tunnel_iface              => $ovs_nic,
       ovs_vlan_ranges               => $ovs_vlan_ranges,
       ovs_tunnel_types              => $ovs_tunnel_types,
       qpid_host                     => map_params("qpid_vip"),

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -70,6 +70,7 @@ class quickstack::pacemaker::params (
   $nova_user_password        = '',
   $private_ip                = '',
   $private_iface             = '',
+  $private_network           = '',
   $qpid_port                 = '5672',
   $qpid_vip                  = '',
   $qpid_group                = 'qpid',
@@ -77,17 +78,9 @@ class quickstack::pacemaker::params (
   $swift_user_password       = '',
   $swift_group               = 'swift',
 ) {
-  # If IP is specified per host, prefer that.
-  # If interface is specified, this should get pulled per host,
-  # or default to hostgroup level interface.
-  if ($private_ip != '') {
-    $local_bind_addr = "$private_ip"
-    notify {"++++++ Looks like we were given an IP: $local_bind_addr ++++++":}
-  } else {
-    #TODO: extract this out into a function, we use it all over:
-    $local_bind_addr = getvar(regsubst("ipaddress_$private_iface", '[.-]', '_', 'G'))
-    notify {"------ OK, thanks for the nic, our IP is: $local_bind_addr ----":}
-  }
+  $local_bind_addr = find_ip("$private_network",
+                            "$private_iface",
+                            "$private_ip")
 
   # Hackery explained: an external db is always ready.  Or, if hamysql
   # was running in the cluster at the start of the puppet run, we can

--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -1,11 +1,12 @@
 class quickstack::pacemaker::swift (
-  $swift_shared_secret  = '',
-  $swift_storage_ips    = [],
-  $swift_storage_device = '',
-  $swift_internal_ip    = '',
-  $swift_internal_iface = '',
-  $swift_internal_vip   = '',
-  $memcached_port       = '11211',  # maybe move to params.pp since also in nova.pp
+  $swift_shared_secret    = '',
+  $swift_storage_ips      = [],
+  $swift_storage_device   = '',
+  $swift_internal_ip      = '',
+  $swift_internal_iface   = '',
+  $swift_internal_network = '',
+  $swift_internal_vip     = '',
+  $memcached_port         = '11211',  # maybe move to params.pp since also in nova.pp
 ) {
   include quickstack::pacemaker::common
 
@@ -18,13 +19,9 @@ class quickstack::pacemaker::swift (
 
     # swift_bind_addr is for internal swift-proxy/swift-storage traffic only
     # must be same subnet as swift_internal_vip
-    if ($swift_internal_ip != '') {
-      $swift_bind_addr = "$swift_internal_ip"
-    } else {
-      #TODO: extract this out into a function, we use it all over:
-      $swift_bind_addr = getvar(regsubst("ipaddress_$swift_internal_iface", '[.-]', '_', 'G'))
-      notify {"------ OK, thanks for the nic, our IP is: $swift_internal_iface ----":}
-    }
+    $swift_bind_addr = find_ip("$swift_internal_network",
+                              "$swift_internal_iface",
+                              "$swift_internal_ip")
 
     Exec['i-am-swift-vip-OR-swift-is-up-on-vip'] -> Service['swift-proxy']
     if (map_params('include_keystone') == 'true') {

--- a/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
+++ b/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
@@ -5,7 +5,8 @@ class quickstack::storage_backend::lvm_cinder(
   $cinder_gluster_volume       = $quickstack::params::cinder_gluster_volume,
   $cinder_gluster_peers        = $quickstack::params::cinder_gluster_peers,
   $controller_priv_host        = $quickstack::params::controller_priv_host,
-  $cinder_iscsi_iface          = 'em1',
+  $cinder_iscsi_iface          = 'eth1',
+  $cinder_iscsi_network        = '',
   $mysql_host                  = $quickstack::params::mysql_host,
   $qpid_host                   = $quickstack::params::qpid_host,
   $qpid_username               = $quickstack::params::qpid_username,
@@ -56,8 +57,11 @@ class quickstack::storage_backend::lvm_cinder(
   }
 
   if str2bool_i("$cinder_backend_iscsi") {
+    $iscsi_ip_address = find_ip("$cinder_iscsi_network",
+                                "$cinder_iscsi_iface",
+                                "")
     class { '::cinder::volume::iscsi':
-      iscsi_ip_address => getvar(regsubst("ipaddress_${cinder_iscsi_iface}", '[.-]', '_', 'G')),
+      iscsi_ip_address => $iscsi_ip_address,
     }
 
     firewall { '010 cinder iscsi':


### PR DESCRIPTION
The purpose of this is to allow a user to specify what they know, which
sometimes is not the nic (which may not be known to them at setup time until
after the machine is provisioned).  They should be able to provide the network
they know a nic should be in though, and we can use this to figure out which nic
got attached to that network.
