### PR TITLE
BZ #1127887 -  HA: rsync not installed on non-galera bootstrap nodes

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/rsync/get.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rsync/get.pp
@@ -37,6 +37,8 @@ define quickstack::pacemaker::rsync::get (
   $unless = '/bin/false',
 ) {
 
+  include '::quickstack::rsync::common'
+
   if $keyfile {
     $Mykeyfile = $keyfile
   } else {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1127887

Make sure the rsync dependency is included on the "get" side.
