### PR TITLE
Fixed cinder_controller to use puppet-gluster

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -418,9 +418,7 @@ hostgroups = [
               "quickstack::pacemaker::neutron",
              ]},
     {:name=>"Gluster Server",
-     :class=>["puppet::vardir",
-              "quickstack::gluster::server",
-             ]},
+     :class=>"quickstack::gluster::server"},
     {:name=>"Galera Server",
      :class=>"quickstack::galera::server"}
 ]

--- a/puppet/modules/quickstack/manifests/cinder_controller.pp
+++ b/puppet/modules/quickstack/manifests/cinder_controller.pp
@@ -66,6 +66,7 @@ class quickstack::cinder_controller(
     if defined('gluster::client') {
       class { 'gluster::client': }
     } else {
+      class { 'puppet::vardir': }
       class { 'gluster::mount::base': repo => false }
     }
 

--- a/puppet/modules/quickstack/manifests/cinder_volume.pp
+++ b/puppet/modules/quickstack/manifests/cinder_volume.pp
@@ -13,6 +13,8 @@ class quickstack::cinder_volume(
       ->
       Class['::cinder::volume']
     } else {
+      class { 'puppet::vardir': }
+      ->
       class { 'gluster::mount::base': repo => false }
       ->
       Class['::cinder::volume']

--- a/puppet/modules/quickstack/manifests/gluster/server.pp
+++ b/puppet/modules/quickstack/manifests/gluster/server.pp
@@ -30,6 +30,8 @@ class quickstack::gluster::server (
   $volume3_uid   = $quickstack::params::gluster_volume3_uid,
 ) {
 
+  include puppet::vardir
+
   $vip  = ''
   $vrrp =  false
 

--- a/puppet/modules/quickstack/manifests/storage_backend/cinder.pp
+++ b/puppet/modules/quickstack/manifests/storage_backend/cinder.pp
@@ -49,6 +49,7 @@ class quickstack::storage_backend::cinder(
     if defined('gluster::client') {
       class { 'gluster::client': }
     } else {
+      class { 'puppet::vardir': }
       class { 'gluster::mount::base': repo => false }
     }
 


### PR DESCRIPTION
Includes the required vardir module from purpleidea/puppet-puppet
Tested on RHEL7RC3/RHOS5 (using default gluster client RPMs from RHEL7 repos)
