### PR TITLE
BZ #1156183 - open ceph ports on ceph storage node

### DIFF
--- a/puppet/modules/quickstack/manifests/firewall/ceph_osd.pp
+++ b/puppet/modules/quickstack/manifests/firewall/ceph_osd.pp
@@ -1,0 +1,13 @@
+class quickstack::firewall::ceph_osd (
+  $ports = ['6800-6810'],
+  $proto = 'tcp',
+) {
+
+  include quickstack::firewall::common
+
+  firewall { '001 ceph osd incoming':
+    proto  => $proto,
+    dport  => $ports,
+    action => 'accept',
+  }
+}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1156183

Open osd-related ports on ceph storage node.
