### PR TITLE
BZ #1126583 -  Unable to connect to instances via VNC.

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -43,6 +43,9 @@ class quickstack::neutron::compute (
   $libvirt_images_type          = 'rbd',
   $rbd_user                     = 'volumes',
   $rbd_secret_uuid              = '',
+  $private_iface                = '',
+  $private_ip                   = '',
+  $private_network              = '',
 ) inherits quickstack::params {
 
   if str2bool_i("$ssl") {
@@ -144,6 +147,9 @@ class quickstack::neutron::compute (
     libvirt_images_type          => $libvirt_images_type,
     rbd_user                     => $rbd_user,
     rbd_secret_uuid              => $rbd_secret_uuid,
+    private_iface                => $private_iface,
+    private_ip                   => $private_ip,
+    private_network              => $private_network,
   }
 
   class {'quickstack::neutron::firewall::gre':}

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -42,6 +42,10 @@ class quickstack::nova_network::compute (
   $libvirt_images_type          = 'rbd',
   $rbd_user                     = 'volumes',
   $rbd_secret_uuid              = '',
+  $private_iface                = '',
+  $private_ip                   = '',
+  $private_network              = '',
+
 ) inherits quickstack::params {
 
   # Configure Nova
@@ -106,5 +110,8 @@ class quickstack::nova_network::compute (
     libvirt_images_type          => $libvirt_images_type,
     rbd_user                     => $rbd_user,
     rbd_secret_uuid              => $rbd_secret_uuid,
+    private_iface                => $private_iface,
+    private_ip                   => $private_ip,
+    private_network              => $private_network,
   }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1126583

The nova configuration needs the public ip of the controller/nova host for
vncproxy_host, and the compute node's ip on the internal network for
vncserver_proxyclient_address.  Additionally, vncserver_listen needs to be
0.0.0.0 to support live migration.  Further firewall rules will be needed to
lock this down better.
