### PR TITLE
Fix File dep issue for gluster on compute.

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -29,6 +29,7 @@ class quickstack::compute_common (
     if defined('gluster::client') {
       class { 'gluster::client': }
     } else {
+      include ::puppet::vardir
       class { 'gluster::mount::base': repo => false }
     }
 


### PR DESCRIPTION
gluster::mount::base pulls in gluster::vardir for temorary write of files, but
that in turn needs _some_ tmp dir set up.  The gluster module is set up so the
admin can set up whatever they prefer for that tmp dir, but the one in
puppet::vardir is what we will use for now, so this simply makes sure that dir
is there.
