### PR TITLE
open gre in addition to vxlan

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -175,6 +175,8 @@ class quickstack::neutron::all (
 
   #class { 'neutron::agents::fwaas': }
 
+  class {'quickstack::neutron::firewall::gre': }
+
   class {'quickstack::neutron::firewall::vxlan':
     port => $ovs_vxlan_udp_port,
   }

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -119,6 +119,8 @@ class quickstack::neutron::compute (
     use_qemu_for_poc           => $use_qemu_for_poc,
   }
 
+  class {'quickstack::neutron::firewall::gre':}
+
   class {'quickstack::neutron::firewall::vxlan':
     port => $ovs_vxlan_udp_port,
   }

--- a/puppet/modules/quickstack/manifests/neutron/firewall/gre.pp
+++ b/puppet/modules/quickstack/manifests/neutron/firewall/gre.pp
@@ -1,0 +1,9 @@
+class quickstack::neutron::firewall::gre (
+) {
+  include quickstack::firewall::common
+
+  firewall { '002 gre':
+    proto  => 'gre',
+    action => 'accept',
+  }
+}

--- a/puppet/modules/quickstack/manifests/neutron/firewall/vxlan.pp
+++ b/puppet/modules/quickstack/manifests/neutron/firewall/vxlan.pp
@@ -1,6 +1,8 @@
 class quickstack::neutron::firewall::vxlan (
   $port = 4789,
 ) {
+  include quickstack::firewall::common
+
   firewall { '002 vxlan udp':
     proto  => 'udp',
     dport  => ["${port}"],

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -108,6 +108,8 @@ class quickstack::neutron::networker (
 
   #class { 'neutron::agents::fwaas': }
 
+  class {'quickstack::neutron::firewall::gre':}
+
   class {'quickstack::neutron::firewall::vxlan':
     port => $ovs_vxlan_udp_port,
   }


### PR DESCRIPTION
This patch teaches quickstack::neutron about GRE.  It opens GRE access
anywhere that vxlan access was already permitted.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1072325
