### PR TITLE
BZ #1123314 - pacemaker heat op monitor interval to 60s

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -136,6 +136,7 @@ class quickstack::pacemaker::heat(
       group => "$heat_group",
       clone => false,
       options => 'start-delay=10s',
+      interval => '60s',
     }
 
     if str2bool_i($heat_cfn_enabled) {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1123314

From BZ: "Rubygem-staypuft: HA: Relax the openstack-heat-engine: op
monitor interval to 60 seconds.

Now it's openstack-heat-engine: op monitor interval=30s

appears to be too resource consuming in some cases (like
openstack-heat-engine and causes false positives."
