### PR TITLE
Glusterfs support for RHEL7,CentOS7,Fedora20

### DIFF
--- a/puppet/modules/quickstack/manifests/gluster/server.pp
+++ b/puppet/modules/quickstack/manifests/gluster/server.pp
@@ -29,6 +29,7 @@ class quickstack::gluster::server (
   $volume3_path  = $quickstack::params::gluster_volume3_path,
   $volume3_uid   = $quickstack::params::gluster_volume3_uid,
 ) {
+  include gluster::params
 
   $vip  = ''
   $vrrp =  false


### PR DESCRIPTION
Requires Puppet module-data which is already in Openstack-Puppet-Modules.

Hiera is also required since this is relying on yaml datastores

Hiera is included by default but a symbolic link to the default /etc/hiera.yaml
configuration file must be created in /etc/puppet for puppet-hiera to
kick in properly.

https://bugzilla.redhat.com/show_bug.cgi?id=1091777
