### PR TITLE
[when convenient] Use "str2bool_i" instead of "== 'true'"

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -55,7 +55,7 @@ class quickstack::pacemaker::cinder(
 
   include ::quickstack::pacemaker::common
 
-  if (map_params('include_cinder') == 'true') {
+  if (str2bool_i(map_params('include_cinder'))) {
 
     include ::quickstack::pacemaker::amqp
 
@@ -68,19 +68,19 @@ class quickstack::pacemaker::cinder(
     $keystone_host        = map_params("keystone_admin_vip")
 
     Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip'] -> Exec['cinder-manage db_sync'] -> Exec['pcs-cinder-server-set-up']
-    if (map_params('include_mysql') == 'true') {
+    if (str2bool_i(map_params('include_mysql'))) {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
-    if (map_params('include_keystone') == 'true') {
+    if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
-    if (map_params('include_swift') == 'true') {
+    if (str2bool_i(map_params('include_swift'))) {
       Exec['all-swift-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
-    if (map_params('include_glance') == 'true') {
+    if (str2bool_i(map_params('include_glance'))) {
       Exec['all-glance-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
-    if (map_params('include_nova') == 'true') {
+    if (str2bool_i(map_params('include_nova'))) {
       Exec['all-nova-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
 

--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -14,7 +14,7 @@ class quickstack::pacemaker::galera (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_mysql') == 'true') {
+  if (str2bool_i(map_params('include_mysql'))) {
     $galera_vip = map_params("db_vip")
 
     Exec['all-memcached-nodes-are-up'] -> Service['galera']

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -32,7 +32,7 @@ class quickstack::pacemaker::glance (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_glance') == 'true') {
+  if (str2bool_i(map_params('include_glance'))) {
     $glance_private_vip = map_params("glance_private_vip")
     $pcmk_glance_group = map_params("glance_group")
 
@@ -40,13 +40,13 @@ class quickstack::pacemaker::glance (
     Exec['i-am-glance-vip-OR-glance-is-up-on-vip'] -> Service['glance-registry']
     Exec['i-am-glance-vip-OR-glance-is-up-on-vip'] -> Exec['glance-manage db_sync'] -> Exec['pcs-glance-server-set-up']
 
-    if (map_params('include_mysql') == 'true') {
+    if (str2bool_i(map_params('include_mysql'))) {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
     }
-    if (map_params('include_keystone') == 'true') {
+    if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
     }
-    if (map_params('include_swift') == 'true') {
+    if (str2bool_i(map_params('include_swift'))) {
       Exec['all-swift-nodes-are-up'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
     }
 

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -17,7 +17,7 @@ class quickstack::pacemaker::heat(
 
   include ::quickstack::pacemaker::common
 
-  if (map_params('include_heat') == 'true') {
+  if (str2bool_i(map_params('include_heat'))) {
 
     include ::quickstack::pacemaker::amqp
 
@@ -43,25 +43,25 @@ class quickstack::pacemaker::heat(
 
     Exec['i-am-heat-vip-OR-heat-is-up-on-vip'] -> Exec<| title == 'heat-dbsync' |>
     -> Exec['pcs-heat-server-set-up']
-    if (map_params('include_mysql') == 'true') {
+    if (str2bool_i(map_params('include_mysql'))) {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
-    if (map_params('include_keystone') == 'true') {
+    if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
-    if (map_params('include_swift') == 'true') {
+    if (str2bool_i(map_params('include_swift'))) {
       Exec['all-swift-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
-    if (map_params('include_glance') == 'true') {
+    if (str2bool_i(map_params('include_glance'))) {
       Exec['all-glance-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
-    if (map_params('include_nova') == 'true') {
+    if (str2bool_i(map_params('include_nova'))) {
       Exec['all-nova-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
-    if (map_params('include_cinder') == 'true') {
+    if (str2bool_i(map_params('include_cinder'))) {
       Exec['all-cinder-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
-    if (map_params('include_neutron') == 'true') {
+    if (str2bool_i(map_params('include_neutron'))) {
       Exec['all-neutron-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
 

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -10,7 +10,7 @@ class quickstack::pacemaker::horizon (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_horizon') == 'true') {
+  if (str2bool_i(map_params('include_horizon'))) {
     $pcmk_horizon_group = map_params("horizon_group")
     $horizon_public_vip  = map_params("horizon_public_vip")
     $horizon_private_vip = map_params("horizon_private_vip")
@@ -23,28 +23,28 @@ class quickstack::pacemaker::horizon (
     )
 
     Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip'] -> Service['httpd']
-    if (map_params('include_mysql') == 'true') {
+    if (str2bool_i(map_params('include_mysql'))) {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
-    if (map_params('include_keystone') == 'true') {
+    if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
-    if (map_params('include_swift') == 'true') {
+    if (str2bool_i(map_params('include_swift'))) {
       Exec['all-swift-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
-    if (map_params('include_glance') == 'true') {
+    if (str2bool_i(map_params('include_glance'))) {
       Exec['all-glance-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
-    if (map_params('include_cinder') == 'true') {
+    if (str2bool_i(map_params('include_cinder'))) {
       Exec['all-cinder-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
-    if (map_params('include_nova') == 'true') {
+    if (str2bool_i(map_params('include_nova'))) {
       Exec['all-nova-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
-    if (map_params('include_neutron') == 'true') {
+    if (str2bool_i(map_params('include_neutron'))) {
       Exec['all-neutron-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
-    if (map_params('include_heat') == 'true') {
+    if (str2bool_i(map_params('include_heat'))) {
       Exec['all-heat-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
 

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -30,7 +30,7 @@ class quickstack::pacemaker::keystone (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_keystone') == 'true') {
+  if (str2bool_i(map_params('include_keystone'))) {
     $keystone_group = map_params("keystone_group")
     $keystone_private_vip = map_params("keystone_private_vip")
 
@@ -44,7 +44,7 @@ class quickstack::pacemaker::keystone (
     Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip'] -> Keystone_tenant<| |> -> Exec['pcs-keystone-server-set-up']
     Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip'] -> Keystone_service<| |> -> Exec['pcs-keystone-server-set-up']
 
-    if (map_params('include_mysql') == 'true') {
+    if (str2bool_i(map_params('include_mysql'))) {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
     }
 

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -24,27 +24,27 @@ class quickstack::pacemaker::neutron (
 ) {
   include quickstack::pacemaker::common
 
-  if (map_params('include_neutron') == 'true') {
+  if (str2bool_i(map_params('include_neutron'))) {
     $neutron_group = map_params("neutron_group")
     $neutron_public_vip = map_params("neutron_public_vip")
     $ovs_nic = find_nic("$ovs_tunnel_network","$ovs_tunnel_iface","")
 
-    if (map_params('include_mysql') == 'true') {
+    if (str2bool_i(map_params('include_mysql'))) {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
-    if (map_params('include_keystone') == 'true') {
+    if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
-    if (map_params('include_swift') == 'true') {
+    if (str2bool_i(map_params('include_swift'))) {
       Exec['all-swift-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
-    if (map_params('include_cinder') == 'true') {
+    if (str2bool_i(map_params('include_cinder'))) {
       Exec['all-cinder-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
-    if (map_params('include_glance') == 'true') {
+    if (str2bool_i(map_params('include_glance'))) {
       Exec['all-glance-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
-    if (map_params('include_nova') == 'true') {
+    if (str2bool_i(map_params('include_nova'))) {
       Exec['all-nova-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
 

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -16,7 +16,7 @@ class quickstack::pacemaker::nova (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_nova') == 'true') {
+  if (str2bool_i(map_params('include_nova'))) {
     $nova_private_vip = map_params("nova_private_vip")
     $pcmk_nova_group = map_params("nova_group")
     $memcached_ips =  map_params("lb_backend_server_addrs")
@@ -26,16 +26,16 @@ class quickstack::pacemaker::nova (
         ','
     )
     Exec['i-am-nova-vip-OR-nova-is-up-on-vip'] -> Exec['nova-db-sync']
-    if (map_params('include_mysql') == 'true') {
+    if (str2bool_i(map_params('include_mysql'))) {
       Exec['all-galera-nodes-are-up'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
     }
-    if (map_params('include_keystone') == 'true') {
+    if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
     }
-    if (map_params('include_swift') == 'true') {
+    if (str2bool_i(map_params('include_swift'))) {
       Exec['all-swift-nodes-are-up'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
     }
-    if (map_params('include_glance') == 'true') {
+    if (str2bool_i(map_params('include_glance'))) {
       Exec['all-glance-nodes-are-up'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
     }
     if ($scheduler_host_subset_size == '1') {

--- a/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
@@ -30,7 +30,7 @@ class quickstack::pacemaker::qpid (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_amqp') == 'true' and
+  if (str2bool_i(map_params('include_amqp')) and
       map_params('amqp_provider') == 'qpid') {
     $amqp_group = map_params("amqp_group")
     $amqp_username = map_params("amqp_username")

--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -5,7 +5,7 @@ class quickstack::pacemaker::rabbitmq (
 
   include quickstack::pacemaker::common
 
-  if (map_params('include_amqp') == 'true' and
+  if (str2bool_i(map_params('include_amqp')) and
       map_params('amqp_provider') == 'rabbitmq') {
     $amqp_group = map_params("amqp_group")
     $amqp_username = map_params("amqp_username")

--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -7,7 +7,7 @@ class quickstack::pacemaker::swift (
 ) {
   include quickstack::pacemaker::common
 
-  if (map_params('include_swift') == 'true') {
+  if (str2bool_i(map_params('include_swift'))) {
     $swift_group = map_params("swift_group")
     $swift_public_vip = map_params("swift_public_vip")
     $memcached_ips =  map_params("lb_backend_server_addrs")
@@ -15,7 +15,7 @@ class quickstack::pacemaker::swift (
         |x| x+":"+@memcached_port }.join(",") %>')
 
     Exec['i-am-swift-vip-OR-swift-is-up-on-vip'] -> Service['swift-proxy']
-    if (map_params('include_keystone') == 'true') {
+    if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-swift-vip-OR-swift-is-up-on-vip']
     }
 


### PR DESCRIPTION
Not tested yet, we should test and merge when convenient. If the code changes so that new `== true` appear, this commit can be easily regenerated by running this oneliner in Astapor's root dir:

```
grep -ril "== 'true'" puppet | xargs sed -i -e "s/map_params('\([^']*\)') == 'true'/str2bool_i(map_params('\1'))/"
```

and then verifying that this doesn't print anything:

```
grep -ri "== 'true'" puppet
```
