### PR TITLE
Remove neutron-db-check from the pacemaker neutron class

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -121,8 +121,6 @@ class quickstack::pacemaker::neutron (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include neutron",
     }
     ->
-    class {"quickstack::pacemaker::neutron_db_check":}
-    ->
     quickstack::pacemaker::resource::service {'neutron-server':
       clone => true,
       monitor_params => { 'start-delay' => '10s' },


### PR DESCRIPTION
The neutron-db-check causes problems (it does not correctly detect lsb
vs. systemd), and as such, when it fails, nothing else in the class
runs, leaving no pcs neutron resources. The neutron-db-check does not
appear to be necessary for the proper operation of neutron.
