### PR TITLE
BZ#1149777: Add host id to neutron.conf

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -187,6 +187,10 @@ class quickstack::neutron::all (
     shared_secret  => $neutron_metadata_proxy_secret,
   }
 
+  neutron_config {
+    'DEFAULT/host': value => 'neutron-n-0';
+  }
+
   include quickstack::neutron::notifications
 
   #class { 'neutron::agents::lbaas': }


### PR DESCRIPTION
In order for services to fail over properly, a host id must be added to
the DEFAULT section of neutron.conf. This must match on all nodes
involved in the failover.
