### PR TITLE
Change network_floating_range default

### DIFF
--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -24,7 +24,7 @@ class quickstack::nova_network::compute (
   $network_network_size         = 255,
   $network_overrides            = {"force_dhcp_release" => false},
   $network_fixed_range          = '10.0.0.0/24',
-  $network_floating_range       = '10.0.0.0/24',
+  $network_floating_range       = '10.0.1.0/24',
   $amqp_provider                = $quickstack::params::amqp_provider,
   $amqp_host                    = $quickstack::params::amqp_host,
   $amqp_port                    = '5672',


### PR DESCRIPTION
The defaults for the network_fixed_range and network_floating_range
parameters were the same.  Even if this is just defaults that we
expect to be overridden, they should not be the same as that would be
a broken configuration.  They must be separate networks.  Go ahead and
change the defaults of one of them (floating in this case) to be
something that would work.
