### PR TITLE
BZ #1103315 - Openstack firewall rules are not enabled after reboot.

### DIFF
--- a/puppet/modules/quickstack/manifests/openstack_common.pp
+++ b/puppet/modules/quickstack/manifests/openstack_common.pp
@@ -1,7 +1,7 @@
 # Class for nodes running any OpenStack services
-class quickstack::openstack_common(
-) inherits quickstack::params {
+class quickstack::openstack_common {
 
+  include quickstack::firewall::common
   # openstack-selinux does not exist in el7 yet, but it when it does
   # can just remove the ::operatingsystemrelease clause below
   if (str2bool($::selinux) and $::operatingsystem != "Fedora") {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1103315

There was an additional issue where iptables rules were attempted to be
persisted before the service had been started.  We need to make sure we call the
base firewall class on our side, which is what this patch does, and then once the
firewall module gets the fix needed on that side[1], everything should work more
cleanly.

[1] https://github.com/puppetlabs/puppetlabs-firewall/pull/367
