### PR TITLE
a less fragile check for cluster_control_ip in pcmk setup

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -47,7 +47,7 @@ class quickstack::pacemaker::common (
 ) {
   include quickstack::pacemaker::params
 
-  if (map_params("cluster_control_ip") == map_params("local_bind_addr")) {
+  if has_interface_with("ipaddress", map_params("cluster_control_ip")) {
     $setup_cluster = true
   } else {
     $setup_cluster = false


### PR DESCRIPTION
Updating the cluster_control_ip check on one line to be consistent with everywhere else (and also less fragile).
