### PR TITLE
BZ #1100411 - Ceilometer starts before mongo is ready.

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer_controller.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer_controller.pp
@@ -27,6 +27,7 @@ class quickstack::ceilometer_controller(
     # way to run mongo on a different host in the future
     class { 'ceilometer::db':
         database_connection => 'mongodb://localhost:27017/ceilometer',
+        require             => Service['mongod'],
     }
 
     class { 'ceilometer':
@@ -56,5 +57,6 @@ class quickstack::ceilometer_controller(
     class { 'ceilometer::api':
         keystone_host     => $controller_priv_host,
         keystone_password => $ceilometer_user_password,
+        require             => Service['mongod'],
     }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1100411

Wait for the mongo service before starting ceilometer.
