### PR TITLE
BZ #1123318 - HA: set max_retries=-1 for accessing the DB

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder.pp
+++ b/puppet/modules/quickstack/manifests/cinder.pp
@@ -5,6 +5,7 @@ class quickstack::cinder(
   $db_name        = 'cinder',
   $db_user        = 'cinder',
   $db_password    = '',
+  $max_retries    = '',
   $db_ssl         = false,
   $db_ssl_ca      = '',
   $glance_host    = '127.0.0.1',
@@ -35,6 +36,11 @@ class quickstack::cinder(
   cinder_config {
     'DEFAULT/glance_host': value => $glance_host;
     'DEFAULT/notification_driver': value => 'cinder.openstack.common.notifier.rpc_notifier'
+  }
+  if $max_retries {
+    cinder_config {
+      'DEFAULT/max_retries':      value => $max_retries;
+    }
   }
 
   if str2bool_i("$db_ssl") {

--- a/puppet/modules/quickstack/manifests/glance.pp
+++ b/puppet/modules/quickstack/manifests/glance.pp
@@ -20,6 +20,7 @@ class quickstack::glance (
   $db_ssl_ca                = '',
   $db_user                  = 'glance',
   $db_name                  = 'glance',
+  $max_retries              = '',
   $backend                  = 'file',
   $rbd_store_user           = 'images',
   $rbd_store_pool           = 'images',
@@ -89,6 +90,14 @@ class quickstack::glance (
     enabled           => $enabled,
   }
 
+  if $max_retries {
+    glance_api_config {
+      'DEFAULT/max_retries':      value => $max_retries;
+    }
+    glance_registry_config {
+      'DEFAULT/max_retries':      value => $max_retries;
+    }
+  }
   if ($amqp_provider == 'qpid') {
     class { 'glance::notify::qpid':
       qpid_password => $amqp_password,

--- a/puppet/modules/quickstack/manifests/heat.pp
+++ b/puppet/modules/quickstack/manifests/heat.pp
@@ -7,6 +7,7 @@ class quickstack::heat(
   $db_name                 = 'heat',
   $db_user                 = 'heat',
   $db_password             = '',
+  $max_retries             = '',
   $db_ssl                  = false,
   $db_ssl_ca               = '',
   $keystone_host           = '127.0.0.1',
@@ -40,6 +41,12 @@ class quickstack::heat(
   class {'::quickstack::firewall::heat':
     heat_cfn_enabled        => $heat_cfn_enabled,
     heat_cloudwatch_enabled => $heat_cloudwatch_enabled,
+  }
+
+  if $max_retries {
+    heat_config {
+      'DEFAULT/max_retries':      value => $max_retries;
+    }
   }
 
   class { '::heat':

--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -7,6 +7,7 @@ class quickstack::neutron::all (
   $enable_tunneling              = true,
   $enabled                       = true,
   $external_network_bridge       = 'br-ex',
+  $database_max_retries          = '',
   $ml2_type_drivers              = ['local', 'flat', 'vlan', 'gre', 'vxlan'],
   $ml2_tenant_network_types      = ['vxlan', 'vlan', 'gre', 'flat'],
   $ml2_mechanism_drivers         = ['openvswitch','l2population'],
@@ -88,11 +89,12 @@ class quickstack::neutron::all (
   File['/etc/neutron/plugin.ini'] -> Exec['neutron-db-manage upgrade']
 
   class { '::neutron::server':
-    auth_host      => $auth_host,
-    auth_password  => $neutron_user_password,
-    auth_tenant    => $auth_tenant,
-    auth_user      => $auth_user,
-    connection     => $sql_connection,
+    auth_host            => $auth_host,
+    auth_password        => $neutron_user_password,
+    auth_tenant          => $auth_tenant,
+    auth_user            => $auth_user,
+    connection           => $sql_connection,
+    database_max_retries => $database_max_retries,
   }
 
   if $neutron_core_plugin == 'neutron.plugins.ml2.plugin.Ml2Plugin' {

--- a/puppet/modules/quickstack/manifests/nova.pp
+++ b/puppet/modules/quickstack/manifests/nova.pp
@@ -69,6 +69,10 @@
 #   (optional) Whether to start/stop the service
 #   Defaults to true
 #
+# [*max_retries*]
+#   (optional) Value for max_retries in /etc/nova/nova.conf
+#   Defaults to ''.
+#
 # [*memcached_servers*]
 #   (optional) Use memcached instead of in-process cache. Supply a list of
 #   memcached server IP's:Memcached Port.
@@ -117,6 +121,7 @@ class quickstack::nova (
   $glance_port                  = '9292',
   $image_service                = 'nova.image.glance.GlanceImageService',
   $manage_service               = 'true',
+  $max_retries                  = '',
   $memcached_servers            = 'false',
   $multi_host                   = 'true',
   $neutron                      = 'false',
@@ -152,6 +157,12 @@ class quickstack::nova (
 
     nova_config { 'DEFAULT/default_floating_pool':
       value => $default_floating_pool;
+    }
+
+    if $max_retries {
+      nova_config {
+        'DEFAULT/max_retries':      value => $max_retries;
+      }
     }
 
     if str2bool_i("$neutron") {

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -117,6 +117,7 @@ class quickstack::pacemaker::cinder(
       db_name        => $db_name,
       db_user        => $db_user,
       db_password    => $db_password,
+      max_retries    => '-1',
       db_ssl         => $db_ssl,
       db_ssl_ca      => $db_ssl_ca,
       glance_host    => $glance_host,

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -112,6 +112,7 @@ class quickstack::pacemaker::glance (
       db_ssl_ca                => $db_ssl_ca,
       db_user                  => $db_user,
       db_name                  => $db_name,
+      max_retries              => '-1',
       backend                  => $backend,
       rbd_store_user           => $rbd_store_user,
       rbd_store_pool           => $rbd_store_pool,

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -90,6 +90,7 @@ class quickstack::pacemaker::heat(
       db_name                 => $db_name,
       db_user                 => $db_user,
       db_password             => $heat_db_password,
+      max_retries             => '-1',
       db_ssl                  => $db_ssl,
       db_ssl_ca               => $db_ssl_ca,
       keystone_host           => map_params("keystone_admin_vip"),

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -56,6 +56,10 @@ class quickstack::pacemaker::keystone (
       backend_server_addrs => map_params("lb_backend_server_addrs"),
     }
 
+    keystone_config {
+      'DEFAULT/max_retries':      value => '-1';
+    }
+
     Class['::quickstack::pacemaker::common'] ->
 
     quickstack::pacemaker::vips { "$keystone_group":

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -77,6 +77,7 @@ class quickstack::pacemaker::neutron (
       enable_tunneling              => $enable_tunneling,
       enabled                       => $enabled,
       external_network_bridge       => $external_network_bridge,
+      database_max_retries          => '-1',
       ml2_type_drivers              => $ml2_type_drivers,
       ml2_tenant_network_types      => $ml2_tenant_network_types,
       ml2_mechanism_drivers         => $ml2_mechanism_drivers,

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -77,6 +77,7 @@ class quickstack::pacemaker::nova (
       db_name                       => $db_name,
       db_password                   => map_params("nova_db_password"),
       db_user                       => $db_user,
+      max_retries                   => '-1',
       default_floating_pool         => $default_floating_pool,
       force_dhcp_release            => $force_dhcp_release,
       glance_host                   => map_params("glance_private_vip"),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1123318

Services will now continue to retry accessing the db on startup if it
is not available, as the max_retries configuration value in the
openstack .conf files is now set to -1.

From BZ:
"HA: All services are missing max_retries=-1 settings for accessing the DB.

This means that if the DB is not started before the service, the
service will fail to start. This behaviour is currently mitigated by:
start-failure-is-fatal: false, but it is technically incorrect."
