### PR TITLE
Update foreman_server.sh to support Foreman 1.5 release

### DIFF
--- a/bin/foreman_server.sh
+++ b/bin/foreman_server.sh
@@ -125,7 +125,7 @@ class { 'puppet':
     '$OPENSTACK_PUPPET_HOME/modules',
   ],
 }
-include passenger
+
 class { 'foreman':
   db_type => 'mysql',
   custom_repo => true
@@ -186,8 +186,8 @@ echo '*' >> /etc/puppet/autosign.conf
 sudo -u foreman scl enable ruby193 "cd $FOREMAN_DIR; RAILS_ENV=production rake puppet:import:puppet_classes[batch]"
 
 # Set params, and run the db:seed file to set class parameter defaults
-cp ./seeds.rb $FOREMAN_DIR/db/.
-sed -i "s#PROVISIONING_INTERFACE#$PROVISIONING_INTERFACE#" $FOREMAN_DIR/db/seeds.rb
+cp ./seeds.rb $FOREMAN_DIR/db/seeds.d/99-ofi.rb
+sed -i "s#PROVISIONING_INTERFACE#$PROVISIONING_INTERFACE#" $FOREMAN_DIR/db/seeds.d/99-ofi.rb
 sudo -u foreman scl enable ruby193 "cd $FOREMAN_DIR; rake db:seed RAILS_ENV=production FOREMAN_PROVISIONING=$FOREMAN_PROVISIONING"
 
 if [ "$FOREMAN_PROVISIONING" = "true" ]; then


### PR DESCRIPTION
- Remove 'include passenger' from the install manifest, as it appears
  this was never needed, and actually causes a problem with 1.5
- Change the location of seeds.rb, since Foreman is now using the "real"
  seeds.rb, and makes use of a seeds.d drop dir.
