### PR TITLE
Make sure rpcbind is installed and running

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -45,6 +45,11 @@ class quickstack::pacemaker::common (
 
   include quickstack::pacemaker::params
 
+  package {'rpcbind': } ->
+  service {'rpcbind':
+    enable => true,
+    ensure => 'running',
+  } ->
   class {'pacemaker::corosync':
     cluster_name    => $pacemaker_cluster_name,
     cluster_members => $pacemaker_cluster_members,


### PR DESCRIPTION
Rpcbind is a dependency of pacemaker, so the package should be
installed anyway. But i discovered that if the sevice gets stopped
(manually or otherwise), re-running Puppet won't start it up again. So
we should explicitly make sure that we install/enable/run rpcbind.
