### PR TITLE
BZ #1109311 - Re-add openstack-selinux to deployment

### DIFF
--- a/puppet/modules/quickstack/manifests/openstack_common.pp
+++ b/puppet/modules/quickstack/manifests/openstack_common.pp
@@ -2,16 +2,9 @@
 class quickstack::openstack_common {
 
   include quickstack::firewall::common
-  # openstack-selinux does not exist in el7 yet, but it when it does
-  # can just remove the ::operatingsystemrelease clause below
   if (str2bool($::selinux) and $::operatingsystem != "Fedora") {
-    if ($::operatingsystemrelease =~ /^6\..*$/)  {
       package{ 'openstack-selinux':
           ensure => present, }
-    } else {
-      package{ 'selinux-policy':
-          ensure => present, }
-    }
   }
 
   # Stop firewalld since everything uses iptables


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1109311

Openstack-selinux will be used in RHEL 7 after all.
