### PR TITLE
WIP: controller_common: fixed rabbitmq provider parameters handling for glanc...

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -232,15 +232,11 @@ class quickstack::controller_common (
     rbd_store_user => $glance_rbd_store_user,
     rbd_store_pool => $glance_rbd_store_pool,
     require        => Class['quickstack::db::mysql'],
-  }
-  if $amqp_provider == 'qpid' {
-    class { 'glance::notify::qpid':
-      qpid_password => $amqp_password,
-      qpid_username => $amqp_username,
-      qpid_hostname => $amqp_host,
-      qpid_port     => $amqp_port,
-      qpid_protocol => 'tcp',
-    }
+    amqp_host      => $amqp_host,
+    amqp_port      => $amqp_port,
+    amqp_username  => $amqp_username,
+    amqp_password  => $amqp_password,
+    amqp_provider  => $amqp_provider,
   }
 
 


### PR DESCRIPTION
On the latest installation tests, glance cannot connect to rabbitmq because of missing credentials. I believe file
puppet/modules/quickstack/manifests/controller_common.pp is missing this part that handles rabbit credentials for rabbitmq provider.

File puppet/modules/quickstack/manifests/glance.pp does a similar thing, but without passing the correct parameters, the class glance::notify::rabbitmq is only using default blank credentials.
I think this patch should work, but I just wanted to notify this at the moment, test of this patch is in progress, so don't merge it yet.

 thanks
