### PR TITLE
name rabbitmq nodes with short hostnames (bz1119429)

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -9,6 +9,7 @@ class quickstack::pacemaker::rabbitmq (
     $amqp_group = map_params("amqp_group")
     $amqp_username = map_params("amqp_username")
     $amqp_password = map_params("amqp_password")
+    $cluster_nodes = regsubst(map_params("lb_backend_server_names"), '\..*', '')
 
     class {'::quickstack::firewall::amqp':
       ports => [ map_params("amqp_port"), "${inet_dist_listen}", 4369 ]
@@ -19,7 +20,7 @@ class quickstack::pacemaker::rabbitmq (
                                    'inet_dist_listen_max' => "${inet_dist_listen}"},
       wipe_db_on_cookie_change => true,
       config_cluster           => true,
-      cluster_nodes            => map_params("lb_backend_server_names"),
+      cluster_nodes            => $cluster_nodes,
       node_ip_address          => map_params("local_bind_addr"),
       port                     => map_params("amqp_port"),
       default_user             => $amqp_username,


### PR DESCRIPTION
RabbitMQ node names must be short names, not fqdn.  For example,
'node1.example.org' is invalid, but 'node1' is valid.  This strips off
the domain part of the hostname when creating the cluster node names.
