### PR TITLE
BZ #1129227 - Set l3 external_network_bridge to ''.

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -6,7 +6,7 @@ class quickstack::neutron::all (
   $cisco_vswitch_plugin          = '',
   $enable_tunneling              = true,
   $enabled                       = true,
-  $external_network_bridge       = 'br-ex',
+  $external_network_bridge       = '',
   $database_max_retries          = '',
   $ml2_type_drivers              = ['local', 'flat', 'vlan', 'gre', 'vxlan'],
   $ml2_tenant_network_types      = ['vxlan', 'vlan', 'gre', 'flat'],

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -13,7 +13,7 @@ class quickstack::neutron::networker (
   $mysql_host                    = $quickstack::params::mysql_host,
   $amqp_provider                 = $quickstack::params::amqp_provider,
   $amqp_host                     = $quickstack::params::amqp_host,
-  $external_network_bridge       = 'br-ex',
+  $external_network_bridge       = '',
   $amqp_username                 = $quickstack::params::amqp_username,
   $amqp_password                 = $quickstack::params::amqp_password,
   $tenant_network_type           = $quickstack::params::tenant_network_type,

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -2,7 +2,7 @@ class quickstack::pacemaker::neutron (
   $core_plugin                = 'neutron.plugins.ml2.plugin.Ml2Plugin',
   $enable_tunneling           = false,
   $enabled                    = true,
-  $external_network_bridge    = 'br-ex',
+  $external_network_bridge    = '',
   $ml2_type_drivers           = ['local', 'flat', 'vlan', 'gre', 'vxlan'],
   $ml2_tenant_network_types   = ['vxlan', 'vlan', 'gre', 'flat'],
   $ml2_mechanism_drivers      = ['openvswitch','l2population'],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1129227

This is needed to properly use provider networks in newer versions of neutron.
