### PR TITLE
Install the ceilometer alarm evaluator and notifier services

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer_controller.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer_controller.pp
@@ -60,6 +60,12 @@ class quickstack::ceilometer_controller(
         enabled => true,
     }
 
+    class { 'ceilometer::alarm::notifier':
+    }
+
+    class { 'ceilometer::alarm::evaluator':
+    }
+
     class { 'ceilometer::api':
         keystone_host     => $controller_priv_host,
         keystone_password => $ceilometer_user_password,


### PR DESCRIPTION
The ceilometer alarm evaluator and notifier services are added
to the ceilometer controller manifest.

Fixes-Bug: rhbz#1111158
