### PR TITLE
Fix dependency cycle on Puppet 3.7

### DIFF
--- a/puppet/modules/quickstack/manifests/heat.pp
+++ b/puppet/modules/quickstack/manifests/heat.pp
@@ -73,7 +73,12 @@ class quickstack::heat(
     verbose           => $verbose,
     debug             => $debug,
   }
-  contain heat
+  # FIXME(jistr): after we drop support for Puppet <= 3.6, we can use
+  # `contain ::heat` instead of the anchors here, and use fully qualified
+  # class names in the rest of `contain` statements too
+  anchor { 'quickstack-heat-first': } ->
+  Class['::heat'] ->
+  anchor { 'quickstack-heat-last': }
 
   class { '::heat::api':
     bind_host      => $bind_host,


### PR DESCRIPTION
I didn't test this manually but we got an e-mail report of this bug and also that the fix heled.

Commit message follows:

"contain heat" from within quickstack::heat is going to resolve to
"contain ::quickstack::heat" instead of "contain ::heat", causing a
dep cycle:

Error: Could not apply complete catalog: Found 2 dependency cycles:
(Class[Quickstack::Heat] => Class[Quickstack::Heat])
(Class[Quickstack::Heat] => Class[Quickstack::Heat])

This commit makes use of absolute namespacing with 'contain' to avoid
such naming collisions.
