### PR TITLE
ceph/rbd on compute: add missing nova.conf param

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -26,6 +26,7 @@ class quickstack::compute_common (
   $libvirt_images_rbd_ceph_conf = '/etc/ceph/ceph.conf',
   $libvirt_inject_password      = 'false',
   $libvirt_inject_key           = 'false',
+  $libvirt_images_type          = 'rbd',
   $rbd_user                     = 'volumes',
   $rbd_secret_uuid              = '',
 ) inherits quickstack::params {
@@ -68,6 +69,7 @@ class quickstack::compute_common (
       'DEFAULT/libvirt_inject_password':      value => $libvirt_inject_password;
       'DEFAULT/libvirt_inject_key':           value => $libvirt_inject_key;
       'DEFAULT/libvirt_inject_partition':     value => '-2';
+      'DEFAULT/libvirt_images_type':          value => $libvirt_images_type;
       'DEFAULT/rbd_user':                     value => $rbd_user;
       'DEFAULT/rbd_secret_uuid':              value => $rbd_secret_uuid;
     }

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -40,6 +40,7 @@ class quickstack::neutron::compute (
   $libvirt_images_rbd_ceph_conf = '/etc/ceph/ceph.conf',
   $libvirt_inject_password      = 'false',
   $libvirt_inject_key           = 'false',
+  $libvirt_images_type          = 'rbd',
   $rbd_user                     = 'volumes',
   $rbd_secret_uuid              = '',
 ) inherits quickstack::params {
@@ -140,6 +141,7 @@ class quickstack::neutron::compute (
     libvirt_images_rbd_ceph_conf => $libvirt_images_rbd_ceph_conf,
     libvirt_inject_password      => $libvirt_inject_password,
     libvirt_inject_key           => $libvirt_inject_key,
+    libvirt_images_type          => $libvirt_images_type,
     rbd_user                     => $rbd_user,
     rbd_secret_uuid              => $rbd_secret_uuid,
   }

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -39,6 +39,7 @@ class quickstack::nova_network::compute (
   $libvirt_images_rbd_ceph_conf = '/etc/ceph/ceph.conf',
   $libvirt_inject_password      = 'false',
   $libvirt_inject_key           = 'false',
+  $libvirt_images_type          = 'rbd',
   $rbd_user                     = 'volumes',
   $rbd_secret_uuid              = '',
 ) inherits quickstack::params {
@@ -102,6 +103,7 @@ class quickstack::nova_network::compute (
     libvirt_images_rbd_ceph_conf => $libvirt_images_rbd_ceph_conf,
     libvirt_inject_password      => $libvirt_inject_password,
     libvirt_inject_key           => $libvirt_inject_key,
+    libvirt_images_type          => $libvirt_images_type,
     rbd_user                     => $rbd_user,
     rbd_secret_uuid              => $rbd_secret_uuid,
   }


### PR DESCRIPTION
One more tweak for an rbd-related compute param.  Tested: was able to attach an rbd cinder volume to a nova instance.
