### PR TITLE
BZ #1094444 - Add support for neutron-nova notifications on port changes

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -198,6 +198,8 @@ class quickstack::neutron::all (
     metadata_ip   => $neutron_priv_host,
   }
 
+  include quickstack::neutron::notifications
+
   #class { 'neutron::agents::lbaas': }
 
   #class { 'neutron::agents::fwaas': }

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -265,6 +265,15 @@ class quickstack::neutron::controller (
     neutron_admin_password    => $neutron_user_password,
   }
 
+  class { '::neutron::server::notifications':
+    notify_nova_on_port_status_changes => true,
+    notify_nova_on_port_data_changes   => true,
+    nova_url                           => "http://${controller_priv_host}:8774/v2",
+    nova_admin_auth_url                => "http://${controller_priv_host}:35357/v2.0",
+    nova_admin_username                => "nova",
+    nova_admin_password                => "${nova_user_password}",
+  }
+
   firewall { '001 neutron server (API)':
     proto    => 'tcp',
     dport    => ['9696'],

--- a/puppet/modules/quickstack/manifests/neutron/notifications.pp
+++ b/puppet/modules/quickstack/manifests/neutron/notifications.pp
@@ -1,0 +1,18 @@
+class quickstack::neutron::notifications(
+) {
+  include quickstack::pacemaker::params
+
+  $nova_admin_vip     = map_params('nova_admin_vip')
+  $keystone_admin_vip = map_params('keystone_admin_vip')
+  $nova_group         = map_params('nova_group')
+  $nova_user_password = map_params('nova_user_password')
+
+  class { '::neutron::server::notifications':
+    notify_nova_on_port_status_changes => true,
+    notify_nova_on_port_data_changes   => true,
+    nova_url                           => "http://${nova_admin_vip}:8774/v2",
+    nova_admin_auth_url                => "http://${keystone_admin_vip}:35357/v2.0",
+    nova_admin_username                => "${nova_group}",
+    nova_admin_password                => "${nova_user_password}",
+  }
+}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1094444

Recent versions of neutron added the ability for neutron to notify nova
of port changes. This implements those changes for both standalone
and HA controller. The settings must be done on the controller node.
