### PR TITLE
BZ #1128361 - Correctly check for openstack-heat-engine service

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -151,7 +151,7 @@ class quickstack::pacemaker::heat(
       ->
       Exec["i-am-heat-vip-OR-heat-is-up-on-vip"]
 
-      Exec["all-heat-nodes-are-up"]
+      Quickstack::Pacemaker::Resource::Service['openstack-heat-engine']
       ->
       quickstack::pacemaker::resource::service {"openstack-heat-api-cfn":
         clone => true,
@@ -174,7 +174,7 @@ class quickstack::pacemaker::heat(
     }
 
     if str2bool_i($heat_cloudwatch_enabled) {
-      Exec["all-heat-nodes-are-up"]
+      Quickstack::Pacemaker::Resource::Service['openstack-heat-engine']
       ->
       quickstack::pacemaker::resource::service {"openstack-heat-api-cloudwatch":
         clone => true,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1128361

Use Quickstack::Pacemaker::Resource::Service instead of Exec to check
that heat engine is up
