### PR TITLE
BZ #1151438: Add support for network_device_mtu and veth_mtu

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -47,6 +47,7 @@ class quickstack::compute_common (
   $private_ip                   = '',
   $rbd_user                     = 'volumes',
   $rbd_secret_uuid              = '',
+  $network_device_mtu           = $quickstack::params::network_device_mtu,
   $ssl                          = $quickstack::params::ssl,
   $verbose                      = $quickstack::params::verbose,
 ) inherits quickstack::params {
@@ -188,9 +189,10 @@ class quickstack::compute_common (
                         "$private_iface",
                         "$private_ip")
   class { '::nova::compute':
-    enabled => true,
-    vncproxy_host => $nova_host,
+    enabled                       => true,
+    vncproxy_host                 => $nova_host,
     vncserver_proxyclient_address => $compute_ip,
+    network_device_mtu            => $network_device_mtu,
   }
 
   if str2bool_i("$ceilometer") {

--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -70,6 +70,8 @@ class quickstack::neutron::all (
   $rpc_backend                   = 'neutron.openstack.common.rpc.impl_kombu',
   $security_group_api            = 'neutron',
   $tenant_network_type           = 'vlan',
+  $network_device_mtu            = undef,
+  $veth_mtu                      = undef,
   $verbose                       = 'false',
   $ssl                           = 'false',
 ) {
@@ -101,6 +103,7 @@ class quickstack::neutron::all (
     rabbit_password       => $amqp_password,
     rabbit_use_ssl        => $ssl,
     verbose               => $verbose,
+    network_device_mtu    => $network_device_mtu,
   }
   ->
   # FIXME: This really should be handled by the neutron-puppet module, which has
@@ -189,6 +192,7 @@ class quickstack::neutron::all (
       manage_service   => str2bool_i("$manage_service"),
       tunnel_types     => $ovs_tunnel_types,
       vxlan_udp_port   => $ovs_vxlan_udp_port,
+      veth_mtu         => $veth_mtu,
     }
   }
 

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -46,7 +46,7 @@ class quickstack::neutron::compute (
   $ovs_tunnel_types             = $quickstack::params::ovs_tunnel_types,
   $verbose                      = $quickstack::params::verbose,
   $ssl                          = $quickstack::params::ssl,
-  $security_group_api		= 'neutron',
+  $security_group_api           = 'neutron',
   $mysql_ca                     = $quickstack::params::mysql_ca,
   $libvirt_images_rbd_pool      = 'volumes',
   $libvirt_images_rbd_ceph_conf = '/etc/ceph/ceph.conf',
@@ -58,6 +58,8 @@ class quickstack::neutron::compute (
   $private_iface                = '',
   $private_ip                   = '',
   $private_network              = '',
+  $network_device_mtu           = undef,
+  $veth_mtu                     = undef,
 ) inherits quickstack::params {
 
   if str2bool_i("$ssl") {
@@ -84,6 +86,7 @@ class quickstack::neutron::compute (
     rabbit_password       => $amqp_password,
     rabbit_use_ssl        => $ssl,
     verbose               => $verbose,
+    network_device_mtu    => $network_device_mtu,
   }
   ->
   class { '::neutron::server::notifications':
@@ -120,8 +123,9 @@ class quickstack::neutron::compute (
       bridge_mappings     => $ovs_bridge_mappings,
       local_ip            => $local_ip,
       enable_tunneling    => str2bool_i("$enable_tunneling"),
-      tunnel_types     => $ovs_tunnel_types,
-      vxlan_udp_port   => $ovs_vxlan_udp_port,
+      tunnel_types        => $ovs_tunnel_types,
+      vxlan_udp_port      => $ovs_vxlan_udp_port,
+      veth_mtu            => $veth_mtu,
     }
   }
 
@@ -176,6 +180,7 @@ class quickstack::neutron::compute (
     private_iface                => $private_iface,
     private_ip                   => $private_ip,
     private_network              => $private_network,
+    network_device_mtu           => $network_device_mtu,
   }
 
   class {'quickstack::neutron::firewall::gre':}

--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -140,6 +140,8 @@ class quickstack::neutron::controller (
   $horizon_cert                  = $quickstack::params::horizon_cert,
   $horizon_key                   = $quickstack::params::horizon_key,
   $amqp_nssdb_password           = $quickstack::params::amqp_nssdb_password,
+  $network_device_mtu            = $quickstack::params::network_device_mtu,
+  $veth_mtu                      = $quickstack::params::veth_mtu,
 ) inherits quickstack::params {
 
   if str2bool_i("$ssl") {
@@ -265,7 +267,8 @@ class quickstack::neutron::controller (
     rabbit_user           => $amqp_username,
     rabbit_password       => $amqp_password,
     rabbit_use_ssl        => $ssl,
-    core_plugin           => $neutron_core_plugin
+    core_plugin           => $neutron_core_plugin,
+    network_device_mtu    => $network_device_mtu,
   }
   ->
   class { '::nova::network::neutron':

--- a/puppet/modules/quickstack/manifests/neutron/networker.pp
+++ b/puppet/modules/quickstack/manifests/neutron/networker.pp
@@ -28,6 +28,8 @@ class quickstack::neutron::networker (
   $verbose                       = $quickstack::params::verbose,
   $ssl                           = $quickstack::params::ssl,
   $mysql_ca                      = $quickstack::params::mysql_ca,
+  $network_device_mtu            = $quickstack::params::network_device_mtu,
+  $veth_mtu                      = $quickstack::params::veth_mtu,
 ) inherits quickstack::params {
 
   class {'quickstack::openstack_common': }
@@ -56,6 +58,7 @@ class quickstack::neutron::networker (
     rabbit_user           => $amqp_username,
     rabbit_password       => $amqp_password,
     rabbit_use_ssl        => $ssl,
+    network_device_mtu    => $network_device_mtu,
   }
 
   neutron_config {
@@ -87,6 +90,7 @@ class quickstack::neutron::networker (
       enable_tunneling => str2bool_i("$enable_tunneling"),
       tunnel_types     => $ovs_tunnel_types,
       vxlan_udp_port   => $ovs_vxlan_udp_port,
+      veth_mtu         => $veth_mtu,
     }
   }
 

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -55,7 +55,7 @@ class quickstack::nova_network::compute (
   $private_iface                = '',
   $private_ip                   = '',
   $private_network              = '',
-
+  $network_device_mtu           = undef,
 ) inherits quickstack::params {
 
   # Configure Nova
@@ -133,5 +133,6 @@ class quickstack::nova_network::compute (
     private_iface                => $private_iface,
     private_ip                   => $private_ip,
     private_network              => $private_network,
+    network_device_mtu           => $network_device_mtu,
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -50,6 +50,8 @@ class quickstack::pacemaker::neutron (
   $tunnel_id_ranges           = '1:1000',
   $nexus_config               = {},
   $verbose                    = 'false',
+  $network_device_mtu         = undef,
+  $veth_mtu                   = undef,
 ) {
   include quickstack::pacemaker::common
 
@@ -112,8 +114,8 @@ class quickstack::pacemaker::neutron (
     class { 'quickstack::neutron::all':
       auth_host                     => map_params("keystone_public_vip"),
       database_max_retries          => '-1',
-      cisco_vswitch_plugin         => $cisco_vswitch_plugin,
-      cisco_nexus_plugin           => $cisco_nexus_plugin,
+      cisco_vswitch_plugin          => $cisco_vswitch_plugin,
+      cisco_nexus_plugin            => $cisco_nexus_plugin,
       enable_tunneling              => $enable_tunneling,
       enabled                       => $_enabled,
       external_network_bridge       => $external_network_bridge,
@@ -136,8 +138,8 @@ class quickstack::pacemaker::neutron (
       neutron_metadata_proxy_secret => map_params("neutron_metadata_proxy_secret"),
       neutron_conf_additional_params=> $neutron_conf_additional_params,
       nova_conf_additional_params   => $nova_conf_additional_params,
-      n1kv_vsm_ip                  => $n1kv_vsm_ip,
-      n1kv_vsm_password            => $n1kv_vsm_password,
+      n1kv_vsm_ip                   => $n1kv_vsm_ip,
+      n1kv_vsm_password             => $n1kv_vsm_password,
       n1kv_plugin_additional_params => $n1kv_plugin_additional_params,
       ovs_bridge_mappings           => $ovs_bridge_mappings,
       ovs_bridge_uplinks            => $ovs_bridge_uplinks,
@@ -154,6 +156,8 @@ class quickstack::pacemaker::neutron (
       security_group_api            => $security_group_api,
       nexus_config                  => $nexus_config,
       verbose                       => $verbose,
+      network_device_mtu            => $network_device_mtu,
+      veth_mtu                      => $veth_mtu,
     }
     ->
     exec {"pcs-neutron-server-set-up":

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -115,6 +115,8 @@ class quickstack::params (
   $enable_tunneling              = 'True',
   $ovs_vxlan_udp_port            = '4789',
   $ovs_tunnel_types              = [],
+  $network_device_mtu            = undef,
+  $veth_mtu                      = undef,
 
   # neutron plugin config
   $neutron_core_plugin           = 'neutron.plugins.ml2.plugin.Ml2Plugin',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1151438

Expose the network_device_mtu param on neutron and the veth_mtu param on
neutron::agents::ovs in order to properly set the mtu in the appropriate
configurations. Both params default to undef, so if not specified, there
will be no change in behaviour.
