### PR TITLE
Set network_size to undefined by default

### DIFF
--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -21,7 +21,7 @@ class quickstack::nova_network::compute (
   $network_manager              = 'FlatDHCPManager',
   $network_create_networks      = true,
   $network_num_networks         = 1,
-  $network_network_size         = 255,
+  $network_network_size         = '',
   $network_overrides            = {"force_dhcp_release" => false},
   $network_fixed_range          = '10.0.0.0/24',
   $network_floating_range       = '10.0.0.0/24',


### PR DESCRIPTION
quickstack defaults the network_size parameter for nova-network to
255.  This parameter is used as an argument to nova-manage when
pre-creating networks.  The better default is to leave it unspecified
and to allow nova to calculate the network size.

This is particularly relevant for the case of using VlanManager with
nova-network.  We don't want to force tenant networks of size 255.  We
should let Nova calculate the appropriate network size based on the
number of networks being created and the full range of addresses
provided that is being broken up into separate tenant networks.

A UI may want to allow this parameter to be specified.  If a user
specifies a value, great.  Otherwise, we should let Nova do its thing.
