### PR TITLE
Refactor amqp provider selection for HA deployment

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -45,8 +45,7 @@ class quickstack::pacemaker::params (
   $include_mysql             = 'true',
   $include_neutron           = 'true',
   $include_nova              = 'true',
-  $include_qpid              = 'false',
-  $include_rabbitmq          = 'true',
+  $include_amqp              = 'true',
   $include_swift             = 'true',
   $loadbalancer_vip          = '',
   $loadbalancer_group        = 'loadbalancer',
@@ -75,6 +74,7 @@ class quickstack::pacemaker::params (
   $private_ip                = '',
   $private_iface             = '',
   $private_network           = '',
+  $amqp_provider             = 'rabbitmq',
   $amqp_port                 = '5672',
   $amqp_vip                  = '',
   $amqp_group                = 'amqp',
@@ -87,17 +87,6 @@ class quickstack::pacemaker::params (
   $local_bind_addr = find_ip("$private_network",
                             "$private_iface",
                             "$private_ip")
-
-  if ($include_rabbitmq == 'true' and
-      $include_qpid     == 'true') {
-    fail("include_rabbitmq and include_qpid cannot both be set")
-  }
-
-  if ($include_qpid == 'true') {
-    $amqp_provider = 'qpid'
-  } else {
-    $amqp_provider = 'rabbitmq'
-  }
 
   include quickstack::pacemaker::common
   include quickstack::pacemaker::load_balancer

--- a/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
@@ -30,7 +30,8 @@ class quickstack::pacemaker::qpid (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_qpid') == 'true') {
+  if (map_params('include_amqp') == 'true' and
+      map_params('amqp_provider') == 'qpid') {
     $amqp_group = map_params("amqp_group")
     $amqp_username = map_params("amqp_username")
     $amqp_password = map_params("amqp_password")

--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -5,7 +5,8 @@ class quickstack::pacemaker::rabbitmq (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_rabbitmq') == 'true') {
+  if (map_params('include_amqp') == 'true' and
+      map_params('amqp_provider') == 'rabbitmq') {
     $amqp_group = map_params("amqp_group")
     $amqp_username = map_params("amqp_username")
     $amqp_password = map_params("amqp_password")


### PR DESCRIPTION
- Add amqp_provider parameter to quickstack::pacemaker::params, so
  staypuft can pass the UI selection in properly
- Remove include_{rabbitmq,qpid} parameters and replace with unified
  include_amqp parameters instead.
- Use above changes to toggle the rabbitmq and qpid classes on and off
  accordingly.
