### PR TITLE
[Merge this one or PR #340] BZ #1127862 - ceph client packages (compute, non-ha and ha controller)

### DIFF
--- a/puppet/modules/quickstack/manifests/ceph/client_packages.pp
+++ b/puppet/modules/quickstack/manifests/ceph/client_packages.pp
@@ -1,0 +1,10 @@
+class quickstack::ceph::client_packages {
+
+  $ceph_client_packages = ['librados2','librbd1','ceph-common']
+
+  # if and when glance::backend::rbd stops declaring python-ceph,
+  # we can instead declare all ceph client packages below
+  # $ceph_client_packages = ['librados2','librbd1','ceph-common','python-ceph']
+
+  package { $ceph_client_packages: ensure => "installed" }
+}

--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -63,6 +63,9 @@ class quickstack::compute_common (
   }
 
   if str2bool_i("$cinder_backend_rbd") {
+    include ::quickstack::ceph::client_packages
+    package {'python-ceph': }
+
     nova_config {
       'DEFAULT/libvirt_images_rbd_pool':      value => $libvirt_images_rbd_pool;
       'DEFAULT/libvirt_images_rbd_ceph_conf': value => $libvirt_images_rbd_ceph_conf;

--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -239,7 +239,6 @@ class quickstack::controller_common (
     amqp_provider  => $amqp_provider,
   }
 
-
   # Configure Nova
   class { '::nova':
     sql_connection     => $nova_sql_connection,
@@ -339,6 +338,15 @@ class quickstack::controller_common (
   } else {
     $cinder_backend_iscsi_with_fallback = $cinder_backend_iscsi
   }
+ 
+  if (str2bool_i("$cinder_backend_rbd") or ($glance_backend == 'rbd')) {
+    # hack around the glance package declaration if needed
+    if ($glance_backend != 'rbd') {
+      package {'python-ceph': }
+    }
+    include ::quickstack::ceph::client_packages
+  }
+
   class { 'quickstack::cinder_volume':
     backend_eqlx           => $cinder_backend_eqlx,
     backend_eqlx_name      => $cinder_backend_eqlx_name,

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -234,5 +234,20 @@ class quickstack::pacemaker::cinder(
         score => "INFINITY",
       }
     }
+
+    # the rest is sad puppet hackery to install rbd/ceph packages,
+    # avoiding a "package" re-declaration (for python-ceph)
+    if (str2bool_i($backend_rbd)) {
+      if (str2bool_i(map_params('include_glance'))) {
+        include ::quickstack::pacemaker::glance
+        if ($::quickstack::pacemaker::glance::backend != 'rbd') {
+          package {'python-ceph': }
+        }
+      }
+      else {
+        package {'python-ceph': }
+      }
+      include ::quickstack::ceph::client_packages
+    }
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -190,5 +190,8 @@ class quickstack::pacemaker::glance (
       target => "openstack-glance-registry-clone",
       score => "INFINITY",
     }
+    if ($backend == 'rbd') {
+      include ::quickstack::ceph::client_packages
+    }
   }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1127862

Unfortunately, glance::backend::rbd already includes one ceph client
package dependency, 'python-ceph'.  So, we tap dance around whether
glance::backend::rbd itself has been declared and thus declares
'python-ceph'.

Client packages include:

 librados2
 librbd1
 ceph-common
 python-ceph
