### PR TITLE
ha controller: add fence_ipmilan_host_to_address param to commmon

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -38,6 +38,7 @@ class quickstack::pacemaker::common (
   $fence_ipmilan_password         = "",
   $fence_ipmilan_interval         = "60s",
   $fence_ipmilan_hostlist         = "",
+  $fence_ipmilan_host_to_address  = [],
   $fence_xvm_clu_iface            = "eth2",
   $fence_xvm_clu_network          = "",
   $fence_xvm_manage_key_file      = "false",
@@ -68,12 +69,13 @@ class quickstack::pacemaker::common (
       disable => false,
     }
     class {'quickstack::pacemaker::stonith::ipmilan':
-      address        => $fence_ipmilan_address,
-      username       => $fence_ipmilan_username,
-      password       => $fence_ipmilan_password,
-      interval       => $fence_ipmilan_interval,
-      pcmk_host_list => $fence_ipmilan_hostlist,
-      lanplus        => true,
+      address         => $fence_ipmilan_address,
+      username        => $fence_ipmilan_username,
+      password        => $fence_ipmilan_password,
+      interval        => $fence_ipmilan_interval,
+      pcmk_host_list  => $fence_ipmilan_hostlist,
+      host_to_address => $fence_ipmilan_host_to_address,
+      lanplus         => true,
     }
   }
   elsif $fencing_type =~ /(?i-mx:^fence_xvm$)/ {

--- a/puppet/modules/quickstack/manifests/pacemaker/stonith/ipmilan.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/stonith/ipmilan.pp
@@ -6,13 +6,29 @@ class quickstack::pacemaker::stonith::ipmilan (
   $ensure          = "present",
   $lanplus         = false,
   $lanplus_options = '',
-  $pcmk_host_list ="",
+  $pcmk_host_list  = "",
+  $host_to_address = [],
   ) {
 
+  # a string that looks like "cluster_ip1,address1,cluster_ip1,adress2,...,"
+  # with any errant single quotes, double quotes, or white space removed
+  # and ":" replaced with ","
+  $host_to_address_string = inline_template('<%= @host_to_address.map {
+    |x| x.gsub(/\s+/, "").gsub("\'", "").gsub("\"", "").gsub(":",",")}.join(",") +"," %>')
+
+  # this nastiness exist because this puppet manifest doesn't know
+  # during compilation what its cluster IP is, and therefore wouldn't
+  # know which address to pick out of $host_to_address.  so we defer
+  # it to bash.
+  $real_address = $address ? {
+      ''      => "$(/bin/echo $host_to_address_string | /usr/bin/perl -p -e \"s/.*$(/usr/sbin/crm_node -n),(.*?),.*/\\\$1/\")",
+      default => "${address}",
+  }
+
   if($ensure == absent) {
-    exec { "Removing stonith::ipmilan ${address}":
-      command => "/usr/sbin/pcs stonith delete stonith-ipmilan-${address}",
-      onlyif  => "/usr/sbin/pcs stonith show stonith-ipmilan-${address} > /dev/null 2>&1",
+    exec { "Removing stonith::ipmilan":
+      command => "/usr/sbin/pcs stonith delete stonith-ipmilan-${real_address}",
+      onlyif  => "/usr/sbin/pcs stonith show stonith-ipmilan-${real_address} > /dev/null 2>&1",
       require => Class['pacemaker::corosync'],
     }
   } else {
@@ -37,9 +53,9 @@ class quickstack::pacemaker::stonith::ipmilan (
     package { "ipmitool":
       ensure => installed,
     } ->
-    exec { "Creating stonith::ipmilan ${address}":
-      command => "/usr/sbin/pcs stonith create stonith-ipmilan-${address} fence_ipmilan ${pcmk_host_list_chunk} ipaddr=${address} ${username_chunk} ${password_chunk} ${lanplus_chunk} op monitor interval=${interval}",
-      unless  => "/usr/sbin/pcs stonith show stonith-ipmilan-${address} > /dev/null 2>&1",
+    exec { "Creating stonith::ipmilan":
+      command => "/usr/sbin/pcs stonith create stonith-ipmilan-${real_address} fence_ipmilan ${pcmk_host_list_chunk} ipaddr=${real_address} ${username_chunk} ${password_chunk} ${lanplus_chunk} op monitor interval=${interval}",
+      unless  => "/usr/sbin/pcs stonith show stonith-ipmilan-${real_address} > /dev/null 2>&1",
       require => Class['pacemaker::corosync'],
     }
   }


### PR DESCRIPTION
This is a list of pairs that determines what address to use
when creating a stonith ipmilan device in pacemaker.

E.g., given a fence_ipmilan_host_to_address that looks like:
["192.168.200.10:10.10.10.10", "192.168.200.20:10.10.10.20",
"192.168.200.30:10.10.10.30"],

the cluster node 192.168.200.10 should use 10.10.10.10 as its ipmilan
fence address.

Note that the "address" param must be blank when providing the
"fence_ipmilan_host_to_address" param.
