### PR TITLE
HAProxy config for galera must use httpchk

### DIFF
--- a/puppet/modules/quickstack/manifests/load_balancer/galera.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/galera.pp
@@ -13,7 +13,7 @@ class quickstack::load_balancer::galera (
     addr                 => [ $frontend_pub_host ],
     port                 => "$public_port",
     mode                 => "$public_mode",
-    listen_options       => { 'option'     => [ "$log" ],
+    listen_options       => { 'option' => [ "$log", 'httpchk' ],
                               'stick-table' => 'type ip size 2',
                               'stick' => 'on dst', },
     member_options       => [ 'check', 'port 9200' ],


### PR DESCRIPTION
Since galera's health-check is determined by an HTTP response from the
galera-monitor xinetd service, 'option httpchk' must be used.
