### PR TITLE
expose ipmilan lanplus options to end user

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -27,7 +27,6 @@
 #
 # [*fence_xvm_key_file_password*]
 #
-# TODO: expose params fence_ipmilan_lanplus, fence_ipmilan_lanplus_options
 
 class quickstack::pacemaker::common (
   $pacemaker_cluster_name         = "openstack",
@@ -39,6 +38,8 @@ class quickstack::pacemaker::common (
   $fence_ipmilan_interval         = "60s",
   $fence_ipmilan_hostlist         = "",
   $fence_ipmilan_host_to_address  = [],
+  $fence_ipmilan_expose_lanplus   = "true",
+  $fence_ipmilan_lanplus_options  = "",
   $fence_xvm_clu_iface            = "eth2",
   $fence_xvm_clu_network          = "",
   $fence_xvm_manage_key_file      = "false",
@@ -82,7 +83,8 @@ class quickstack::pacemaker::common (
       interval        => $fence_ipmilan_interval,
       pcmk_host_list  => $fence_ipmilan_hostlist,
       host_to_address => $fence_ipmilan_host_to_address,
-      lanplus         => true,
+      lanplus         => str2bool_i("$fence_ipmilan_expose_lanplus"),
+      lanplus_options => $fence_ipmilan_lanplus_options,
     }
   }
   elsif $fencing_type =~ /(?i-mx:^fence_xvm$)/ {


### PR DESCRIPTION
The reason there are two params rather than just one, is we want to allow the user to _not_ pass in the lanplus argument at all in the command line to "pcs stonith create..." (i.e. $fence_ipmilan_expose_lanplus is false), or just pass in lanplus="" (i.e. $fence_ipmilan_lanplus_options is empty but $fence_ipmilan_expose_lanplus is true ), or lanplus="1" ($fence_ipmilan_lanplus_options is 1), etc.
