### PR TITLE
BZ #1150246 - galera+puppet stability improvements

### DIFF
--- a/puppet/modules/quickstack/manifests/galera/server.pp
+++ b/puppet/modules/quickstack/manifests/galera/server.pp
@@ -21,6 +21,7 @@ class quickstack::galera::server (
       bind_address   => $mysql_bind_address,
       root_password  => $mysql_root_password,
       default_engine => 'InnoDB',
+      restart => false,
     },
     service_enable        => $service_enable,
     service_ensure        => $service_ensure,


### PR DESCRIPTION
- Only create openstack db users on the boostrap node rather than
  all nodes.
- Do not restart mysql after setting root pw.  This affects all nodes,
  so this changes prevents N mysqld restarts which should improve
  cluster stability in the bootstrap phase).
- Add a pcs resource cleanup for galera to allow pacemaker to retry
  starting galera.  Occasionally, one node had been observed to fail
  after the pacemaker resource was added.  However, allowing pacemaker
  to try again typically resolves the issue.
- remove "meta ordered=true" which was being ignored as it was
  in the wrong location within the pcs command line.
