### PR TITLE
BZ #1130304 - nfs-utils should be installed before using nfs

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder_volume.pp
+++ b/puppet/modules/quickstack/manifests/cinder_volume.pp
@@ -79,16 +79,8 @@ class quickstack::cinder_volume(
         glusterfs_shares_config    => '/etc/cinder/shares-glusterfs.conf',
       }
     } elsif str2bool_i("$backend_nfs") {
-      package { 'nfs-utils':
-        ensure => 'present',
-      }
-
-      if ($::selinux != "false") {
-        selboolean { 'virt_use_nfs':
-            value => on,
-            persistent => true,
-        }
-      }
+      include ::quickstack::nfs_common
+      Package['nfs-utils'] -> Cinder::Backend::Nfs<| |>
 
       class { '::cinder::volume::nfs':
         nfs_servers       => $nfs_shares,
@@ -161,18 +153,10 @@ class quickstack::cinder_volume(
     }
 
     if str2bool_i("$backend_nfs") {
+      include ::quickstack::nfs_common
+      Package['nfs-utils'] -> Cinder::Backend::Nfs<| |>
+
       $nfs_backends = ["nfs"]
-
-      package { 'nfs-utils':
-        ensure => 'present',
-      }
-
-      if ($::selinux != "false") {
-        selboolean { 'virt_use_nfs':
-            value => on,
-            persistent => true,
-        }
-      }
 
       cinder::backend::nfs { 'nfs':
         volume_backend_name => $backend_nfs_name,

--- a/puppet/modules/quickstack/manifests/nfs_common.pp
+++ b/puppet/modules/quickstack/manifests/nfs_common.pp
@@ -1,0 +1,12 @@
+class quickstack::nfs_common {
+  package { 'nfs-utils':
+    ensure => 'present',
+  }
+
+  if ($::selinux != "false") {
+    selboolean { 'virt_use_nfs':
+        value => on,
+        persistent => true,
+    } -> Package['nfs-utils']
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -58,6 +58,10 @@ class quickstack::pacemaker::glance (
       }
     } elsif ($backend == 'file') {
       if str2bool_i("$pcmk_fs_manage") {
+        if ($pcmk_fs_type == 'nfs') {
+          include ::quickstack::nfs_common
+          Package['nfs-utils'] -> Exec['stonith-setup-complete']
+        }
         Exec['stonith-setup-complete']
         ->
         quickstack::pacemaker::resource::filesystem { "glance-fs":


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1130304

Make sure nfs-utils is installed and the selinux bit flipped (if
applicable) before attempting to nfs mount something in glance or
cinder.
