### PR TITLE
Add start-delay to galera (mysqld) pacemaker resource

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -90,8 +90,9 @@ class quickstack::pacemaker::galera (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include galera",
     } ->
     quickstack::pacemaker::resource::service {'mysqld':
-      group => "$pcmk_galera_group",
-      clone => true,
+      group          => "$pcmk_galera_group",
+      monitor_params => { 'start-delay' => '60s' },
+      clone          => true,
     }
   }
 }


### PR DESCRIPTION
This patch sets the start-delay for the galera (mysqld) service to 60 seconds. This should give the service enough time to start before pacemaker begins monitoring.
