### PR TITLE
BZ #1132155 - Work around potential galera failures

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -69,7 +69,7 @@ class quickstack::pacemaker::cinder(
 
     Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip'] -> Exec['cinder-manage db_sync'] -> Exec['pcs-cinder-server-set-up']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['all-galera-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
+      Exec['galera-online'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -120,6 +120,13 @@ class quickstack::pacemaker::galera (
       group          => "$pcmk_galera_group",
       options        => 'start timeout=300s meta ordered=true',
       clone          => true,
+    } ->
+    # one last clustercheck to make sure service is up
+    exec {"galera-online":
+      timeout   => 3600,
+      tries     => 360,
+      try_sleep => 10,
+      command   => "/usr/bin/clustercheck >/dev/null",
     }
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -41,7 +41,7 @@ class quickstack::pacemaker::glance (
     Exec['i-am-glance-vip-OR-glance-is-up-on-vip'] -> Exec['glance-manage db_sync'] -> Exec['pcs-glance-server-set-up']
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['all-galera-nodes-are-up'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
+      Exec['galera-online'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -44,7 +44,7 @@ class quickstack::pacemaker::heat(
     Exec['i-am-heat-vip-OR-heat-is-up-on-vip'] -> Exec<| title == 'heat-dbsync' |>
     -> Exec['pcs-heat-server-set-up']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['all-galera-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
+      Exec['galera-online'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -24,7 +24,7 @@ class quickstack::pacemaker::horizon (
 
     Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip'] -> Service['httpd']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['all-galera-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+      Exec['galera-online'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -45,7 +45,7 @@ class quickstack::pacemaker::keystone (
     Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip'] -> Keystone_service<| |> -> Exec['pcs-keystone-server-set-up']
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['all-galera-nodes-are-up'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
+      Exec['galera-online'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
     }
 
     class {"::quickstack::load_balancer::keystone":

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -30,7 +30,7 @@ class quickstack::pacemaker::neutron (
     $ovs_nic = find_nic("$ovs_tunnel_network","$ovs_tunnel_iface","")
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['all-galera-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+      Exec['galera-online'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -27,7 +27,7 @@ class quickstack::pacemaker::nova (
     )
     Exec['i-am-nova-vip-OR-nova-is-up-on-vip'] -> Exec['nova-db-sync']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['all-galera-nodes-are-up'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
+      Exec['galera-online'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']


### PR DESCRIPTION
Two changes:
- For the initial puppet run, once galera is fully bootstrapped, shut it down before we add it as a pacemaker resource which will start it back up.
- Make sure the galera cluster is up with one last clustercheck.  Use this as the dependency for other services that rely on the db to avoid db_sync errors.
