### PR TITLE
BZ #1100369 - Puppet agent fails to run because fencing was off

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -135,7 +135,7 @@ class quickstack::pacemaker::common (
   }
 
   if has_interface_with("ipaddress", map_params("cluster_control_ip")){
-    Exec['all-nodes-joined-cluster']
+    Exec['stonith-setup-complete']
     ->
     exec {"pcs-resource-default":
       command => "/usr/sbin/pcs resource defaults resource-stickiness=100",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1100369

When fencing is disabled, the all-nodes-joined-cluster exec is not
defined, but it is used as an ordering dependency in
quickstack::pacemaker::common, causing puppet to fail with:

Error 400 on SERVER: Could not find resource
'Exec[all-nodes-joined-cluster]' for relationship on
'Exec[pcs-resource-default]'

Use stonith-setup-complete hook instead, which is defined even when
fencing is disabled.
