### PR TITLE
Manage cinder-volume service with pacemaker

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -139,6 +139,15 @@ class quickstack::pacemaker::cinder(
         iscsi_bind_addr  => map_params('local_bind_addr'),
         glusterfs_shares => $glusterfs_shares,
       }
+      ->
+      Exec['pcs-cinder-server-set-up']
+
+      Exec['all-cinder-nodes-are-up']
+      ->
+      pacemaker::resource::lsb {'openstack-cinder-volume':
+        group => "$pcmk_cinder_group",
+        clone => true,
+      }
     }
   }
 }


### PR DESCRIPTION
Unlike other Cinder services, the openstack-cinder-volume service was
not managed by Pacemaker. This is now fixed.

Tested on a 1 node controller containing Keystone and Cinder.

Before:

```
[root@r64-acontrol ~]# pcs status
Cluster name: openstack
Last updated: Mon May  5 15:59:01 2014
Last change: Wed Apr 30 22:35:34 2014 via cibadmin on 192.168.122.10
Stack: cman
Current DC: 192.168.122.10 - partition with quorum
Version: 1.1.10-14.el6_5.3-368c726
1 Nodes configured
10 Resources configured


Online: [ 192.168.122.10 ]

Full list of resources:

 Clone Set: lsb-memcached-clone [lsb-memcached]
     Started: [ 192.168.122.10 ]
 ip-192.168.122.61  (ocf::heartbeat:IPaddr2):   Started 192.168.122.10 
 Clone Set: lsb-qpidd-clone [lsb-qpidd]
     Started: [ 192.168.122.10 ]
 ip-192.168.122.50  (ocf::heartbeat:IPaddr2):   Started 192.168.122.10 
 Clone Set: lsb-openstack-keystone-clone [lsb-openstack-keystone]
     Started: [ 192.168.122.10 ]
 ip-192.168.122.51  (ocf::heartbeat:IPaddr2):   Started 192.168.122.10 
 Clone Set: lsb-openstack-cinder-api-clone [lsb-openstack-cinder-api]
     Started: [ 192.168.122.10 ]
 Clone Set: lsb-openstack-cinder-scheduler-clone [lsb-openstack-cinder-scheduler]
     Started: [ 192.168.122.10 ]
 ip-192.168.122.60  (ocf::heartbeat:IPaddr2):   Started 192.168.122.10 
 Clone Set: lsb-haproxy-clone [lsb-haproxy]
     Started: [ 192.168.122.10 ]
```

After:

```
[root@r64-acontrol ~]# pcs status
Cluster name: openstack
Last updated: Mon May  5 16:58:39 2014
Last change: Mon May  5 16:57:06 2014 via crmd on 192.168.122.10
Stack: cman
Current DC: 192.168.122.10 - partition with quorum
Version: 1.1.10-14.el6_5.3-368c726
1 Nodes configured
11 Resources configured


Online: [ 192.168.122.10 ]

Full list of resources:

 Clone Set: lsb-memcached-clone [lsb-memcached]
     Started: [ 192.168.122.10 ]
 ip-192.168.122.61  (ocf::heartbeat:IPaddr2):   Started 192.168.122.10 
 Clone Set: lsb-qpidd-clone [lsb-qpidd]
     Started: [ 192.168.122.10 ]
 ip-192.168.122.50  (ocf::heartbeat:IPaddr2):   Started 192.168.122.10 
 Clone Set: lsb-openstack-keystone-clone [lsb-openstack-keystone]
     Started: [ 192.168.122.10 ]
 ip-192.168.122.51  (ocf::heartbeat:IPaddr2):   Started 192.168.122.10 
 Clone Set: lsb-openstack-cinder-api-clone [lsb-openstack-cinder-api]
     Started: [ 192.168.122.10 ]
 Clone Set: lsb-openstack-cinder-scheduler-clone [lsb-openstack-cinder-scheduler]
     Started: [ 192.168.122.10 ]
 ip-192.168.122.60  (ocf::heartbeat:IPaddr2):   Started 192.168.122.10 
 Clone Set: lsb-haproxy-clone [lsb-haproxy]
     Started: [ 192.168.122.10 ]
 Clone Set: lsb-openstack-cinder-volume-clone [lsb-openstack-cinder-volume]
     Started: [ 192.168.122.10 ]
```
