### PR TITLE
BZ#1127816 - HA neutron sets pcs properties before starting service

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -96,6 +96,7 @@ class quickstack::neutron::all (
     connection           => $sql_connection,
     database_max_retries => $database_max_retries,
   }
+  contain neutron::server
 
   if $neutron_core_plugin == 'neutron.plugins.ml2.plugin.Ml2Plugin' {
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1127816

Make quickstack::neutron::all contain neutron::server, so that
resources after quickstack::neutron::all also are after
neutron::server.

See also:
https://docs.puppetlabs.com/puppet/3/reference/lang_containment.html
