### PR TITLE
BZ #1123312 - increase galera pacemaker start timeout

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -97,7 +97,7 @@ class quickstack::pacemaker::galera (
     } ->
     quickstack::pacemaker::resource::service {'mysqld':
       group          => "$pcmk_galera_group",
-      monitor_params => { 'start-delay' => '60s' },
+      options        => 'start timeout=300s meta ordered=true',
       clone          => true,
     }
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1123312

Increase galera start timeout to allow a sufficient amount
of time for syncing to occur between galera modes.
