### PR TITLE
Fix ceilometer circular dependency

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer_controller.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer_controller.pp
@@ -56,6 +56,5 @@ class quickstack::ceilometer_controller(
     class { 'ceilometer::api':
         keystone_host     => $controller_priv_host,
         keystone_password => $ceilometer_user_password,
-        require           => Class['ceilometer::db'],
     }
 }


### PR DESCRIPTION
We have a circular dependency error in the manifests:

```
Error: Could not apply complete catalog: Found 1 dependency cycle:
(Ceilometer_config[database/connection] => Class[Ceilometer::Db] => Class[Ceilometer::Api] => Package[ceilometer-api] => Ceilometer_config[database/connection])
Try the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz
```

It seems the only way we can fix this from our code is to remove
relationship
Class[Ceilometer::Db] => Class[Ceilometer::Api].  Packstack doesn't
include the relationship either [1].

I'm still getting this on the first run:

Notice: /Stage[main]/Ceilometer::Db/Exec[ceilometer-dbsync]/returns: 2014-04-30 11:28:50.688 3850 TRACE ceilometer ConnectionFailure: could not connect to localhost:27017: [Errno 111] ECONNREFUSED
Notice: /Stage[main]/Ceilometer::Db/Exec[ceilometer-dbsync]/returns: 2014-04-30 11:28:50.688 3850 TRACE ceilometer
Error: /Stage[main]/Ceilometer::Db/Exec[ceilometer-dbsync]: Failed to call refresh: ceilometer-dbsync --config-file=/etc/ceilometer/ceilometer.conf returned 1 instead of one of [0]
Error: /Stage[main]/Ceilometer::Db/Exec[ceilometer-dbsync]: ceilometer-dbsync --config-file=/etc/ceilometer/ceilometer.conf returned 1 instead of one of [0]

I think this can't be caused by removal of the dependency in
question. This is a MongoDB startup problem already reported [2].

[1] https://github.com/stackforge/packstack/blob/597459d68d8d0fd5b70c7d5224653fd8341c4bef/packstack/puppet/templates/ceilometer.pp
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1066408
