### PR TITLE
BZ #1147077 - Explicitly require rabbitmq service before setting HA policy

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -63,7 +63,7 @@ class quickstack::pacemaker::rabbitmq (
     exec {"rabbit-mirrored-queues":
       command => '/usr/sbin/rabbitmqctl set_policy HA \'^(?!amq\.).*\' \'{"ha-mode": "all"}\'',
       unless  => '/usr/sbin/rabbitmqctl list_policies | grep -q HA',
-      require => Service['rabbitmq-server'],
+      require => Class['::rabbitmq::service'],
     } ->
     Class['::quickstack::load_balancer::amqp'] ->
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1147077

PR erratum for #372.  Require the class instead of the service
resource, since the service resource does not exist after the first
run due to the service being unmanaged.
