### PR TITLE
BZ#1125136 - ensure firewalld is stopped before starting iptables

### DIFF
--- a/puppet/modules/quickstack/manifests/openstack_common.pp
+++ b/puppet/modules/quickstack/manifests/openstack_common.pp
@@ -7,11 +7,12 @@ class quickstack::openstack_common {
           ensure => present, }
   }
 
-  # Stop firewalld since everything uses iptables
-  # for now (same as packstack did)
+  # Stop firewalld since everything uses iptables. Firewalld provider will
+  # have to be implemented in puppetlabs-firewall in future.
   service { "firewalld":
     ensure => "stopped",
     enable => false,
+    before => Service['iptables'],
   }
 
   service { "auditd":


### PR DESCRIPTION
There is racecondition when shutting down firewalld and starting
iptables which causes iptables service to fail.
