### PR TITLE
fix rbd dependency cycle

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -208,7 +208,6 @@ class quickstack::pacemaker::glance (
       include ::quickstack::pacemaker::ceph_config
 
       Class['quickstack::pacemaker::ceph_config'] ->
-      Package['python-ceph'] ->
       Class['quickstack::ceph::client_packages'] ->
       Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
     }


### PR DESCRIPTION
Remove extra dep that causes the puppet dependency cycle: Package[ceph-common] => Class[Quickstack::Ceph::Client_packages] => Class[Glance::Backend::Rbd] => Package[python-ceph] => Class[Quickstack::Ceph::Client_packages] => Package[ceph-common]
