### PR TITLE
Wrapper for 'old gluster' client to allow compatibility with new 'gluster

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder_controller.pp
+++ b/puppet/modules/quickstack/manifests/cinder_controller.pp
@@ -58,7 +58,7 @@ class quickstack::cinder_controller(
   if str2bool_i("$cinder_backend_gluster") {
     class { '::cinder::volume': }
 
-    class { 'gluster::client': }
+    class { 'quickstack::gluster::client': }
 
     if ($::selinux != "false") {
       selboolean{'virt_use_fusefs':

--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -23,7 +23,7 @@ class quickstack::compute_common (
   class {'quickstack::openstack_common': }
 
   if str2bool_i("$cinder_backend_gluster") {
-    class { 'gluster::client': }
+    class { 'quickstack::gluster::client': }
 
     if ($::selinux != "false") {
       selboolean{'virt_use_fusefs':

--- a/puppet/modules/quickstack/manifests/glance_storage.pp
+++ b/puppet/modules/quickstack/manifests/glance_storage.pp
@@ -7,7 +7,7 @@ class quickstack::glance_storage (
 ) inherits quickstack::params {
 
   if $glance_backend_gluster == true {
-    class { 'gluster::client': }
+    class { 'quickstack::gluster::client': }
 
     if ($::selinux != "false") {
       selboolean{'virt_use_fusefs':

--- a/puppet/modules/quickstack/manifests/gluster/client.pp
+++ b/puppet/modules/quickstack/manifests/gluster/client.pp
@@ -1,0 +1,7 @@
+# Quickstack gluster client
+# This is a wrapper mostly for offering compatibility between soon to be
+# deprecated puppet-openstack-storage version of gluster
+# replaced with purpleidea/puppet-gluster module
+class quickstack::gluster::client {
+  class { 'gluster::mount::base': }
+}

--- a/puppet/modules/quickstack/manifests/gluster/mount.pp
+++ b/puppet/modules/quickstack/manifests/gluster/mount.pp
@@ -1,0 +1,16 @@
+# Quickstack Service for gluster server
+# This could be used when external resources aren't available
+# It must be executed on each gluster server in a round robbin mode
+class quickstack::gluster::mount (
+  $volume_name,
+  $volume_path,
+  $vip          = $quickstack::params::gluster_vip,
+) {
+
+  # mount a share on a client somewhere
+  gluster::mount { "${volume_name}":
+    server => "${vip}:${volume_path}",
+    rw => true,
+    mounted => true,
+  }
+}

--- a/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
+++ b/puppet/modules/quickstack/manifests/storage_backend/lvm_cinder.pp
@@ -41,7 +41,7 @@ class quickstack::storage_backend::lvm_cinder(
   class { '::cinder::volume': }
 
   if str2bool_i("$cinder_backend_gluster") {
-    class { 'gluster::client': }
+    class { 'quickstack::gluster::client': }
 
     if ($::selinux != "false") {
       selboolean{'virt_use_fusefs':


### PR DESCRIPTION
This would provide transparent compatibility to use either version of 'gluster client'
