### PR TITLE
BZ#1124950 - Quickstack nova compute manifest not setting qpid config

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -127,6 +127,7 @@ class quickstack::neutron::compute (
     nova_db_password             => $nova_db_password,
     nova_host                    => $nova_host,
     nova_user_password           => $nova_user_password,
+    amqp_provider                => $amqp_provider,
     amqp_host                    => $amqp_host,
     amqp_port                    => $amqp_port,
     amqp_ssl_port                => $amqp_ssl_port,

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -89,6 +89,7 @@ class quickstack::nova_network::compute (
     nova_db_password             => $nova_db_password,
     nova_host                    => $nova_host,
     nova_user_password           => $nova_user_password,
+    amqp_provider                => $amqp_provider,
     amqp_host                    => $amqp_host,
     amqp_port                    => $amqp_port,
     amqp_ssl_port                => $amqp_ssl_port,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1124950
