### PR TITLE
more robust updating of custom pcs properties

### DIFF
--- a/puppet/modules/quickstack/templates/ha-all-in-one-util.erb
+++ b/puppet/modules/quickstack/templates/ha-all-in-one-util.erb
@@ -44,17 +44,28 @@ all_members_include() {
 # update a resource property with same name as my node
 # to include the argument in a list if it is not there already
 update_my_node_property() {
-   element=$1
-   mynode=$(my_cluster_ip)
-   if ! $(property_exists $mynode); then
-     /usr/sbin/pcs property set $mynode=$element --force || return 1
-     return 0
-   fi
-   if $(property_includes $mynode $element); then
-     return 0
-   fi
-   /usr/sbin/pcs property set $mynode=$(get_property_value $mynode),$element --force || return 1
-   return 0
+  element=$1
+  mynode=$(my_cluster_ip)
+  if ! $(property_exists $mynode); then
+    /usr/sbin/pcs property set $mynode=$element --force || return 1
+    return 0
+  fi
+  if $(property_includes $mynode $element); then
+    return 0
+  fi
+  /usr/sbin/pcs property set $mynode=$(get_property_value $mynode),$element --force || return 1
+  return 0
+}
+
+update_my_node_property_verified() {
+  element=$1
+  mynode=$(my_cluster_ip)
+  property_includes $mynode $element
+  while [ $? -ne 0 ]; do
+    update_my_node_property $element $mynode
+    sleep 1
+    property_includes $mynode $element
+  done
 }
 
 # obsolete, but here as an illustration of how i_am_vip works
@@ -98,7 +109,7 @@ case "$1" in
      property_exists $2
      ;;
   "update_my_node_property")
-     update_my_node_property $2 $3
+     update_my_node_property_verified $2
      ;;
   "all_members_include")
      all_members_include $2


### PR DESCRIPTION
Added the function update_my_node_property_verified which makes use of the already existing update_my_node_property function.  This is more robust -- we want to make sure the property update sticks (I believe I saw a case in development recently where it did not... bad things ensue).

Note that if called from the command line there would be the potential for an infinite loop, however this is not the case when called from a puppet exec where a "timeout" exists.  I.e., it should be up to puppet how long the command should attempt to update the property before giving up.

Tested.
