### PR TITLE
BZ #1103915 - neutron notification setup ordering.

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -165,7 +165,7 @@ class quickstack::neutron::controller (
   class { '::nova::network::neutron':
     neutron_admin_password    => $neutron_user_password,
   }
-
+  ->
   class { '::neutron::server::notifications':
     notify_nova_on_port_status_changes => true,
     notify_nova_on_port_data_changes   => true,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1103915

Missed a line in the enforcement of ordering.
