### PR TITLE
Explicitly require rabbitmq service before setting HA policy

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -62,7 +62,8 @@ class quickstack::pacemaker::rabbitmq (
     Class['::rabbitmq'] ->
     exec {"rabbit-mirrored-queues":
       command => '/usr/sbin/rabbitmqctl set_policy HA \'^(?!amq\.).*\' \'{"ha-mode": "all"}\'',
-      unless  => '/usr/sbin/rabbitmqctl list_policies | grep -q HA'
+      unless  => '/usr/sbin/rabbitmqctl list_policies | grep -q HA',
+      require => Service['rabbitmq-server'],
     } ->
     Class['::quickstack::load_balancer::amqp'] ->
 


### PR DESCRIPTION
This is yet another case of class containment gone wrong.  The
mirrored queues exec requires ::rabbitmq, and the latter includes
::rabbitmq::service which declares the service.  Since ::rabbitmq does
not 'contain' ::rabbitmq:service, the dependency does not get applied
to the mirrored queues exec.  Thus, it is possible for the exec to run
before the service is started.
