### PR TITLE
[BUGFIX] - Neutron bind_host for HA.

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -57,6 +57,7 @@ class quickstack::neutron::all (
 
   class { '::neutron':
     allow_overlapping_ips => str2bool_i("$allow_overlapping_ips"),
+    bind_host             => $neutron_priv_host,
     core_plugin           => $neutron_core_plugin,
     enabled               => str2bool_i("$enabled"),
     rpc_backend           => $rpc_backend,


### PR DESCRIPTION
We were not passing it in, so it would bind to 0.0.0.0
