### PR TITLE
Added monitoring with nagios

### DIFF
--- a/bin/seeds.rb
+++ b/bin/seeds.rb
@@ -408,6 +408,10 @@ params = {
   "wsrep_ssl"                     => true,
   "wsrep_ssl_key"                 => "/etc/pki/galera/galera.key",
   "wsrep_ssl_cert"                => "/etc/pki/galera/galera.crt",
+  "monitoring"                    => 'nagios',
+  "monitoring_adm_passwd"         => SecureRandom.hex,
+  "monitoring_host"               => '172.16.0.1',
+  "monitoring_interface"          => 'eth0',
 }
 
 hostgroups = [
@@ -452,7 +456,9 @@ hostgroups = [
               "quickstack::gluster::server",
              ]},
     {:name=>"Galera Server",
-     :class=>"quickstack::galera::server"}
+     :class=>"quickstack::galera::server"},
+    {:name=>"Nagios Server",
+     :class=>"quickstack::monitoring::server"}
 ]
 
 def get_key_type(value)

--- a/config/hostgroups.yaml
+++ b/config/hostgroups.yaml
@@ -41,3 +41,5 @@
   - quickstack::gluster::server
 - :name: Galera Server
   :class: quickstack::galera::server
+- :name: Nagios Server
+  :class: quickstack::monitoring::server

--- a/config/quickstack.yaml.erb
+++ b/config/quickstack.yaml.erb
@@ -177,3 +177,7 @@ wsrep_sst_password: <%= passwd_auto %>
 wsrep_ssl: true
 wsrep_ssl_key: /etc/pki/galera/galera.key
 wsrep_ssl_cert: /etc/pki/galera/galera.crt
+monitoring: nagios
+monitoring_adm_passwd: <%= passwd_auto %>
+monitoring_host: 172.16.0.1
+monitoring_interface: eth0

