### PR TITLE
BZ #1104219 - Update HA Nova support for Icehouse.

### DIFF
--- a/puppet/modules/quickstack/manifests/nova.pp
+++ b/puppet/modules/quickstack/manifests/nova.pp
@@ -5,94 +5,126 @@
 # === Parameters
 # [*admin_password*]
 #   Sets the password for the nova api config.
+#
+# [*amqp_hostname*]
+#   (optional) Location of amqp server
+#   Defaults to 'localhost'
+#
+# [*amqp_port*]
+#   (optional) Port for amqp server
+#   Defaults to '5672'
+#
+# [*amqp_username*]
+#   (optional) amqp username
+#   Defaults to '' for amqp no auth.
+#
+# [*amqp_password*]
+#   (optional) amqp password
+#   Defaults to ''.
+#
 # [*auth_host*]
 #   Where to authenticate against for nova api, usually your Keystone
 #   internal ip.
 #   Defaults to 'localhost'.
+#
 # [*auto_assign_floating_ip*]
 #   Defaults to 'true'.
+#
 # [*bind_address*]
 #   (optional) Address to bind api service to.
 #   Defaults to  '0.0.0.0'.
+#
 # [*db_host*]
 #   (optional) Nova's database host.
 #   Defaults to 'localhost'.
+#
 # [*db_name*]
 #   (optional) Nova's database name
 #   Defaults to 'nova'.
+#
 # [*db_password*]
+#
 # [*db_user*]
 #   (optional) Nova's database user.
 #   Defaults to 'nova'.
+#
 # [*default_floating_pool*]
+#
 # [*force_dhcp_release*]
 #   Defaults to 'false'.
+#
 # [*glance_host*]
 #   (optional) List of addresses for api server hosts.
 #   Defaults to 'localhost'.
+#
 # [*glance_port*]
 #   (optional) Port glance api is listening on for server host.
 #   Defaults to '9292'.
+#
 # [*image_service*]
 #   (optional) Service used to search for and retrieve images.
 #   Defaults to 'nova.image.glance.GlanceImageService'.
+#
+# [*manage_service*]
+#   (optional) Whether to start/stop the service
+#   Defaults to true
+#
 # [*memcached_servers*]
 #   (optional) Use memcached instead of in-process cache. Supply a list of
 #   memcached server IP's:Memcached Port.
 #   Defaults to false
+#
 # [*multi_host*]
 #   Defaults to 'true'.
+#
 # [*neutron*]
 #   Whether to configure nova api to use neutron for networking.
 #   Defaults to 'false'.
+#
 # [*neutron_metadata_proxy_secret*]
 # [*qpid_heartbeat*]
 #   (optional) Seconds between connection keepalive heartbeats
 #   Defaults to '60'.
-# [*amqp_hostname*]
-#   (optional) Location of amqp server
-#   Defaults to 'localhost'
-# [*amqp_port*]
-#   (optional) Port for amqp server
-#   Defaults to '5672'
-# [*amqp_username*]
-#   (optional) amqp username
-#   Defaults to '' for amqp no auth.
-# [*amqp_password*]
-#   (optional) amqp password
-#   Defaults to ''.
+#
 # [*rpc_backend*]
 #   (optional) The rpc backend implementation to use.
 #   Defaults to 'nova.openstack.common.rpc.impl_kombu'.
+#
+# [*scheduler_host_subset_size*]
+#   (optional) defines the subset size that a host is chosen from
+#   Defaults to '1'
+#
 # [*verbose*]
 #   (optional) Set log output to verbose output.
 #   Defaults to 'false'.
 
 class quickstack::nova (
   $admin_password,
-  $auth_host          = 'localhost',
-  $auto_assign_floating_ip = 'true',
-  $bind_address       = '0.0.0.0',
-  $db_host            = 'localhost',
-  $db_name            = 'nova',
+  $amqp_hostname                = 'localhost',
+  $amqp_port                    = '5672',
+  $amqp_username                = '',
+  $amqp_password                = '',
+  $auth_host                    = 'localhost',
+  $auto_assign_floating_ip      = 'true',
+  $bind_address                 = '0.0.0.0',
+  $db_host                      = 'localhost',
+  $db_name                      = 'nova',
   $db_password,
-  $db_user            = 'nova',
+  $db_user                      = 'nova',
   $default_floating_pool,
-  $force_dhcp_release = 'false',
-  $glance_host        = 'localhost',
-  $glance_port        = '9292',
-  $image_service      = 'nova.image.glance.GlanceImageService',
-  $memcached_servers  = 'false',
-  $multi_host         = 'true',
-  $neutron            = 'false',
+  $force_dhcp_release           = 'false',
+  $glance_host                  = 'localhost',
+  $glance_port                  = '9292',
+  $image_service                = 'nova.image.glance.GlanceImageService',
+  $manage_service               = 'true',
+  $memcached_servers            = 'false',
+  $multi_host                   = 'true',
+  $neutron                      = 'false',
   $neutron_metadata_proxy_secret,
-  $qpid_heartbeat     = '60',
-  $amqp_hostname      = 'localhost',
-  $amqp_port          = '5672',
-  $amqp_username      = '',
-  $amqp_password      = '',
-  $rpc_backend        = 'nova.openstack.common.rpc.impl_kombu',
-  $verbose            = 'false',
+  $qpid_heartbeat               = '60',
+  $rpc_backend                  = 'nova.openstack.common.rpc.impl_kombu',
+  $scheduler_host_subset_size   = '1',
+  $verbose                      = 'false',
 ) {
 
     # TODO: add ssl config here
@@ -128,6 +160,7 @@ class quickstack::nova (
         api_bind_address                     => $bind_address,
         auth_host                            => $auth_host,
         enabled                              => true,
+        manage_service                       => str2bool_i("$manage_service"),
         neutron_metadata_proxy_shared_secret => $neutron_metadata_proxy_secret,
       }
     } else {
@@ -143,24 +176,33 @@ class quickstack::nova (
         admin_password   => $admin_password,
         api_bind_address => $bind_address,
         auth_host        => $auth_host,
+        manage_service   => str2bool_i("$manage_service"),
       }
     }
     class {'::nova::scheduler':
-      enabled => true,
+      enabled        => true,
+      manage_service => str2bool_i("$manage_service"),
+    }
+    class {'::nova::scheduler::filter':
+      scheduler_host_subset_size => $scheduler_host_subset_size,
     }
     class {'::nova::cert':
       enabled => true,
+      manage_service => str2bool_i("$manage_service"),
     }
     class {'::nova::consoleauth':
       enabled => true,
+      manage_service => str2bool_i("$manage_service"),
     }
     class {'::nova::conductor':
       enabled => true,
+      manage_service => str2bool_i("$manage_service"),
     }
 
     class { '::nova::vncproxy':
       host    => $bind_address,
       enabled => true,
+      manage_service => str2bool_i("$manage_service"),
     }
     class {'::quickstack::firewall::nova':}
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1104219

This includes making nova A/A by default.  If you wish to make it A/P, simply
set scheduler_host_subset_size=1.
