### PR TITLE
BZ #1151176 - fence_xvm: expose port param, remove unused params, add firewall rule

### DIFF
--- a/puppet/modules/quickstack/manifests/firewall/fence_xvm.pp
+++ b/puppet/modules/quickstack/manifests/firewall/fence_xvm.pp
@@ -1,0 +1,12 @@
+class quickstack::firewall::fence_xvm (
+  $port = '1229',
+) {
+
+  include quickstack::firewall::common
+
+  firewall { '010 fence_xvm incoming':
+    proto  => 'tcp',
+    dport  => ["$port"],
+    action => 'accept',
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -40,8 +40,7 @@ class quickstack::pacemaker::common (
   $fence_ipmilan_host_to_address  = [],
   $fence_ipmilan_expose_lanplus   = "true",
   $fence_ipmilan_lanplus_options  = "",
-  $fence_xvm_clu_iface            = "eth2",
-  $fence_xvm_clu_network          = "",
+  $fence_xvm_port                 = "",
   $fence_xvm_manage_key_file      = "false",
   $fence_xvm_key_file_password    = "",
 ) {
@@ -89,17 +88,19 @@ class quickstack::pacemaker::common (
   }
   elsif $fencing_type =~ /(?i-mx:^fence_xvm$)/ {
     $fencing = true
-    $clu_ip_address = find_ip("$fence_xvm_clu_network",
-                              "$fence_xvm_clu_iface",
-                              "")
     class {'pacemaker::stonith':
       disable => false,
     }
+    $xvm_port = $fence_xvm_port ? {
+      ''      =>  "$::hostname",
+      default =>  "$fence_xvm_port",
+    }
+    class {'::quickstack::firewall::fence_xvm':} ->
     class {'pacemaker::stonith::fence_xvm':
       name              => "$::hostname",
       manage_key_file   => str2bool_i("$fence_xvm_manage_key_file"),
       key_file_password => $fence_xvm_key_file_password,
-      port              => "$::hostname",    # the name of the vm
+      port              => $xvm_port,  # the domname or uuid of the vm
     }
   }
   else {


### PR DESCRIPTION
Not tested.

Remove $fence_xvm_clu_iface/$fence_xvm_clu_network which were not used for anything in this manifest.  Once upon a time, they could be used to derive the pacemaker cluster IP which _was_ equivalent to the pacemaker node name which in turn was passed along here: https://github.com/redhat-openstack/astapor/blob/4e4a138288fdaf6336758f3944da4a731571919b/puppet/modules/quickstack/manifests/pacemaker/common.pp#L85 .  This is no longer the case (the pacemaker node name is now an fqdn) and now we can rely on pacemaker::stonith::fence_xvm to derive the pacemaker node name rather than pass it along.

Expose the $fence_xvm_port parameter which corresponds to the vm's dom name or uuid.  If it is not set, continue to make the assumption currently being made, that the fact $::hostname is the dom name.
