### PR TITLE
HA Controller - NFS backend for Cinder

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -7,6 +7,9 @@ class quickstack::pacemaker::cinder(
 
   $glusterfs_shares  = [],
 
+  $nfs_shares        = [],
+  $nfs_mount_options = undef,
+
   $db_ssl            = false,
   $db_ssl_ca         = undef,
 
@@ -135,9 +138,11 @@ class quickstack::pacemaker::cinder(
       Class['::quickstack::cinder']
       ->
       class {'::quickstack::cinder_volume':
-        volume_backend   => $volume_backend,
-        iscsi_bind_addr  => map_params('local_bind_addr'),
-        glusterfs_shares => $glusterfs_shares,
+        volume_backend    => $volume_backend,
+        iscsi_bind_addr   => map_params('local_bind_addr'),
+        glusterfs_shares  => $glusterfs_shares,
+        nfs_shares        => $nfs_shares,
+        nfs_mount_options => $nfs_mount_options,
       }
     }
   }


### PR DESCRIPTION
On exporting node:

```
yum -y install nfs-utils
service rpcbind start
service nfs start
service nfslock start
mkdir -p /export/cinder
cp /etc/exports /etc/exports.orig
echo "/export/cinder *(rw,sync,no_root_squash)" > /etc/exports
exportfs -rav

# verify the export
showmount -e localhost
```

Controller params on the pacemaker::cinder class (note volume,
volume_backend, nfs_shares, nfs_mount_options):

```
quickstack::pacemaker::cinder:
  db_name: cinder
  db_ssl: false
  db_ssl_ca: ''
  db_user: cinder
  debug: false
  enabled: true
  glusterfs_shares: []
  log_facility: LOG_USER
  nfs_mount_options: retry=1
  nfs_shares:
  - r64-acompute:/export/cinder
  qpid_heartbeat: '60'
  use_syslog: false
  verbose: 'true'
  volume: true
  volume_backend: nfs
```

On controller:

```
[root@r64-acontrol ~(openstack_admin)]# cat /etc/cinder/cinder.conf | grep volume_driver
#volume_driver=cinder.volume.drivers.lvm.LVMISCSIDriver
volume_driver=cinder.volume.drivers.nfs.NfsDriver
[root@r64-acontrol ~(openstack_admin)]# cat /etc/cinder/cinder.conf | grep nfs_mount_options
#nfs_mount_options=<None>
nfs_mount_options=retry=1
[root@r64-acontrol ~(openstack_admin)]# cat /etc/
Display all 184 possibilities? (y or n)^C
[root@r64-acontrol ~(openstack_admin)]# cat /etc/cinder/shares.conf 
r64-acompute:/export/cinder[root@r64-acontrol ~(openstack_admin)]#

^ the file doesn't contain newline at the end so it printed with a
command prompt right after it, but that's ok

[root@r64-acontrol ~(openstack_admin)]# cinder create --display-name=testvol 1
+---------------------+--------------------------------------+
|       Property      |                Value                 |
+---------------------+--------------------------------------+
|     attachments     |                  []                  |
|  availability_zone  |                 nova                 |
|       bootable      |                false                 |
|      created_at     |      2014-04-30T20:39:34.196285      |
| display_description |                 None                 |
|     display_name    |               testvol                |
|          id         | 5224e026-3a86-42dc-bc27-89c42d940664 |
|       metadata      |                  {}                  |
|         size        |                  1                   |
|     snapshot_id     |                 None                 |
|     source_volid    |                 None                 |
|        status       |               creating               |
|     volume_type     |                 None                 |
+---------------------+--------------------------------------+
[root@r64-acontrol ~(openstack_admin)]# cinder list
+--------------------------------------+-----------+--------------+------+-------------+----------+-------------+
|                  ID                  |   Status  | Display Name | Size | Volume Type | Bootable | Attached to |
+--------------------------------------+-----------+--------------+------+-------------+----------+-------------+
| 5224e026-3a86-42dc-bc27-89c42d940664 | available |   testvol    |  1   |     None    |  false   |             |
+--------------------------------------+-----------+--------------+------+-------------+----------+-------------+
[root@r64-acontrol ~(openstack_admin)]# cinder show testvol
+--------------------------------+--------------------------------------+
|            Property            |                Value                 |
+--------------------------------+--------------------------------------+
|          attachments           |                  []                  |
|       availability_zone        |                 nova                 |
|            bootable            |                false                 |
|           created_at           |      2014-04-30T20:39:34.000000      |
|      display_description       |                 None                 |
|          display_name          |               testvol                |
|               id               | 5224e026-3a86-42dc-bc27-89c42d940664 |
|            metadata            |                  {}                  |
|     os-vol-host-attr:host      |             r64-acontrol             |
| os-vol-mig-status-attr:migstat |                 None                 |
| os-vol-mig-status-attr:name_id |                 None                 |
|  os-vol-tenant-attr:tenant_id  |   63ffe5a845ea47089018063f09d25a2a   |
|              size              |                  1                   |
|          snapshot_id           |                 None                 |
|          source_volid          |                 None                 |
|             status             |              available               |
|          volume_type           |                 None                 |
+--------------------------------+--------------------------------------+
```

On exporting node:

```
[root@r64-acompute ~]# cd /export/cinder/
[root@r64-acompute cinder]# ll
total 0
-rw-rw-rw-. 1 root root 1073741824 30. dub 22.39 volume-5224e026-3a86-42dc-bc27-89c42d940664
```
