### PR TITLE
BZ #1113294 - HA cinder db_sync fails on 2nd and 3rd nodes

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -67,7 +67,7 @@ class quickstack::pacemaker::cinder(
     $glance_host          = map_params("glance_admin_vip")
     $keystone_host        = map_params("keystone_admin_vip")
 
-    Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip'] -> Exec['cinder-manage db_sync']
+    Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip'] -> Exec['cinder-manage db_sync'] -> Exec['pcs-cinder-server-set-up']
     if (map_params('include_mysql') == 'true') {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -38,7 +38,7 @@ class quickstack::pacemaker::glance (
 
     Exec['i-am-glance-vip-OR-glance-is-up-on-vip'] -> Service['glance-api']
     Exec['i-am-glance-vip-OR-glance-is-up-on-vip'] -> Service['glance-registry']
-    Exec['i-am-glance-vip-OR-glance-is-up-on-vip'] -> Exec['glance-manage db_sync']
+    Exec['i-am-glance-vip-OR-glance-is-up-on-vip'] -> Exec['glance-manage db_sync'] -> Exec['pcs-glance-server-set-up']
 
     if (map_params('include_mysql') == 'true') {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1113294

Add a puppet dependency to make sure that the first node completes a
db_sync before it is attempted on the other HA nodes.  The same logic
applies for cinder and glance.
