### PR TITLE
BZ #1123293 - start-failure-is-fatal should be true.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -149,9 +149,5 @@ class quickstack::pacemaker::common (
     exec {"pcs-resource-default":
       command => "/usr/sbin/pcs resource defaults resource-stickiness=100",
     }
-    ->
-    exec {"pcs-property-start-failure-is-false":
-      command => "/usr/sbin/pcs property set start-failure-is-fatal=false",
-    }
   }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1123293

This setting should not be needed any longer for icehouse.
