### PR TITLE
BZ#1121760 - Run clustercheck before setting galera property

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -80,6 +80,12 @@ class quickstack::pacemaker::galera (
     exec {"pcs-galera-server-setup":
       command => "/usr/sbin/pcs property set galera=running --force",
     } ->
+    exec {"clustercheck-sync":
+      timeout   => 3600,
+      tries     => 360,
+      try_sleep => 10,
+      command   => "/usr/bin/clustercheck >/dev/null",
+    } ->
     exec {"pcs-galera-server-set-up-on-this-node":
       command => "/tmp/ha-all-in-one-util.bash update_my_node_property galera"
     } ->


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1121760

This patch adds a check to see if the node is fully syncd before
setting the galera property.
