### PR TITLE
BZ #1084229 - Add support for configuring SSL for RabbitMQ

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer_controller.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer_controller.pp
@@ -10,6 +10,7 @@ class quickstack::ceilometer_controller(
   $qpid_protocol = 'tcp',
   $amqp_username,
   $amqp_password,
+  $rabbit_use_ssl = false,
   $verbose,
 ) {
 
@@ -42,6 +43,7 @@ class quickstack::ceilometer_controller(
         rabbit_port     => $amqp_port,
         rabbit_userid   => $amqp_username,
         rabbit_password => $amqp_password,
+        rabbit_use_ssl  => $rabbit_use_ssl,
         rpc_backend     => amqp_backend('ceilometer', $amqp_provider),
         verbose         => $verbose,
     }

--- a/puppet/modules/quickstack/manifests/cinder.pp
+++ b/puppet/modules/quickstack/manifests/cinder.pp
@@ -20,6 +20,7 @@ class quickstack::cinder(
   $amqp_password  = '',
   $qpid_heartbeat = '60',
   $qpid_protocol  = 'tcp',
+  $rabbit_use_ssl = false,
 
   $enabled        = true,
   $manage_service = true,
@@ -62,6 +63,7 @@ class quickstack::cinder(
     rabbit_port     => $amqp_port,
     rabbit_userid   => $amqp_username,
     rabbit_password => $amqp_password_safe_for_cinder,
+    rabbit_use_ssl  => $rabbit_use_ssl,
     sql_connection  => $sql_connection,
     verbose         => str2bool_i("$verbose"),
     use_syslog      => str2bool_i("$use_syslog"),

--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -168,6 +168,7 @@ class quickstack::compute_common (
     rabbit_port        => $real_amqp_port,
     rabbit_userid      => $amqp_username,
     rabbit_password    => $amqp_password,
+    rabbit_use_ssl     => $ssl,
     verbose            => $verbose,
   }
 
@@ -202,6 +203,7 @@ class quickstack::compute_common (
       rabbit_port     => $real_amqp_port,
       rabbit_userid   => $amqp_username,
       rabbit_password => $amqp_password,
+      rabbit_use_ssl  => $ssl,
       rpc_backend     => amqp_backend('ceilometer', $amqp_provider),
       verbose         => $verbose,
     }

--- a/puppet/modules/quickstack/manifests/controller_common.pp
+++ b/puppet/modules/quickstack/manifests/controller_common.pp
@@ -250,6 +250,7 @@ class quickstack::controller_common (
     amqp_username  => $amqp_username,
     amqp_password  => $amqp_password,
     amqp_provider  => $amqp_provider,
+    rabbit_use_ssl => $ssl,
   }
 
   # Configure Nova
@@ -265,6 +266,7 @@ class quickstack::controller_common (
     rabbit_userid      => $amqp_username,
     rabbit_password    => $amqp_password,
     rabbit_port        => $amqp_port,
+    rabbit_use_ssl     => $ssl,
     verbose            => $verbose,
     qpid_protocol      => $qpid_protocol,
     qpid_port          => $amqp_port,
@@ -311,6 +313,7 @@ class quickstack::controller_common (
     amqp_port                   => $amqp_port,
     amqp_username               => $amqp_username,
     amqp_password               => $amqp_password,
+    rabbit_use_ssl              => $ssl,
     verbose                     => $verbose,
   }
 
@@ -326,19 +329,20 @@ class quickstack::controller_common (
   }
 
   class { 'quickstack::cinder':
-    user_password => $cinder_user_password,
-    db_host       => $mysql_host,
-    db_ssl        => $ssl,
-    db_ssl_ca     => $mysql_ca,
-    db_password   => $cinder_db_password,
-    glance_host   => $controller_priv_host,
-    rpc_backend   => amqp_backend('cinder', $amqp_provider),
-    amqp_host     => $amqp_host,
-    amqp_port     => $amqp_port,
-    amqp_username => $amqp_username,
-    amqp_password => $amqp_password,
-    qpid_protocol => $qpid_protocol,
-    verbose       => $verbose,
+    user_password  => $cinder_user_password,
+    db_host        => $mysql_host,
+    db_ssl         => $ssl,
+    db_ssl_ca      => $mysql_ca,
+    db_password    => $cinder_db_password,
+    glance_host    => $controller_priv_host,
+    rpc_backend    => amqp_backend('cinder', $amqp_provider),
+    amqp_host      => $amqp_host,
+    amqp_port      => $amqp_port,
+    amqp_username  => $amqp_username,
+    amqp_password  => $amqp_password,
+    qpid_protocol  => $qpid_protocol,
+    rabbit_use_ssl => $ssl,
+    verbose        => $verbose,
   }
 
   # preserve original behavior - fall back to iscsi

--- a/puppet/modules/quickstack/manifests/glance.pp
+++ b/puppet/modules/quickstack/manifests/glance.pp
@@ -39,6 +39,7 @@ class quickstack::glance (
   $amqp_username            = '',
   $amqp_password            = '',
   $amqp_provider            = 'rabbitmq',
+  $rabbit_use_ssl           = false,
 ) {
 
   # Configure the db string
@@ -117,6 +118,7 @@ class quickstack::glance (
       rabbit_userid   => $amqp_username,
       rabbit_host     => $amqp_host,
       rabbit_port     => $amqp_port,
+      rabbit_use_ssl  => $rabbit_use_ssl,
     }
   }
 

--- a/puppet/modules/quickstack/manifests/heat.pp
+++ b/puppet/modules/quickstack/manifests/heat.pp
@@ -17,6 +17,7 @@ class quickstack::heat(
   $amqp_username           = '',
   $amqp_password           = '',
   $amqp_provider           = 'rabbitmq',
+  $rabbit_use_ssl          = false,
 
   $cfn_host                = '127.0.0.1',
   $cloudwatch_host         = '127.0.0.1',
@@ -68,6 +69,7 @@ class quickstack::heat(
     rabbit_port       => $amqp_port,
     rabbit_userid     => $amqp_username,
     rabbit_password   => $amqp_password,
+    rabbit_use_ssl    => $rabbit_use_ssl,
     use_syslog        => str2bool_i("$use_syslog"),
     log_facility      => $log_facility,
     verbose           => $verbose,

--- a/puppet/modules/quickstack/manifests/heat_controller.pp
+++ b/puppet/modules/quickstack/manifests/heat_controller.pp
@@ -52,6 +52,7 @@ class quickstack::heat_controller(
       rabbit_port       => $amqp_port,
       rabbit_userid     => $amqp_username,
       rabbit_password   => $amqp_password,
+      rabbit_use_ssl    => $ssl,
       verbose           => $verbose,
       sql_connection    => $sql_connection,
   }

--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -99,6 +99,7 @@ class quickstack::neutron::all (
     rabbit_port           => $real_amqp_port,
     rabbit_user           => $amqp_username,
     rabbit_password       => $amqp_password,
+    rabbit_use_ssl        => $ssl,
     verbose               => $verbose,
   }
   ->

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -82,6 +82,7 @@ class quickstack::neutron::compute (
     rabbit_port           => $real_amqp_port,
     rabbit_user           => $amqp_username,
     rabbit_password       => $amqp_password,
+    rabbit_use_ssl        => $ssl,
     verbose               => $verbose,
   }
   ->

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -264,6 +264,7 @@ class quickstack::neutron::controller (
     rabbit_port           => $amqp_port,
     rabbit_user           => $amqp_username,
     rabbit_password       => $amqp_password,
+    rabbit_use_ssl        => $ssl,
     core_plugin           => $neutron_core_plugin
   }
   ->

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -55,6 +55,7 @@ class quickstack::neutron::networker (
     rabbit_port           => $amqp_port,
     rabbit_user           => $amqp_username,
     rabbit_password       => $amqp_password,
+    rabbit_use_ssl        => $ssl,
   }
 
   neutron_config {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1084229

Pass the value of $ssl as rabbit_use_ssl to the nova and cinder
services

This relies on o-p-m pulling in fixes for puppet-ceilometer and puppet-neutron to drop the requirement for kombu certificates when SSL in rabbit is enabled. See BZ for blocking bugs.
