### PR TITLE
BZ #1118513 - Rsync Get errors with exit code 23.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/rsync/get.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rsync/get.pp
@@ -64,9 +64,11 @@ define quickstack::pacemaker::rsync::get (
   $rsync_options = "-${override_options} ${MyPurge} ${MyExclude} ${MyUser}${source} ${MyPath}"
 
   exec { "rsync ${name}":
-    command => "rsync -q ${rsync_options}",
-    path    => [ '/bin', '/usr/bin' ],
-    timeout => $timeout,
-    unless  => "$unless",
+    command   => "rsync -q ${rsync_options}",
+    path      => [ '/bin', '/usr/bin' ],
+    timeout   => $timeout,
+    tries     => 360,
+    try_sleep => 10,
+    unless    => "$unless",
   }
 }


### PR DESCRIPTION
If the primary node has not finished creating all the files to be transfers, the
client 'get' call can return an error, as they cannot all be retrieved.
