### PR TITLE
BZ #1109329 - Start ceilometer notification agent service.

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer_controller.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer_controller.pp
@@ -50,6 +50,7 @@ class quickstack::ceilometer_controller(
         require => Class['ceilometer::db'],
     }
 
+    class { 'ceilometer::agent::notification':}
     class { 'ceilometer::agent::auth':
         auth_url      => "http://${controller_priv_host}:35357/v2.0",
         auth_password => $ceilometer_user_password,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1109329

This only applies to non-HA case since we do not yet have ceilometer included in
HA deployments.
