### PR TITLE
BZ #1110773 - ML2 l2population is missing from plugin.ini config

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -9,7 +9,7 @@ class quickstack::neutron::all (
   $external_network_bridge       = 'br-ex',
   $ml2_type_drivers              = ['local', 'flat', 'vlan', 'gre', 'vxlan'],
   $ml2_tenant_network_types      = ['vxlan', 'vlan', 'gre', 'flat'],
-  $ml2_mechanism_drivers         = ['openvswitch'],
+  $ml2_mechanism_drivers         = ['openvswitch','l2population'],
   $ml2_flat_networks             = ['*'],
   $ml2_network_vlan_ranges       = ['10:50'],
   $ml2_tunnel_id_ranges          = ['20:100'],

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -21,6 +21,7 @@ class quickstack::neutron::compute (
   $ovs_vlan_ranges             = $quickstack::params::ovs_vlan_ranges,
   $ovs_tunnel_iface            = 'eth1',
   $ovs_tunnel_network          = '',
+  $ovs_l2_population           = 'True',
   $amqp_provider               = $quickstack::params::amqp_provider,
   $amqp_host                   = $quickstack::params::amqp_host,
   $amqp_port                   = '5672',
@@ -86,6 +87,9 @@ class quickstack::neutron::compute (
     tunnel_id_ranges    => $tunnel_id_ranges,
     vxlan_udp_port      => $ovs_vxlan_udp_port,
   }
+
+  neutron_plugin_ovs { 'AGENT/l2_population': value => "$ovs_l2_population"; }
+
   $local_ip = find_ip("$ovs_tunnel_network","$ovs_tunnel_iface","")
   class { '::neutron::agents::ovs':
     bridge_uplinks   => $ovs_bridge_uplinks,

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -9,6 +9,7 @@ class quickstack::neutron::networker (
   $controller_priv_host          = $quickstack::params::controller_priv_host,
   $ovs_tunnel_iface              = 'eth1',
   $ovs_tunnel_network            = '',
+  $ovs_l2_population             = 'True',
   $mysql_host                    = $quickstack::params::mysql_host,
   $amqp_provider                 = $quickstack::params::amqp_provider,
   $amqp_host                     = $quickstack::params::amqp_host,
@@ -69,6 +70,8 @@ class quickstack::neutron::networker (
     tunnel_id_ranges    => $tunnel_id_ranges,
     vxlan_udp_port      => $ovs_vxlan_udp_port,
   }
+
+  neutron_plugin_ovs { 'AGENT/l2_population': value => "$ovs_l2_population"; }
 
   $local_ip = find_ip("$ovs_tunnel_network","$ovs_tunnel_iface","")
 

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -5,7 +5,7 @@ class quickstack::pacemaker::neutron (
   $external_network_bridge    = 'br-ex',
   $ml2_type_drivers           = ['local', 'flat', 'vlan', 'gre', 'vxlan'],
   $ml2_tenant_network_types   = ['vxlan', 'vlan', 'gre', 'flat'],
-  $ml2_mechanism_drivers      = ['openvswitch'],
+  $ml2_mechanism_drivers      = ['openvswitch','l2population'],
   $ml2_flat_networks          = ['*'],
   $ml2_network_vlan_ranges    = ['10:50'],
   $ml2_tunnel_id_ranges       = ['20:100'],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1110773

Add a param for l2_population config to compute and networker.
Include l2population mechanism by default in
controller/neutron-server.
