### PR TITLE
BZ #1111656 - Horizon puppet error for HA-all-in-one-controller

### DIFF
--- a/puppet/modules/quickstack/manifests/horizon.pp
+++ b/puppet/modules/quickstack/manifests/horizon.pp
@@ -34,6 +34,11 @@ class quickstack::horizon(
     apache::listen { '443': }
   }
 
+  # needed for https://bugzilla.redhat.com/show_bug.cgi?id=1111656
+  class { 'apache':
+    default_vhost => false,
+  }
+
   class {'::horizon':
     bind_address          => $bind_address,
     cache_server_ip       => $cache_server_ip,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1111656

Puppet no longer errors and horizon gets configured.
Thanks to xbezdick for finding the fix.
