### PR TITLE
Add support to enable ML2 Cisco Nexus plugin

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -113,6 +113,14 @@ class quickstack::neutron::all (
       vni_ranges            => $ml2_vni_ranges,
       enable_security_group => $ml2_security_group,
     }
+
+    # If cisco nexus is part of ml2 mechanism drivers,
+    # setup Mech Driver Cisco Neutron plugin class.
+    if ('cisco_nexus' in $ml2_mechanism_drivers) {
+      class { 'neutron::plugins::ml2::cisco::nexus':
+        nexus_config        => $nexus_config,
+      }
+    }
   }
 
   if $neutron_core_plugin == 'neutron.plugins.cisco.network_plugin.PluginV2' {

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -271,6 +271,14 @@ class quickstack::neutron::controller (
       enable_security_group => str2bool_i("$ml2_security_group"),
       firewall_driver       => $ml2_firewall_driver,
     }
+
+    # If cisco nexus is part of ml2 mechanism drivers,
+    # setup Mech Driver Cisco Neutron plugin class.
+    if ('cisco_nexus' in $ml2_mechanism_drivers) {
+      class { 'neutron::plugins::ml2::cisco::nexus':
+        nexus_config        => $nexus_config,
+      }
+    }
   }
 
   if $neutron_core_plugin == 'neutron.plugins.cisco.network_plugin.PluginV2' {


### PR DESCRIPTION
NOTE: This requires upstream changes to puppet-neutron 
master: https://review.openstack.org/#/c/101338/
icehouse: https://review.openstack.org/#/c/110347/
