### PR TITLE
updated quickstack/manifests/pacemaker/neutron.pp to include

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -126,30 +126,54 @@ class quickstack::pacemaker::neutron (
       monitor_params => { 'start-delay' => '10s' },
     }
     ->
-    # unreliable systemd script to  manage (see howto)
-    #quickstack::pacemaker::resource::service {'neutron-ovs-cleanup':
-    #  group => "neutron-agents-pre",
-    #  clone => false,
-    #}
-    #->
+    quickstack::pacemaker::resource::ocf {'neutron-ovs-cleanup':
+      resource_name => 'neutron:OVSCleanup',
+      clone         => true,
+    }
+    ->
+    quickstack::pacemaker::resource::ocf {'neutron-netns-cleanup':
+      resource_name => 'neutron:NetnsCleanup',
+      clone         => true,
+    }
+    ->
     quickstack::pacemaker::resource::service {'neutron-openvswitch-agent':
+      group => "neutron-agents",
       clone => false,
       monitor_params => { 'start-delay' => '10s' },
     }
     ->
     quickstack::pacemaker::resource::service {'neutron-dhcp-agent':
+      group => "neutron-agents",
       clone => false,
       monitor_params => { 'start-delay' => '10s' },
     }
     ->
     quickstack::pacemaker::resource::service {'neutron-l3-agent':
+      group => "neutron-agents",
       clone => false,
       monitor_params => { 'start-delay' => '10s' },
     }
     ->
     quickstack::pacemaker::resource::service {'neutron-metadata-agent':
+      group => "neutron-agents",
       clone => false,
       monitor_params => { 'start-delay' => '10s' },
+    }
+    ->
+    quickstack::pacemaker::constraint::base { 'neutron-ovs-to-netns-cleanup-constr' :
+      constraint_type => "order",
+      first_resource  => "neutron-ovs-cleanup",
+      second_resource => "neutron-netns-cleanup",
+      first_action    => "start",
+      second_action   => "start",
+    }
+    ->
+    quickstack::pacemaker::constraint::base { 'neutron-cleanup-to-agents-constr' :
+      constraint_type => "order",
+      first_resource  => "neutron-netns-cleanup",
+      second_resource => "neutron-agents",
+      first_action    => "start",
+      second_action   => "start",
     }
     ->
     quickstack::pacemaker::constraint::base { 'neutron-openvswitch-dhcp-constr' :
@@ -191,6 +215,18 @@ class quickstack::pacemaker::neutron (
     quickstack::pacemaker::constraint::colocation { 'neutron-openvswitch-metadata-colo' :
       source => "neutron-metadata-agent",
       target => "neutron-openvswitch-agent",
+      score  => "INFINITY",
+    }
+    ->
+    quickstack::pacemaker::constraint::colocation { 'neutron-netns-ovs-cleanup-colo' :
+      source => "neutron-netns-cleanup",
+      target => "neutron-ovs-cleanup",
+      score  => "INFINITY",
+    }
+    ->
+    quickstack::pacemaker::constraint::colocation { 'neutron-agents-with-netns-cleanup-colo' :
+      source => "neutron-agents",
+      target => "neutron-netns-cleanup",
       score  => "INFINITY",
     }
   }


### PR DESCRIPTION
neutron-agents-pre group, which handles the cleanup of agent
resources (qrouter, qdhcp, etc..) when those are migrated to
different hosts.

It's done to match ocf changes around that line.

https://github.com/fabbione/rhos-ha-deploy/blob/master/rhos5-rhel7/mrgcloud-setup/RHOS-RHEL-HA-how-to-mrgcloud-rhos5-on-rhel7-neutron-n-latest.txt#L104

I'm not 100% sure the if our 'clone' at lines 131 and 136 is equivalent to the clone in line L104.
