### PR TITLE
HA swift proxy and storage node tweaks

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -17,12 +17,6 @@ class quickstack::pacemaker::swift (
     $memcached_servers_str = inline_template('<%= @memcached_ips.map {
         |x| x+":"+@memcached_port }.join(",") %>')
 
-    # swift_bind_addr is for internal swift-proxy/swift-storage traffic only
-    # must be same subnet as swift_internal_vip
-    $swift_bind_addr = find_ip("$swift_internal_network",
-                              "$swift_internal_iface",
-                              "$swift_internal_ip")
-
     Exec['i-am-swift-vip-OR-swift-is-up-on-vip'] -> Service['swift-proxy']
     if (map_params('include_keystone') == 'true') {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-swift-vip-OR-swift-is-up-on-vip']
@@ -48,6 +42,7 @@ class quickstack::pacemaker::swift (
       source           => "rsync://$swift_internal_vip/swift_server/",
       override_options => "aI",
       purge            => true,
+      exclude          => '*.conf',
       unless           => "/tmp/ha-all-in-one-util.bash i_am_vip $swift_internal_vip",
     }
     ->

--- a/puppet/modules/quickstack/manifests/swift/storage.pp
+++ b/puppet/modules/quickstack/manifests/swift/storage.pp
@@ -12,7 +12,7 @@ class quickstack::swift::storage (
   class {'quickstack::openstack_common': }
 
   $storage_local_net_ip = find_ip("$swift_local_network",
-                                  "$swift_local_interface ",
+                                  "$swift_local_interface",
                                   "")
 
   class { '::swift::storage::all':


### PR DESCRIPTION
Two fixes here.  1. is to not blow away .conf files as part of an rsync.  2. is a typo fix needed for the swift storage node to work off of its swift_local_interface.

I did an end-to-end test using the ha-all-in-one-controller host group (with include_heat set to false but that shouldn't matter) and the swift storage host group.
Verified that bind_ip was correct (based off of private_iface) and different in each /etc/swift/proxy-server.conf, e.g. "bind_ip = 192.168.200.10" on one node, "bind_ip = 192.168.200.20" on the 2nd, etc.
Verified bound to correct frontend and backend ip's, e.g.

```
# netstat -tulpn | grep 8080
tcp        0      0 192.168.201.73:8080         0.0.0.0:*                   LISTEN      11579/haproxy
tcp        0      0 192.168.200.10:8080         0.0.0.0:*                   LISTEN      10328/python
```

Note that currently there are three unused parameters in quickstack::pacemaker::swift: swift_internal_ip, swift_internal_iface, swift_internal_network.  This should get cleaned up soon.

Yaml for the HA-all-in-one-controller: http://fpaste.org/96492/39832726/
Yaml for the Swift Storage host: http://fpaste.org/96493/83273311/
