### PR TITLE
Included quickstack::load_balancer::common

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
@@ -1,6 +1,7 @@
 class quickstack::pacemaker::load_balancer {
 
   include quickstack::pacemaker::common
+  include quickstack::load_balancer::common
 
   $loadbalancer_group = map_params("loadbalancer_group")
   $loadbalancer_vip   = map_params("loadbalancer_vip")


### PR DESCRIPTION
into quickstack::pacemaker::load_balancer

To avoid following error when all $include_\* are false (testing use cases):
"Could not find resource 'Service[haproxy]' for relationship from 'Quickstack::Pacemaker::Vips[loadbalancer]'"
