### PR TITLE
haproxy configured and running before mysql, keystone, etc

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -80,6 +80,14 @@ class quickstack::pacemaker::cinder(
       Exec['all-nova-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
 
+    class {"::quickstack::load_balancer::cinder":
+      frontend_pub_host    => map_params("cinder_public_vip"),
+      frontend_priv_host   => map_params("cinder_private_vip"),
+      frontend_admin_host  => map_params("cinder_admin_vip"),
+      backend_server_names => map_params("lb_backend_server_names"),
+      backend_server_addrs => map_params("lb_backend_server_addrs"),
+    }
+
     Class['::quickstack::pacemaker::qpid']
     ->
     # assuming openstack-cinder-api and openstack-cinder-scheduler
@@ -123,14 +131,6 @@ class quickstack::pacemaker::cinder(
     }
 
     Class['::quickstack::cinder']
-    ->
-    class {"::quickstack::load_balancer::cinder":
-      frontend_pub_host    => map_params("cinder_public_vip"),
-      frontend_priv_host   => map_params("cinder_private_vip"),
-      frontend_admin_host  => map_params("cinder_admin_vip"),
-      backend_server_names => map_params("lb_backend_server_names"),
-      backend_server_addrs => map_params("lb_backend_server_addrs"),
-    }
     ->
     exec {"pcs-cinder-server-set-up":
       command => "/usr/sbin/pcs property set cinder=running --force",

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -77,6 +77,14 @@ class quickstack::pacemaker::glance (
       }
     }
 
+    class {"::quickstack::load_balancer::glance":
+      frontend_pub_host    => map_params("glance_public_vip"),
+      frontend_priv_host   => map_params("glance_private_vip"),
+      frontend_admin_host  => map_params("glance_admin_vip"),
+      backend_server_names => map_params("lb_backend_server_names"),
+      backend_server_addrs => map_params("lb_backend_server_addrs"),
+    }
+
     Class['::quickstack::pacemaker::common']
     ->
     # assuming openstack-glance-api and openstack-glance-registry
@@ -126,13 +134,6 @@ class quickstack::pacemaker::glance (
 
     Class['::quickstack::glance']
     ->
-    class {"::quickstack::load_balancer::glance":
-      frontend_pub_host    => map_params("glance_public_vip"),
-      frontend_priv_host   => map_params("glance_private_vip"),
-      frontend_admin_host  => map_params("glance_admin_vip"),
-      backend_server_names => map_params("lb_backend_server_names"),
-      backend_server_addrs => map_params("lb_backend_server_addrs"),
-    } ->
     exec {"pcs-glance-server-set-up":
       command => "/usr/sbin/pcs property set glance=running --force",
     } ->

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -28,6 +28,19 @@ class quickstack::pacemaker::heat(
     $heat_cfn_group          = map_params("heat_cfn_group")
     $heat_private_vip        = map_params("heat_private_vip")
 
+    class {"::quickstack::load_balancer::heat":
+      frontend_heat_pub_host              => map_params("heat_public_vip"),
+      frontend_heat_priv_host             => map_params("heat_private_vip"),
+      frontend_heat_admin_host            => map_params("heat_admin_vip"),
+      frontend_heat_cfn_pub_host          => map_params("heat_cfn_public_vip"),
+      frontend_heat_cfn_priv_host         => map_params("heat_cfn_private_vip"),
+      frontend_heat_cfn_admin_host        => map_params("heat_cfn_admin_vip"),
+      backend_server_names                => map_params("lb_backend_server_names"),
+      backend_server_addrs                => map_params("lb_backend_server_addrs"),
+      heat_cfn_enabled                    => $heat_cfn_enabled,
+      heat_cloudwatch_enabled             => $heat_cloudwatch_enabled,
+    }
+
     Exec['i-am-heat-vip-OR-heat-is-up-on-vip'] -> Exec<| title == 'heat-manage db_sync' |>
     if (map_params('include_mysql') == 'true') {
       if str2bool_i("$hamysql_is_running") {
@@ -97,19 +110,6 @@ class quickstack::pacemaker::heat(
       heat_cloudwatch_enabled => $heat_cloudwatch_enabled,
       # don't start heat-engine on all hosts, let pacemaker start it on one
       heat_engine_enabled     => false,
-    }
-    ->
-    class {"::quickstack::load_balancer::heat":
-      frontend_heat_pub_host              => map_params("heat_public_vip"),
-      frontend_heat_priv_host             => map_params("heat_private_vip"),
-      frontend_heat_admin_host            => map_params("heat_admin_vip"),
-      frontend_heat_cfn_pub_host          => map_params("heat_cfn_public_vip"),
-      frontend_heat_cfn_priv_host         => map_params("heat_cfn_private_vip"),
-      frontend_heat_cfn_admin_host        => map_params("heat_cfn_admin_vip"),
-      backend_server_names                => map_params("lb_backend_server_names"),
-      backend_server_addrs                => map_params("lb_backend_server_addrs"),
-      heat_cfn_enabled                    => $heat_cfn_enabled,
-      heat_cloudwatch_enabled             => $heat_cloudwatch_enabled,
     }
     ->
     exec {"pcs-heat-server-set-up":

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -50,6 +50,14 @@ class quickstack::pacemaker::horizon (
       Exec['all-heat-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
 
+    class {"::quickstack::load_balancer::horizon":
+      frontend_pub_host    => $horizon_public_vip,
+      frontend_priv_host   => $horizon_private_vip,
+      frontend_admin_host  => $horizon_admin_vip,
+      backend_server_names => map_params("lb_backend_server_names"),
+      backend_server_addrs => map_params("lb_backend_server_addrs"),
+    }
+
     Class['::quickstack::pacemaker::common']
     ->
     quickstack::pacemaker::vips { "$pcmk_horizon_group":
@@ -81,14 +89,6 @@ class quickstack::pacemaker::horizon (
       keystone_host         => map_params("keystone_admin_vip"),
       memcached_servers     => $memcached_servers,
       secret_key            => $secret_key,
-    }
-    ->
-    class {"::quickstack::load_balancer::horizon":
-      frontend_pub_host    => $horizon_public_vip,
-      frontend_priv_host   => $horizon_private_vip,
-      frontend_admin_host  => $horizon_admin_vip,
-      backend_server_names => map_params("lb_backend_server_names"),
-      backend_server_addrs => map_params("lb_backend_server_addrs"),
     }
     ->
     exec {"pcs-horizon-server-set-up":

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -45,6 +45,14 @@ class quickstack::pacemaker::keystone (
       }
     }
 
+    class {"::quickstack::load_balancer::keystone":
+      frontend_pub_host    => map_params("keystone_public_vip"),
+      frontend_priv_host   => map_params("keystone_private_vip"),
+      frontend_admin_host  => map_params("keystone_admin_vip"),
+      backend_server_names => map_params("lb_backend_server_names"),
+      backend_server_addrs => map_params("lb_backend_server_addrs"),
+    }
+
     Class['::quickstack::pacemaker::common'] ->
 
     quickstack::pacemaker::vips { "$keystone_group":
@@ -129,14 +137,6 @@ class quickstack::pacemaker::keystone (
       heat_cfn_public_address     => map_params("heat_cfn_public_vip"),
       heat_cfn_internal_address   => map_params("heat_cfn_private_vip"),
       heat_cfn_admin_address      => map_params("heat_cfn_admin_vip"),
-    } ->
-    class {"::quickstack::load_balancer::keystone":
-      frontend_pub_host    => map_params("keystone_public_vip"),
-      frontend_priv_host   => map_params("keystone_private_vip"),
-      frontend_admin_host  => map_params("keystone_admin_vip"),
-      backend_server_names => map_params("lb_backend_server_names"),
-      backend_server_addrs => map_params("lb_backend_server_addrs"),
-      require              => Quickstack::Pacemaker::Vips["$keystone_group"],
     } ->
     exec {"pcs-keystone-server-set-up":
       command => "/usr/sbin/pcs property set keystone=running --force",

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -49,6 +49,14 @@ class quickstack::pacemaker::neutron (
       Exec['all-nova-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
 
+    class {"::quickstack::load_balancer::neutron":
+      frontend_pub_host    => map_params("neutron_public_vip"),
+      frontend_priv_host    => map_params("neutron_private_vip"),
+      frontend_admin_host    => map_params("neutron_admin_vip"),
+      backend_server_names => map_params("lb_backend_server_names"),
+      backend_server_addrs => map_params("lb_backend_server_addrs"),
+    }
+
     Class['::quickstack::pacemaker::common']
     ->
     quickstack::pacemaker::vips { "$neutron_group":
@@ -99,14 +107,6 @@ class quickstack::pacemaker::neutron (
       tenant_network_type           => $tenant_network_type,
       tunnel_id_ranges              => $tunnel_id_ranges,
       verbose                       => $verbose,
-    }
-    class {"::quickstack::load_balancer::neutron":
-      frontend_pub_host    => map_params("neutron_public_vip"),
-      frontend_priv_host    => map_params("neutron_private_vip"),
-      frontend_admin_host    => map_params("neutron_admin_vip"),
-      backend_server_names => map_params("lb_backend_server_names"),
-      backend_server_addrs => map_params("lb_backend_server_addrs"),
-      require              => Quickstack::Pacemaker::Vips["$neutron_group"],
     }
     ->
     exec {"pcs-neutron-server-set-up":

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -46,6 +46,13 @@ class quickstack::pacemaker::nova (
       $sched_clone = true
     }
 
+    class {"::quickstack::load_balancer::nova":
+      frontend_pub_host    => map_params("nova_public_vip"),
+      frontend_priv_host   => map_params("nova_private_vip"),
+      frontend_admin_host  => map_params("nova_admin_vip"),
+      backend_server_names => map_params("lb_backend_server_names"),
+      backend_server_addrs => map_params("lb_backend_server_addrs"),
+    }
 
     Class['::quickstack::pacemaker::common']
     ->
@@ -90,14 +97,6 @@ class quickstack::pacemaker::nova (
       rpc_backend                   => $rpc_backend,
       scheduler_host_subset_size    => $scheduler_host_subset_size,
       verbose                       => $verbose,
-    }
-    ->
-    class {"::quickstack::load_balancer::nova":
-      frontend_pub_host    => map_params("nova_public_vip"),
-      frontend_priv_host   => map_params("nova_private_vip"),
-      frontend_admin_host  => map_params("nova_admin_vip"),
-      backend_server_names => map_params("lb_backend_server_names"),
-      backend_server_addrs => map_params("lb_backend_server_addrs"),
     }
     ->
     exec {"pcs-nova-server-set-up":

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -95,7 +95,6 @@ class quickstack::pacemaker::params (
 
   include quickstack::pacemaker::common
   include quickstack::pacemaker::mysql
-  include quickstack::load_balancer::common
   include quickstack::pacemaker::qpid
   include quickstack::pacemaker::keystone
   include quickstack::pacemaker::swift
@@ -106,14 +105,13 @@ class quickstack::pacemaker::params (
   include quickstack::pacemaker::load_balancer
 
   Class['::quickstack::pacemaker::common'] ->
+  Class['::quickstack::pacemaker::load_balancer'] ->
   Class['::quickstack::pacemaker::mysql'] ->
-  Class['::quickstack::load_balancer::common'] ->
   Class['::quickstack::pacemaker::qpid'] ->
   Class['::quickstack::pacemaker::keystone'] ->
   Class['::quickstack::pacemaker::swift'] ->
   Class['::quickstack::pacemaker::glance'] ->
   Class['::quickstack::pacemaker::nova'] ->
   Class['::quickstack::pacemaker::cinder'] ->
-  Class['::quickstack::pacemaker::heat'] ->
-  Class['::quickstack::pacemaker::load_balancer']
+  Class['::quickstack::pacemaker::heat']
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
@@ -92,7 +92,6 @@ class quickstack::pacemaker::qpid (
       private_vip => map_params("qpid_vip"),
       admin_vip   => map_params("qpid_vip"),
     } ->
-    Class['::quickstack::load_balancer::qpid'] ->
 
     exec {"pcs-qpid-server-set-up-on-this-node":
       command => "/tmp/ha-all-in-one-util.bash update_my_node_property qpid"

--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -19,6 +19,12 @@ class quickstack::pacemaker::swift (
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-swift-vip-OR-swift-is-up-on-vip']
     }
 
+    class {"::quickstack::load_balancer::swift":
+      frontend_pub_host    => map_params("swift_public_vip"),
+      backend_server_names => map_params("lb_backend_server_names"),
+      backend_server_addrs => map_params("lb_backend_server_addrs"),
+    }
+
     Class['::quickstack::pacemaker::common']
     ->
     quickstack::pacemaker::vips { "$swift_group":
@@ -68,12 +74,6 @@ class quickstack::pacemaker::swift (
       swift_is_ringserver  => true,
       swift_storage_ips    => $swift_storage_ips,
       swift_storage_device => $swift_storage_device,
-    }
-    class {"::quickstack::load_balancer::swift":
-      frontend_pub_host    => map_params("swift_public_vip"),
-      backend_server_names => map_params("lb_backend_server_names"),
-      backend_server_addrs => map_params("lb_backend_server_addrs"),
-      require              => Quickstack::Pacemaker::Vips["$swift_group"],
     }
     ->
     # no way to do this with puppet-swift, so exec for now


### PR DESCRIPTION
Moving haproxy config _before_ mysql, keystone, etc.  Note that dependencies have been removed around quickstack::load_balancer::\* classes (e.g. class {"::quickstack::load_balancer::cinder": ) within individual service manifests so their contribution to haproxy.cfg actually gets "executed" in ::quickstack::pacemaker::load_balancer without causing dependency cycle issues.
