### PR TITLE
BZ #1075818 - HA controller tiny bug fix

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -23,9 +23,10 @@ class quickstack::pacemaker::cinder(
   $verbose           = false,
 ) {
 
+  include ::quickstack::pacemaker::common
+
   if (map_params('include_cinder') == 'true' and map_params("db_is_ready")) {
 
-    include ::quickstack::pacemaker::common
     include ::quickstack::pacemaker::qpid
 
     $cinder_user_password = map_params("cinder_user_password")

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -15,9 +15,10 @@ class quickstack::pacemaker::heat(
   $verbose             = false,
 ) {
 
+  include ::quickstack::pacemaker::common
+
   if (map_params('include_heat') == 'true' and map_params("db_is_ready")) {
 
-    include ::quickstack::pacemaker::common
     include ::quickstack::pacemaker::qpid
 
     $heat_db_password        = map_params("heat_db_password")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1075818

Bump up include to ensure all potential resources have been included
to avoid errors like Error 400 on SERVER: Could not find resource
'Exec[all-cinder-nodes-are-up]' for relationship on
'Exec[i-am-heat-vip-OR-heat-is-up-on-vip']
