### PR TITLE
BZ #1132155 - Openstack services fail when galera not fully running.

### DIFF
--- a/puppet/modules/quickstack/manifests/galera/server.pp
+++ b/puppet/modules/quickstack/manifests/galera/server.pp
@@ -30,6 +30,7 @@ class quickstack::galera::server (
     wsrep_ssl_key         => $wsrep_ssl_key,
     wsrep_ssl_cert        => $wsrep_ssl_cert,
   }
+  contain galera::server
 
   class {'::galera::monitor':
     mysql_username => $galera_monitor_username,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1132155

This is an additional enforcement of ordering, to make sure the galera module
has done everything it is supposed to when we expect it has. Some dependencies
could have happened out of order without this addition.
