### PR TITLE
kvm config in compute nodes by puppet fact

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -372,7 +372,6 @@ params = {
   "horizon_key"                   => "/etc/pki/tls/private/PUB_HOST-horizon.key",
   "amqp_nssdb_password"           => SecureRandom.hex,
   "fence_xvm_key_file_password"   => SecureRandom.hex,
-  "use_qemu_for_poc"              => "false",
   "secret_key"                    => SecureRandom.hex,
   "admin_token"                   => SecureRandom.hex,
   "gluster_device1"               => '/dev/vdb',

--- a/puppet/modules/quickstack/lib/facter/kvm_capable.rb
+++ b/puppet/modules/quickstack/lib/facter/kvm_capable.rb
@@ -1,0 +1,5 @@
+Facter.add("kvm_capable") do
+  setcode do
+    File.readlines("/proc/cpuinfo").grep(/(vmx|svm)/).any?
+  end
+end

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -35,7 +35,6 @@ class quickstack::neutron::compute (
   $verbose                     = $quickstack::params::verbose,
   $ssl                         = $quickstack::params::ssl,
   $mysql_ca                    = $quickstack::params::mysql_ca,
-  $use_qemu_for_poc            = $quickstack::params::use_qemu_for_poc,
 ) inherits quickstack::params {
 
   if str2bool_i("$ssl") {
@@ -128,7 +127,6 @@ class quickstack::neutron::compute (
     verbose                    => $verbose,
     ssl                        => $ssl,
     mysql_ca                   => $mysql_ca,
-    use_qemu_for_poc           => $use_qemu_for_poc,
   }
 
   class {'quickstack::neutron::firewall::gre':}

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -34,7 +34,6 @@ class quickstack::nova_network::compute (
   $verbose                      = $quickstack::params::verbose,
   $ssl                          = $quickstack::params::ssl,
   $mysql_ca                     = $quickstack::params::mysql_ca,
-  $use_qemu_for_poc             = $quickstack::params::use_qemu_for_poc,
 ) inherits quickstack::params {
 
   # Configure Nova
@@ -90,6 +89,5 @@ class quickstack::nova_network::compute (
     verbose                    => $verbose,
     ssl                        => $ssl,
     mysql_ca                   => $mysql_ca,
-    use_qemu_for_poc           => $use_qemu_for_poc,
   }
 }

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -173,9 +173,6 @@ class quickstack::params {
   $fence_ipmilan_password        = ''
   $fence_ipmilan_interval        = '60s'
 
-  # Nova Compute
-  $use_qemu_for_poc              = 'false'
-
   # Gluster Servers
   $gluster_device1       = '/dev/vdb'
   $gluster_device2       = '/dev/vdc'


### PR DESCRIPTION
Tested for config sanity -- that the fact returns true on bare metal when it should, and false otherwise if vmx or svm flags are not present, and that the right thing happens with the quickstack::nova::compute node when running in a non-kvm VM (i.e: grep -P '^virt_type' /etc/nova/nova.conf shows
virt_type=qemu
 ).
