### PR TITLE
longer default timeout for mongodb

### DIFF
--- a/puppet/modules/quickstack/manifests/db/nosql.pp
+++ b/puppet/modules/quickstack/manifests/db/nosql.pp
@@ -29,12 +29,27 @@
 
 
 class quickstack::db::nosql(
-  $bind_host       = '127.0.0.1',
-  $nojournal       = false,
-  $port            = '27017',
-  $service_enable  = true,
-  $service_ensure  = 'running',
+  $bind_host             = '127.0.0.1',
+  $nojournal             = false,
+  $port                  = '27017',
+  $service_enable        = true,
+  $service_ensure        = 'running',
+  $service_start_timeout = '240',
 ) {
+
+  # This can be removed when bz 1040573 is resolved
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1040573
+  if (($::operatingsystem == 'fedora' and versioncmp($::operatingsystemrelease, '22') >= 0) or
+      ($::operatingsystem != 'fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0)) {
+    $mongodb_service_file_path = '/usr/lib/systemd/system/mongod.service'
+  } else {
+    $mongodb_service_file_path = '/usr/lib/systemd/system/mongodb.service'
+  }
+  file_line {'mongodb start timeout':
+    path => $mongodb_service_file_path,
+    after => '\[Service\]',
+    line => "TimeoutStartSec=$service_start_timeout",
+  } -> Service['mongodb']
 
   anchor {'mongodb setup start': }
   ->


### PR DESCRIPTION
The default systemd TimeoutStartSec of 30 seconds isn't long enough on
slow systems.  Make it 240 seconds so we don't timeout (mainly an
issue the first time mongodb is started).
