### PR TITLE
BZ #1068885 - Fix url in keystonerc.

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -389,10 +389,18 @@ class quickstack::controller_common (
     }
   }
 
+  # This exists to cover havana release, where we only exposed the pub and priv
+  # hosts, admin was not a param there.
+  if $controller_admin_host == undef or $controller_admin_host == '' {
+    $real_admin_host = $controller_priv_host
+  } else {
+    $real_admin_host = $controller_admin_host
+  }
+
   if str2bool_i("$keystonerc") {
     class { 'quickstack::admin_client':
       admin_password        => $admin_password,
-      controller_admin_host => $controller_admin_host,
+      controller_admin_host => $real_admin_host,
     }
   }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1068885

The original version of this fie depended on the admin network host ip being
set, but this does not exist in the Havana release, so check for existence of
that ip, default to priv_host when admin is not set or does not exist.
