### PR TITLE
BZ#1168433 - undefined method `to_a' for "ens7":String

### DIFF
--- a/puppet/modules/quickstack/lib/puppet/parser/functions/find_ip.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/find_ip.rb
@@ -16,7 +16,7 @@ This returns the ip associated with the given network or nic.
       function_get_ip_from_network([the_network])
     elsif (the_nic != '')
       my_ip = nil
-      the_nic.to_a.each do |this_nic|
+      [the_nic].flatten.each do |this_nic|
         if !function_get_ip_from_nic([this_nic]).nil?
           my_ip = function_get_ip_from_nic([this_nic])
           break


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1168433

We want to allow both a string and an array of strings as the
`the_nic` parameter to `find_ip` function. However, `to_a` method is
not defined on strings. We now use a different approach with `flatten`
method.
