### PR TITLE
BZ #1118067 - Intermittent incompletion of puppet run on compute nodes.

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -125,6 +125,7 @@ class quickstack::compute_common (
 
     class { 'ceilometer::agent::compute':
       enabled => true,
+      require => Package['nova-common'],
     }
   }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1118067

It seems that ceilometer::compute depends on a nova user group existing, which
may or may not have been created yet with the existing code.  Add an ordering
dependency to make sure nova is installed and configured first.
