### PR TITLE
BZ #1124484 - Puppet fails on networker after br-ex is configured.

### DIFF
--- a/puppet/modules/quickstack/lib/puppet/parser/functions/find_ip.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/find_ip.rb
@@ -15,7 +15,14 @@ This returns the ip associated with the given network or nic.
     if (the_network != '')
       function_get_ip_from_network([the_network])
     elsif (the_nic != '')
-      function_get_ip_from_nic([the_nic])
+      my_ip = nil
+      the_nic.to_a.each do |this_nic|
+        if !function_get_ip_from_nic([this_nic]).nil?
+          my_ip = function_get_ip_from_nic([this_nic])
+          break
+        end
+      end
+      my_ip
     else
       the_ip
     end

--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -152,7 +152,9 @@ class quickstack::neutron::all (
     neutron_admin_auth_url => "http://${auth_host}:35357/v2.0",
   }
 
-  $local_ip = find_ip("$ovs_tunnel_network","$ovs_tunnel_iface","")
+  $local_ip = find_ip("$ovs_tunnel_network",
+                      ["$ovs_tunnel_iface","$external_network_bridge"],
+                      "")
 
   class { '::neutron::agents::ovs':
     bridge_mappings  => $ovs_bridge_mappings,

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -75,7 +75,9 @@ class quickstack::neutron::networker (
 
     neutron_plugin_ovs { 'AGENT/l2_population': value => "$ovs_l2_population"; }
 
-    $local_ip = find_ip("$ovs_tunnel_network","$ovs_tunnel_iface","")
+    $local_ip = find_ip("$ovs_tunnel_network",
+                        ["$ovs_tunnel_iface","$external_network_bridge"],
+                        "")
 
     class { '::neutron::agents::ovs':
       bridge_uplinks   => $ovs_bridge_uplinks,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1124484

Previously, once the IP was moved to the bridge, subsequent puppet runs would
fail because puppet would (rightly) find no ip on the ovs_tunnel_iface.  This
patch updates the find_ip finction to optionally take a list of interfaces to
check.  In the case of the networker node, we use the external_network_bridge to
check for IP as well, if set.
