### PR TITLE
BZ #1123300 - haproxy check options missing interval parameter

### DIFF
--- a/puppet/modules/quickstack/manifests/load_balancer/amqp.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/amqp.pp
@@ -22,7 +22,7 @@ class quickstack::load_balancer::amqp (
     port                 => "$port",
     mode                 => "$mode",
     listen_options       => $listen_options,
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
     backend_port         => $backend_port,

--- a/puppet/modules/quickstack/manifests/load_balancer/cinder.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/cinder.pp
@@ -18,7 +18,7 @@ class quickstack::load_balancer::cinder (
     port                 => "$api_port",
     mode                 => "$api_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }

--- a/puppet/modules/quickstack/manifests/load_balancer/galera.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/galera.pp
@@ -19,7 +19,7 @@ class quickstack::load_balancer::galera (
                                              "server $timeout", ],
                               'stick-table' => 'type ip size 2',
                               'stick' => 'on dst', },
-    member_options       => [ 'check', 'port 9200' ],
+    member_options       => [ 'check inter 1s', 'port 9200' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }

--- a/puppet/modules/quickstack/manifests/load_balancer/glance.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/glance.pp
@@ -20,7 +20,7 @@ class quickstack::load_balancer::glance (
     port                 => "$api_port",
     mode                 => "$api_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }
@@ -32,7 +32,7 @@ class quickstack::load_balancer::glance (
     port                 => "$registry_port",
     mode                 => "$registry_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }

--- a/puppet/modules/quickstack/manifests/load_balancer/heat.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/heat.pp
@@ -27,7 +27,7 @@ class quickstack::load_balancer::heat (
     port                 => "$heat_port",
     mode                 => "$heat_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }
@@ -40,7 +40,7 @@ class quickstack::load_balancer::heat (
       port                 => "$heat_cfn_port",
       mode                 => "$heat_cfn_mode",
       listen_options       => { 'option' => [ "$log" ] },
-      member_options       => [ 'check' ],
+      member_options       => [ 'check inter 1s' ],
       backend_server_addrs => $backend_server_addrs,
       backend_server_names => $backend_server_names,
     }
@@ -54,7 +54,7 @@ class quickstack::load_balancer::heat (
       port                 => "$heat_cloudwatch_port",
       mode                 => "$heat_cloudwatch_mode",
       listen_options       => { 'option' => [ "$log" ] },
-      member_options       => [ 'check' ],
+      member_options       => [ 'check inter 1s' ],
       backend_server_addrs => $backend_server_addrs,
       backend_server_names => $backend_server_names,
     }

--- a/puppet/modules/quickstack/manifests/load_balancer/horizon.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/horizon.pp
@@ -21,7 +21,7 @@ class quickstack::load_balancer::horizon (
       'option'     => [ "$log" ],
       'cookie'     => 'SERVERID insert indirect nocache',
     },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     define_cookies       => true,
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,

--- a/puppet/modules/quickstack/manifests/load_balancer/keystone.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/keystone.pp
@@ -20,7 +20,7 @@ class quickstack::load_balancer::keystone (
     port                 => "$public_port",
     mode                 => "$public_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }
@@ -32,7 +32,7 @@ class quickstack::load_balancer::keystone (
     port                 => "$admin_port",
     mode                 => "$admin_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }

--- a/puppet/modules/quickstack/manifests/load_balancer/mysql.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/mysql.pp
@@ -14,7 +14,7 @@ class quickstack::load_balancer::mysql (
     port                 => "$public_port",
     mode                 => "$public_mode",
     listen_options       => { 'option'     => [ "$log" ], },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }

--- a/puppet/modules/quickstack/manifests/load_balancer/neutron.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/neutron.pp
@@ -18,7 +18,7 @@ class quickstack::load_balancer::neutron (
     port                 => "$api_port",
     mode                 => "$api_mode",
     listen_options       => { 'option' => [ "$api_log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }

--- a/puppet/modules/quickstack/manifests/load_balancer/nova.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/nova.pp
@@ -24,7 +24,7 @@ class quickstack::load_balancer::nova (
     port                 => "$api_port",
     mode                 => "$api_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }
@@ -36,7 +36,7 @@ class quickstack::load_balancer::nova (
   #  port                 => "$metadata_port",
   #  mode                 => "$metadata_mode",
   #  listen_options       => { 'option' => [ "$log" ] },
-  #  member_options       => [ 'check' ],
+  #  member_options       => [ 'check inter 1s' ],
   #  backend_server_addrs => $backend_server_addrs,
   #  backend_server_names => $backend_server_names,
   #}
@@ -48,7 +48,7 @@ class quickstack::load_balancer::nova (
     port                 => "$novncproxy_port",
     mode                 => "$novncproxy_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }
@@ -60,7 +60,7 @@ class quickstack::load_balancer::nova (
     port                 => "$xvpvncproxy_port",
     mode                 => "$xvpvncproxy_mode",
     listen_options       => { 'option' => [ "$log" ] },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }

--- a/puppet/modules/quickstack/manifests/load_balancer/swift.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/swift.pp
@@ -14,7 +14,7 @@ class quickstack::load_balancer::swift (
     port                 => "$public_port",
     mode                 => "$public_mode",
     listen_options       => { 'option'     => [ "$log" ], },
-    member_options       => [ 'check' ],
+    member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1123300

From BZ: "HA: all "check" options are missing the interval
parameter. This can cause higher recovery times in case of failure."
