### PR TITLE
BZ#1129896 - HA: openstack-heat-engine fails to start

### DIFF
--- a/puppet/modules/quickstack/manifests/heat.pp
+++ b/puppet/modules/quickstack/manifests/heat.pp
@@ -72,6 +72,7 @@ class quickstack::heat(
     verbose           => $verbose,
     debug             => $debug,
   }
+  contain heat
 
   class { '::heat::api':
     bind_host         => $bind_host,
@@ -98,4 +99,5 @@ class quickstack::heat(
     heat_watch_server_url         => "http://${cloudwatch_host}:8003",
     enabled                       => str2bool_i("$heat_engine_enabled"),
   }
+  contain heat::engine
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1129896

Class[quickstack::heat] needs to contain ::heat, otherwise the
ordering in Class[quickstack::pacemaker::heat] doesn't necessarily
expect as one might expect.
