### PR TITLE
BZ #1127236 - Create cron job to flush the keystone tokens.

### DIFF
--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -99,6 +99,7 @@ class quickstack::controller_common (
 ) inherits quickstack::params {
 
   class {'quickstack::openstack_common': }
+  include ::quickstack::cron::keystone_token
 
   if str2bool_i("$ssl") {
     $qpid_protocol = 'ssl'

--- a/puppet/modules/quickstack/manifests/cron/keystone_token.pp
+++ b/puppet/modules/quickstack/manifests/cron/keystone_token.pp
@@ -1,0 +1,17 @@
+class quickstack::cron::keystone_token {
+  # Run token flush every minute (without output so we won't spam admins)
+  # This seems like something that should be in puppet-keystone, but since it is
+  # not, adding to quickstack.
+  cron { 'token-flush':
+    ensure  => 'present',
+    command => '/usr/bin/keystone-manage token_flush >/dev/null 2>&1',
+    minute  => '*/1',
+    user    => 'keystone',
+    require => [User['keystone'], Group['keystone']],
+    } ->
+
+    service { 'crond':
+      ensure => 'running',
+      enable => true,
+    }
+}

--- a/puppet/modules/quickstack/manifests/keystone/common.pp
+++ b/puppet/modules/quickstack/manifests/keystone/common.pp
@@ -84,4 +84,6 @@ class quickstack::keystone::common (
     verbose        => $verbose,
   }
   contain keystone
+
+  include ::quickstack::cron::keystone_token
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1127236

Since puppet-keystone does not set this up, add to quickstack. To reduce code
duplication and increase consistency between HA and non, move to using
quickstack::keystone classes as part of this PR.
