### PR TITLE
Open port 9200 for galera monitor

### DIFF
--- a/puppet/modules/quickstack/manifests/firewall/galera.pp
+++ b/puppet/modules/quickstack/manifests/firewall/galera.pp
@@ -1,5 +1,6 @@
 class quickstack::firewall::galera (
   $mysql_port      = '3306',
+  $monitor_port    = '9200',
   $galera_port     = '4567',
   $galera_ist_port = '4568',
   $galera_sst_port = '4444',
@@ -9,7 +10,7 @@ class quickstack::firewall::galera (
 
   firewall { '001 galera incoming':
     proto  => 'tcp',
-    dport  => ["$mysql_port", "$galera_port", "$galera_ist_port", "$galera_sst_port" ],
+    dport  => ["$mysql_port", "$monitor_port", "$galera_port", "$galera_ist_port", "$galera_sst_port" ],
     action => 'accept',
   }
 }


### PR DESCRIPTION
The xinetd service that we use to healthcheck galera listens on port 9200. This port needs to be open for the healthcheck to work.
