### PR TITLE
contain pcmk_resource within the quickstack pacemaker service

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/resource/service.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/service.pp
@@ -14,5 +14,15 @@ define quickstack::pacemaker::resource::service($group='',
                                 monitor_params => $monitor_params,
                                 ensure         => $ensure,
                                 options        => $options}
+
+    anchor { "qprs start $name": } 
+    -> Pcmk_Resource["$name"]
+    -> exec {"wait for pcmk_resource $name":
+        timeout   => 3600,
+        tries     => 360,
+        try_sleep => 10,
+        command   => "/usr/sbin/pcs resource show $name",
+    }
+    -> anchor { "qprs end $name": }
   }
 }


### PR DESCRIPTION
This PR it intended to address the error http://fpaste.org/145063/14200364/ discovered by QE . I was not able to reproduce this error in development, despite re-running puppet and deleting pcs resources a couple of dozen times.  However, this PR takes a stab at fixing the potential problems:
- a non-deterministic puppet error where the actual bit of puppet that creates the pacemaker resource wasn't "contained" (by adding the anchors and " -> Pcmk_Resource["$name"]")
- making sure pacemaker has really created resource (it may take some time for the cluster nodes to agree it has been created) with an extra exec/wait check.

I tested it, seems to work.
