### PR TITLE
BZ #1125301 - Add heat-engine to cloudwatch colo constraint

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -204,6 +204,12 @@ class quickstack::pacemaker::heat(
           first_action    => "start",
           second_action   => "start",
         }
+        ->
+        quickstack::pacemaker::constraint::colocation { 'heat-cloudwatch-engine-colo' :
+          source => "openstack-heat-engine",
+          target => "openstack-heat-api-cloudwatch-clone",
+          score => "INFINITY",
+        }
       }
     }
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1125301

Add a colocation constraint from heat-engine to heat-api-cloudwatch

jayg: changed resource name to 'openstack-heat-api-cloudwatch-clone' and verifed
functional.

Signed-off-by: Jason Guiditta jguiditt@redhat.com
