### PR TITLE
remove group option from cloned pcmk resources

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -146,12 +146,10 @@ class quickstack::pacemaker::cinder(
     }
     ->
     quickstack::pacemaker::resource::service {'openstack-cinder-api':
-      group => "$pcmk_cinder_group",
       clone => true,
     }
     ->
     quickstack::pacemaker::resource::service {'openstack-cinder-scheduler':
-      group => "$pcmk_cinder_group",
       clone => true,
     }
 
@@ -188,7 +186,6 @@ class quickstack::pacemaker::cinder(
       Exec['all-cinder-nodes-are-up']
       ->
       quickstack::pacemaker::resource::service {'openstack-cinder-volume':
-        group => "$pcmk_cinder_group",
         clone => true,
       }
     }

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -146,12 +146,10 @@ class quickstack::pacemaker::glance (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include glance",
     } ->
     quickstack::pacemaker::resource::service {'openstack-glance-api':
-      group => "$pcmk_glance_group",
       clone => true,
     }
     ->
     quickstack::pacemaker::resource::service {'openstack-glance-registry':
-      group => "$pcmk_glance_group",
       clone => true,
     }
   }

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -128,7 +128,6 @@ class quickstack::pacemaker::heat(
     }
     ->
     quickstack::pacemaker::resource::service {'openstack-heat-api':
-      group => "$heat_group",
       clone => true,
     }
     ->
@@ -151,7 +150,6 @@ class quickstack::pacemaker::heat(
       Exec["all-heat-nodes-are-up"]
       ->
       quickstack::pacemaker::resource::service {"openstack-heat-api-cfn":
-        group => "$heat_cfn_group",
         clone => true,
       }
     }
@@ -160,7 +158,6 @@ class quickstack::pacemaker::heat(
       Exec["all-heat-nodes-are-up"]
       ->
       quickstack::pacemaker::resource::service {"openstack-heat-api-cloudwatch":
-        group => "$heat_group",
         clone => true,
       }
     }

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -107,7 +107,6 @@ class quickstack::pacemaker::horizon (
     }
     ->
     quickstack::pacemaker::resource::service {"$::horizon::params::http_service":
-      group => "$::horizon::params::http_service",
       clone => true,
     }
   }

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -151,7 +151,6 @@ class quickstack::pacemaker::keystone (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include keystone",
     } ->
     quickstack::pacemaker::resource::service {'openstack-keystone':
-      group   => map_params("keystone_group"),
       clone   => true,
       options => 'start-delay=10s',
     }

--- a/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
@@ -23,7 +23,6 @@ class quickstack::pacemaker::load_balancer {
 
   } ->
   quickstack::pacemaker::resource::service {'haproxy':
-    group => "$loadbalancer_group",
     clone => true,
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
@@ -16,7 +16,6 @@ class quickstack::pacemaker::memcached {
     command   => "/tmp/ha-all-in-one-util.bash all_members_include memcached",
   } ->
   quickstack::pacemaker::resource::service { 'memcached':
-    group   => 'openstack_memcached',
     clone   => true,
     options => 'start-delay=10s',
   }


### PR DESCRIPTION
Untested.  But we clearly do not want cloned resources to have a "group" option, which results in an error message from pacemaker (albeit a harmless error message from the puppet perspective).
