### PR TITLE
BZ #1103315 - Openstack firewall rules are not enabled after reboot.

### DIFF
--- a/puppet/modules/quickstack/manifests/openstack_common.pp
+++ b/puppet/modules/quickstack/manifests/openstack_common.pp
@@ -8,4 +8,11 @@ class quickstack::openstack_common(
     }
   }
 
+  # Stop firewalld since everything uses iptables
+  # for now (same as packstack did)
+  service { "firewalld":
+    ensure     => "stopped",
+    enable => false,
+  }
+
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1103315

The firewall module we depend on doesnt yet account for firewalld, which is
enabled by default in RHEL 7.