--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -18,8 +18,8 @@ class quickstack::compute_common (
   $ceilometer                   = 'true',
   $ceilometer_metering_secret   = $quickstack::params::ceilometer_metering_secret,
   $ceilometer_user_password     = $quickstack::params::ceilometer_user_password,
-  $ceph_cluster_network         = '', 
-  $ceph_public_network          = '', 
+  $ceph_cluster_network         = '',
+  $ceph_public_network          = '',
   $ceph_fsid                    = '',
   $ceph_images_key              = '',
   $ceph_volumes_key             = '',
@@ -35,6 +35,9 @@ class quickstack::compute_common (
   $libvirt_inject_password      = 'false',
   $libvirt_inject_key           = 'false',
   $libvirt_images_type          = 'rbd',
+  $monitoring                   = $quickstack::params::monitoring,
+  $monitoring_host              = $quickstack::params::monitoring_host,
+  $monitoring_interface         = $quickstack::params::monitoring_interface,
   $mysql_ca                     = $quickstack::params::mysql_ca,
   $mysql_host                   = $quickstack::params::mysql_host,
   $nova_host                    = '127.0.0.1',
@@ -219,5 +222,13 @@ class quickstack::compute_common (
     proto  => 'tcp',
     dport  => '5900-5999',
     action => 'accept',
+  }
+
+  if ($monitoring) {
+    class {'quickstack::monitoring::client':
+      monitoring           => $monitoring,
+      monitoring_host      => $monitoring_host,
+      monitoring_interface => $monitoring_interface,
+    }
   }
 }

--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -61,6 +61,9 @@ class quickstack::controller_common (
   $keystone_db_password          = $quickstack::params::keystone_db_password,
   $keystonerc                    = false,
   $neutron_metadata_proxy_secret = $quickstack::params::neutron_metadata_proxy_secret,
+  $monitoring                    = $quickstack::params::monitoring,
+  $monitoring_host               = $quickstack::params::monitoring_host,
+  $monitoring_interface          = $quickstack::params::monitoring_interface,
   $mysql_host                    = $quickstack::params::mysql_host,
   $mysql_root_password           = $quickstack::params::mysql_root_password,
   $neutron                       = $quickstack::params::neutron,
@@ -92,7 +95,6 @@ class quickstack::controller_common (
   $horizon_cert                  = $quickstack::params::horizon_cert,
   $horizon_key                   = $quickstack::params::horizon_key,
   $amqp_nssdb_password           = $quickstack::params::amqp_nssdb_password,
-
 ) inherits quickstack::params {
 
   class {'quickstack::openstack_common': }
@@ -491,4 +493,11 @@ class quickstack::controller_common (
     }
   }
 
+  if ($monitoring) {
+    class {'quickstack::monitoring::client':
+      monitoring           => $monitoring,
+      monitoring_host      => $monitoring_host,
+      monitoring_interface => $monitoring_interface,
+    }
+  }
 }

--- a/puppet/modules/quickstack/manifests/monitoring/client.pp
+++ b/puppet/modules/quickstack/manifests/monitoring/client.pp
@@ -1,0 +1,21 @@
+# Quickstack Monitoring client
+class quickstack::monitoring::client (
+  $monitoring,
+  $monitoring_host,
+  $monitoring_interface,
+) {
+  case $monitoring {
+    'nagios': {
+      class {'nagios::client':
+        monitored_ip       => getvar("ipaddress_${monitoring_interface}"),
+        nagios_server_host => $monitoring_host,
+      }
+
+      firewall {'001 Nagios NRPE incoming':
+        proto  => 'tcp',
+        dport  => '5666',
+        action => 'accept',
+      }
+    }
+  }
+}

--- a/puppet/modules/quickstack/manifests/monitoring/server.pp
+++ b/puppet/modules/quickstack/manifests/monitoring/server.pp
@@ -1,0 +1,23 @@
+# Quickstack Monitoring Server
+class quickstack::monitoring::server (
+  $admin_password,
+  $monitoring,
+  $monitoring_adm_passwd,
+  $controller_admin_host,
+) {
+  case $monitoring {
+    'nagios': {
+      class {'nagios::server':
+        admin_password       => $monitoring_adm_passwd,
+        openstack_adm_passwd => $admin_password,
+        openstack_controller => $controller_admin_host,
+      }
+
+      firewall {'001 Nagios Server incoming':
+        proto    => 'tcp',
+        dport    => ['80'],
+        action   => 'accept',
+      }
+    }
+  }
+}

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -19,6 +19,9 @@ class quickstack::neutron::compute (
   $glance_host                  = '127.0.0.1',
   $nova_host                    = '127.0.0.1',
   $enable_tunneling             = $quickstack::params::enable_tunneling,
+  $monitoring                   = $quickstack::params::monitoring,
+  $monitoring_host              = $quickstack::params::monitoring_host,
+  $monitoring_interface         = $quickstack::params::monitoring_interface,
   $mysql_host                   = $quickstack::params::mysql_host,
   $neutron_db_password          = $quickstack::params::neutron_db_password,
   $neutron_user_password        = $quickstack::params::neutron_user_password,
@@ -166,6 +169,9 @@ class quickstack::neutron::compute (
     private_iface                => $private_iface,
     private_ip                   => $private_ip,
     private_network              => $private_network,
+    monitoring                 => $monitoring,
+    monitoring_host            => $monitoring_host,
+    monitoring_interface       => $monitoring_interface,
   }
 
   class {'quickstack::neutron::firewall::gre':}

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -111,6 +111,9 @@ class quickstack::neutron::controller (
   $horizon_cert                  = $quickstack::params::horizon_cert,
   $horizon_key                   = $quickstack::params::horizon_key,
   $amqp_nssdb_password           = $quickstack::params::amqp_nssdb_password,
+  $monitoring                    = $quickstack::params::monitoring,
+  $monitoring_host               = $quickstack::params::monitoring_host,
+  $monitoring_interface          = $quickstack::params::monitoring_interface,
 ) inherits quickstack::params {
 
   if str2bool_i("$ssl") {
@@ -215,6 +218,9 @@ class quickstack::neutron::controller (
     horizon_cert                  => $horizon_cert,
     horizon_key                   => $horizon_key,
     amqp_nssdb_password           => $amqp_nssdb_password,
+    monitoring                    => $monitoring,
+    monitoring_host               => $monitoring_host,
+    monitoring_interface          => $monitoring_interface,
   }
   ->
   class { '::neutron':

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -27,6 +27,9 @@ class quickstack::neutron::networker (
   $verbose                       = $quickstack::params::verbose,
   $ssl                           = $quickstack::params::ssl,
   $mysql_ca                      = $quickstack::params::mysql_ca,
+  $monitoring                    = $quickstack::params::monitoring,
+  $monitoring_host               = $quickstack::params::monitoring_host,
+  $monitoring_interface          = $quickstack::params::monitoring_interface,
 ) inherits quickstack::params {
 
   class {'quickstack::openstack_common': }
@@ -105,5 +108,13 @@ class quickstack::neutron::networker (
 
   class {'quickstack::neutron::firewall::vxlan':
     port => $ovs_vxlan_udp_port,
+  }
+
+  if ($monitoring) {
+    class {'quickstack::monitoring::client':
+      monitoring           => $monitoring,
+      monitoring_host      => $monitoring_host,
+      monitoring_interface => $monitoring_interface,
+    }
   }
 }

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -18,6 +18,9 @@ class quickstack::nova_network::compute (
   $glance_backend_rbd           = 'false',
   $glance_host                  = '127.0.0.1',
   $nova_host                    = '127.0.0.1',
+  $monitoring                   = $quickstack::params::monitoring,
+  $monitoring_host              = $quickstack::params::monitoring_host,
+  $monitoring_interface         = $quickstack::params::monitoring_interface,
   $mysql_host                   = $quickstack::params::mysql_host,
   $auto_assign_floating_ip      = 'True',
   $nova_multi_host              = 'True',
@@ -53,7 +56,6 @@ class quickstack::nova_network::compute (
   $private_iface                = '',
   $private_ip                   = '',
   $private_network              = '',
-
 ) inherits quickstack::params {
 
   # Configure Nova
@@ -129,5 +131,8 @@ class quickstack::nova_network::compute (
     private_iface                => $private_iface,
     private_ip                   => $private_ip,
     private_network              => $private_network,
+    monitoring                   => $monitoring,
+    monitoring_host              => $monitoring_host,
+    monitoring_interface         => $monitoring_interface,
   }
 }

--- a/puppet/modules/quickstack/manifests/nova_network/controller.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/controller.pp
@@ -87,6 +87,9 @@ class quickstack::nova_network::controller (
   $horizon_cert                  = $quickstack::params::horizon_cert,
   $horizon_key                   = $quickstack::params::horizon_key,
   $amqp_nssdb_password           = $quickstack::params::amqp_nssdb_password,
+  $monitoring                    = $quickstack::params::monitoring,
+  $monitoring_host               = $quickstack::params::monitoring_host,
+  $monitoring_interface          = $quickstack::params::monitoring_interface,
 
   $auto_assign_floating_ip
 ) inherits quickstack::params {
@@ -187,5 +190,9 @@ class quickstack::nova_network::controller (
     horizon_cert                 => $horizon_cert,
     horizon_key                  => $horizon_key,
     amqp_nssdb_password          => $amqp_nssdb_password,
+
+    monitoring                 => $monitoring,
+    monitoring_host            => $monitoring_host,
+    monitoring_interface       => $monitoring_interface,
   }
 }

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -86,6 +86,13 @@ class quickstack::params (
   # Gluster
   $gluster_open_port_count      = '10',
 
+  # Monitoring
+  # Options are none ('') or 'nagios' for now
+  $monitoring                   = '',
+  $monitoring_host              = '172.16.0.1',
+  $monitoring_interface         = 'eth0',
+  $monitoring_adm_passwd        = 'CHANGEME',
+
   # Networking
   $neutron                       = 'false',
   $controller_admin_host         = '172.16.0.1',


### PR DESCRIPTION
This new version is using an external puppet nagios module.
Which makes more sense since this is not directly related with openstack anyway.
This has the advantage to reduce impact on quickstack as much as possible.

This add a 'Nagios hostgroup' and monitoring::server and monitoring::client to wrap calls to the external nagios module. 

This is impacting only non HA to start with (Neutron/Nova_network controllers/compute/networker) 

Tested with latest RHOS5/RHEL7 

This requires:
- BZ#1118537 - Nagios plugins (load and disk) to be added to RHOS repos
- https://github.com/redhat-openstack/openstack-puppet-modules/pull/83
