### PR TITLE
Install mariadb-galera-server

### DIFF
--- a/puppet/modules/quickstack/manifests/db/mysql.pp
+++ b/puppet/modules/quickstack/manifests/db/mysql.pp
@@ -109,7 +109,8 @@ class quickstack::db::mysql (
       'ssl_cert'       => $mysql_cert,
       'ssl_key'        => $mysql_key,
     },
-    enabled     => $enabled,
+    package_name => 'mariadb-galera-server',
+    enabled      => $enabled,
   }
 
   # This removes default users and guest access


### PR DESCRIPTION
Set package_name to 'mariadb-galera-server' so that it is always
installed when calling mysql::server. This will not deploy a galera
cluster since, by default, clustering is disabled.
