### PR TITLE
get_nic_from_network function fixes

### DIFF
--- a/puppet/modules/quickstack/lib/puppet/parser/functions/get_ip_from_nic.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/get_ip_from_nic.rb
@@ -8,6 +8,9 @@ EOS
     raise(Puppet::ParseError, "get_ip_from_nic(): Wrong number of arguments " +
       "given (#{arguments.size} for 1)") if arguments.size < 1
 
+    if (arguments[0] == nil)
+      return nil
+    end
     the_nic = arguments[0].gsub(/[.:-]+/,'_')
     ip = lookupvar("ipaddress_#{the_nic}")
 

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/get_nic_from_network.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/get_nic_from_network.rb
@@ -14,7 +14,7 @@ EOS
     our_nic = nil 
 
     ifaces.each do |interface|
-        cur_network = Facter::Util::IP.get_network_value(interface)
+        cur_network = lookupvar("network_#{interface}")
         if (cur_network == the_network)
             our_nic = interface 
             break


### PR DESCRIPTION
Do not use a Facter:: call within a function since it seems
Foreman-host specific rather than client-node specific (and we just
care about client facts/variables).

Also, make sure not to call gsub on a nil object to avoid mysterious
stack traces.
