### PR TITLE
Remove trailing commas from some params that cause errors

### DIFF
--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -151,16 +151,16 @@ class quickstack::params {
   $gluster_uuid1         = 'e27f2849-6f69-4900-b348-d7b0ae497509'
   $gluster_uuid2         = '746dc27e-b9bd-46d7-a1a6-7b8957528f4c'
   $gluster_uuid3         = '5fe22c7d-dc85-4d81-8c8b-468876852566'
-  $gluster_volume1_gid   = '165',
+  $gluster_volume1_gid   = '165'
   $gluster_volume1_name  = 'cinder'
   $gluster_volume1_path  = '/cinder'
-  $gluster_volume1_uid   = '165',
-  $gluster_volume2_gid   = '161',
+  $gluster_volume1_uid   = '165'
+  $gluster_volume2_gid   = '161'
   $gluster_volume2_name  = 'glance'
   $gluster_volume2_path  = '/glance'
-  $gluster_volume2_uid   = '161',
-  $gluster_volume3_gid   = '160',
+  $gluster_volume2_uid   = '161'
+  $gluster_volume3_gid   = '160'
   $gluster_volume3_name  = 'swift'
   $gluster_volume3_path  = '/swift'
-  $gluster_volume3_uid   = '160',
+  $gluster_volume3_uid   = '160'
 }


### PR DESCRIPTION
The trailing commas cause a syntax error.
