### PR TITLE
[OPTION 1] BZ#1122701 - Incoming ports are wide open

### DIFF
--- a/puppet/modules/quickstack/manifests/openstack_common.pp
+++ b/puppet/modules/quickstack/manifests/openstack_common.pp
@@ -7,8 +7,12 @@ class quickstack::openstack_common {
           ensure => present, }
   }
 
-  # Stop firewalld since everything uses iptables
-  # for now (same as packstack did)
+  # Stop firewalld since everything uses iptables for now (same as
+  # packstack did), but save and restore the initial firewall rules
+  # (allow loopback, reject at the end of the chain etc.)
+  exec { "iptables-save-before-disabling-firewalld":
+    command => "/usr/sbin/iptables-save > /etc/sysconfig/iptables"
+  } ->
   service { "firewalld":
     ensure => "stopped",
     enable => false,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1122701

OPTION 1: Save firewall rules before disabling firewalld.

Advantage: less intrusive on puppet level. Disadvantage: saves the complete firewalld backend chains, so the resulting iptables rules are much more complicated than necessary. See http://fpaste.org/122022/35270140/

I think we should consider going with option 2.
