### PR TITLE
Add galera server host group

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -368,6 +368,17 @@ params = {
   "gluster_volume3_name"          => 'swift',
   "gluster_volume3_path"          => '/swift',
   "gluster_volume3_uid"           => '160',
+  "galera_bootstrap"              => false,
+  "galera_monitor_username"       => "monitor_user",
+  "galera_monitor_password"       => SecureRandom.hex,
+  "wsrep_cluster_name"            => "galera_cluster",
+  "wsrep_cluster_members"         => ['192.168.203.11', '192.168.203.12', '192.168.203.13'],
+  "wsrep_sst_method"              => "rsync",
+  "wsrep_sst_username"            => "sst_user",
+  "wsrep_sst_password"            => SecureRandom.hex,
+  "wsrep_ssl"                     => true,
+  "wsrep_ssl_key"                 => "/etc/pki/galera/galera.key",
+  "wsrep_ssl_cert"                => "/etc/pki/galera/galera.crt",
 }
 
 hostgroups = [
@@ -409,7 +420,9 @@ hostgroups = [
     {:name=>"Gluster Server",
      :class=>["puppet::vardir",
               "quickstack::gluster::server",
-             ]}
+             ]},
+    {:name=>"Galera Server",
+     :class=>"quickstack::galera::server"}
 ]
 
 def get_key_type(value)

--- a/puppet/modules/quickstack/manifests/galera/server.pp
+++ b/puppet/modules/quickstack/manifests/galera/server.pp
@@ -1,0 +1,37 @@
+class quickstack::galera::server (
+  $mysql_bind_address      = '0.0.0.0',
+  $mysql_root_password     = '',
+  $galera_bootstrap        = false,
+  $galera_monitor_username = 'monitor_user',
+  $galera_monitor_password = 'monitor_pass',
+  $wsrep_cluster_name      = 'galera_cluster',
+  $wsrep_cluster_members   = [],
+  $wsrep_sst_method        = 'rsync',
+  $wsrep_sst_username      = 'sst_user',
+  $wsrep_sst_password      = 'sst_pass',
+  $wsrep_ssl               = true,
+  $wsrep_ssl_key           = '/etc/pki/galera/galera.key',
+  $wsrep_ssl_cert          = '/etc/pki/galera/galera.crt',
+){
+  class {'::galera::server':
+    bootstrap => $galera_bootstrap,
+    config_hash => {
+      bind_address   => $mysql_bind_address,
+      root_password  => $mysql_root_password,
+      default_engine => 'InnoDB',
+    },
+    wsrep_cluster_name    => $wsrep_cluster_name,
+    wsrep_cluster_members => $wsrep_cluster_members,
+    wsrep_sst_method      => $wsrep_sst_method,
+    wsrep_sst_username    => $wsrep_sst_username,
+    wsrep_sst_password    => $wsrep_sst_password,
+    wsrep_ssl             => $wsrep_ssl,
+    wsrep_ssl_key         => $wsrep_ssl_key,
+    wsrep_ssl_cert        => $wsrep_ssl_cert,
+  }
+
+  class {'::galera::monitor':
+    mysql_username => $galera_monitor_username,
+    mysql_password => $galera_monitor_password,
+  }
+}


### PR DESCRIPTION
This patch adds a standalone galera server host group. This host group
can be used to deploy a galera cluster sing the galera::server and
galera::monitor classes from the puppet-galera module.
