### PR TITLE
Hiera - Multiple scenarios support [AIO Part I]

### DIFF
--- a/puppet/modules/quickstack/data/README.md
+++ b/puppet/modules/quickstack/data/README.md
@@ -1,41 +1,70 @@
-# Hiera built-in data
+# Hiera built-in data for Quicsktack
 
-## Setup
-* Install Puppet and Git RPMs
+## Prerequesites
+* Puppet must be setup with future parser option  
 
+- Add following to /etc/puppet/puppet.conf main section: `parser = future`
+or   
+- run following  
+```
+yum -y install augeas
+augtool set /files/etc/puppet/puppet.conf/main/parser future
+```
+
+## Setup  
+* Install Puppet and Git RPMs  
 `yum install -y puppet git`
 
-* Install openstack-puppet-modules RPM
-
+* Install openstack-puppet-modules RPM  
 `yum -y install openstack-puppet-modules`
 
-* Install Quickstack module from Openstack-Foreman-Installer RPM (RHEL-6-Server-OS-Foreman repo)
-
+* Install Quickstack module from Openstack-Foreman-Installer RPM (RHEL-6-Server-OS-Foreman repo). Or alternatively use github source  
 `yum -y install openstack-foreman-installer`
-Alternatively use github source
 
-* Create following link for Hiera to work with Puppet (BZ#1108039)
-
+* Create following link for Hiera to work with Puppet (BZ#1108039)  
 `ln -sf /etc/hiera.yaml /etc/puppet/hiera.yaml`
 
-* classes should be available at hiera top level
+## Set the scene  
+At installation time, the scenario is defined to 'HA' by default in /usr/share/openstack-foreman-installer/puppet/modules/quickstack/data/defaults.yaml
 
-`cp /usr/share/openstack-foreman-installer/puppet/modules/quickstack/data/classes.yaml /var/lib/hiera/defaults.yaml`
-
-## Masterless Deployment - Neither Puppet master nor Foreman server needed
-
-* Change values in YAML files accordingly
-
-* Run Puppet on each node
-
+* To quickly override the scenario, define a new value using /var/lib/hiera/defaults.yaml:  
 ```
-puppet apply -e "hiera_include(<NODE_TYPE>)"  --modulepath=/usr/share/openstack-puppet/modules:/usr/share/openstack-foreman-installer/puppet/modules
+---
+scenario: '<SCENARIO>'
+```
+Choosing <SCENARIO> from the following list:  
+```
+ HA
+ HA-AIO
+ HA-AIO-Neutron
+ HA-AIO-Neutron-compute
+ HA-Neutron
+ Neutron-agents
+ Neutron-ML2-OVS
+ Nova-compute
+ Nova-compute-Neutron-ML2-OVS
+ NHA
+ NHA-Neutron-agents
+ NHA-Neutron-compute
+ PCS-Neutron
+ custom
 ```
 
-where `<NODE_TYPE> ::= HA_AIO_classes | compute_classes`
+* To check all available scenarios   
+Lookup in modules/quickstack/data/classes.yaml file
+or alternatively run:  
+`puppet apply -e "include quickstack::scene" --modulepath=/usr/share/openstack-puppet/modules:/usr/share/openstack-foreman-installer/puppet/modules`
 
-## Notes
+## Run  
+* Masterless deployments where neither Puppet master nor Foreman server are needed  
+Run Puppet on each node  
+`puppet apply -e "include quickstack"  --modulepath=/usr/share/openstack-puppet/modules:/usr/share/openstack-foreman-installer/puppet/modules`
+
+* Using the Foreman   
+YAML parameters are propagated only when the Foreman setting for ENC parameters is turned off.
+
+## Notes  
 * Tested on RHO5/RHEL7
 * Setenforce 0 - Nova scheduler: missing SELinux AVC (BZ#1149975)
-* Compute class to be added soon
+* Scenarios scaffold in progress
 * The Openstack Puppet Modules includes module-data which allows YAML data to be built-in

--- a/puppet/modules/quickstack/data/classes.yaml
+++ b/puppet/modules/quickstack/data/classes.yaml
@@ -1,21 +1,92 @@
-# HA All In One Controller
-HA_AIO_classes:
-  - quickstack::openstack_common
-  - quickstack::pacemaker::common
-  - quickstack::pacemaker::params
-  - quickstack::pacemaker::keystone
-  - quickstack::pacemaker::swift
-  - quickstack::pacemaker::load_balancer
-  - quickstack::pacemaker::memcached
-  - quickstack::pacemaker::qpid
-  - quickstack::pacemaker::rabbitmq
-  - quickstack::pacemaker::glance
-  - quickstack::pacemaker::nova
-  - quickstack::pacemaker::heat
-  - quickstack::pacemaker::cinder
-  - quickstack::pacemaker::horizon
-  - quickstack::pacemaker::galera
-  - quickstack::pacemaker::neutron
+---
+quickstack::params::scenario: "%{hiera('scenario')}"
+quickstack::params::scenarii:
+  compute:
+    desc: "Nova Compute (no network)"
+    classes:
+    - quickstack::compute_common
 
-compute_classes:
-  - quickstack::neutron::compute
+  compute-neutron:
+    desc: "Nova Compute, Neutron Network"
+    classes:
+    - quickstack::neutron::nova
+    roles:
+    - compute
+    - neutron-client-ML2-OVS
+
+  custom:
+    desc: "Scenario from a list of classes and/or roles"
+    roles: []
+    classes: []
+
+  HA:
+    desc: "HA Controllers (3+), Neutron Network agents"
+    roles:
+    - HA-controller
+    - PCS-neutron
+    - neutron-network-agents
+
+  HA-AIO:
+    desc: "HA All in One (1), HA Controllers, Neutron network agents, Compute"
+    classes:
+    - quickstack::compute_common
+    roles:
+    - HA
+
+  HA-controller:
+    desc: "HA Controllers (3+), No network"
+    classes:
+    - quickstack::openstack_common
+    - quickstack::pacemaker::common
+    - quickstack::pacemaker::params
+    - quickstack::pacemaker::keystone
+    - quickstack::pacemaker::swift
+    - quickstack::pacemaker::load_balancer
+    - quickstack::pacemaker::memcached
+    - quickstack::pacemaker::qpid
+    - quickstack::pacemaker::rabbitmq
+    - quickstack::pacemaker::glance
+    - quickstack::pacemaker::nova
+    - quickstack::pacemaker::heat
+    - quickstack::pacemaker::cinder
+    - quickstack::pacemaker::horizon
+    - quickstack::pacemaker::galera
+
+  neutron-client-ML2-OVS:
+    desc: "Neutron network layer, ML2 plugin, OVS agent"
+    classes:
+    - quickstack::neutron
+    - quickstack::neutron::plugins::ml2
+    - quickstack::neutron::agents::ovs
+
+  neutron-network-agents:
+    desc: "Neutron network agents"
+    classes:
+    - quickstack::neutron::agents::dhcp
+    - quickstack::neutron::agents::l3
+    - quickstack::neutron::agents::lbass
+    - quickstack::neutron::services::fwaas
+    roles:
+    - neutron-client-ML2-OVS
+
+  PCS-neutron:
+    desc: "Pacemaker Neutron"
+    classes:
+    - quickstack::pacemaker::neutron
+    roles:
+    - neutron-client-ML2-OVS
+
+  legacy-controller-NHA:
+    desc: "NHA Controller (1)"
+    classes:
+    - quickstack::neutron::controller
+
+  legacy-neutron-networker:
+    desc: "Neutron Agents"
+    classes:
+    - quickstack::neutron::networker
+
+  legacy-compute-neutron:
+    desc: "Nova Compute, Neutron NHA client"
+    classes:
+    - quickstack::neutron::compute

--- a/puppet/modules/quickstack/data/defaults.yaml
+++ b/puppet/modules/quickstack/data/defaults.yaml
@@ -1,4 +1,6 @@
 ---
+scenario: 'HA'
+
 admin_email: 'admin@example.com'
 
 amqp_provider: 'rabbitmq'

--- a/puppet/modules/quickstack/data/hiera.yaml
+++ b/puppet/modules/quickstack/data/hiera.yaml
@@ -4,4 +4,5 @@
 - custom
 - secrets
 - "%{::osfamily}"
+- classes
 - defaults

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/scenario_classes.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/scenario_classes.rb
@@ -1,0 +1,19 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppetx', 'redhat', 'scenario.rb'))
+
+module Puppet::Parser::Functions
+
+newfunction(:scenario_classes, :type => :rvalue, :doc => <<-EOS
+Returns unique list of all embedded class for a scenario
+EOS
+) do |arguments|
+    Puppet::Parser::Functions.autoloader.loadall
+    raise(Puppet::ParseError, "scenario_classes(): Wrong number of arguments " +
+      "given (#{arguments.size} for 2)") if arguments.size < 2
+
+    scenario = arguments[0] ||= ''
+    scenarii = arguments[1] ||= {}
+    raise(Puppet::ParseError, "Missing argumets") if scenario.empty? || scenarii.empty?
+
+    Scenario::Scene.all_classes(scenario, scenarii)
+  end
+end

--- a/puppet/modules/quickstack/lib/puppetx/redhat/scenario.rb
+++ b/puppet/modules/quickstack/lib/puppetx/redhat/scenario.rb
@@ -1,0 +1,30 @@
+module Scenario
+  class Scene
+    class << self
+      def get_all_classes(roles, scenarii)
+        list = []
+        roles.each do |role|
+          if scenarii[role]
+            if scenarii[role]['roles'] && !scenarii[role]['roles'].empty?
+              list << Scene.get_all_classes(scenarii[role]['roles'], scenarii)
+            end
+            if scenarii[role]['classes'] && !scenarii[role]['classes'].empty?
+              list << scenarii[role]['classes']
+            end
+          end
+        end
+        list.flatten!.uniq! unless list.empty?
+        list.delete_if {|x| x == nil }
+        list
+      end
+
+      def all_classes(scenario, scenarii)
+        list = []
+        list = Scene.get_all_classes(scenarii[scenario]['roles'], scenarii) if scenarii[scenario]['roles']
+        list << scenarii[scenario]['classes'] if scenarii[scenario]['classes']
+        list.flatten! unless list.empty?
+        list
+      end
+    end
+  end
+end

--- a/puppet/modules/quickstack/manifests/init.pp
+++ b/puppet/modules/quickstack/manifests/init.pp
@@ -1,5 +1,10 @@
-# Common quickstack configurations
+# Quickstack init
+class quickstack () inherits quickstack::params {
+  $list = scenario_classes("$scenario", $scenarii)
 
-class quickstack(){
-  require ntp
+  notify {"running $scenario":}
+  $list.each |$e| {
+    include "$e"
+  }
 }
+

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -1,5 +1,6 @@
 class quickstack::params (
-  # This class needs to go away.
+  $scenarii = [],
+  $scenario = '',
 
   # Logs
   $admin_email                = "admin@${::domain}",

--- a/puppet/modules/quickstack/manifests/scene.pp
+++ b/puppet/modules/quickstack/manifests/scene.pp
@@ -1,0 +1,12 @@
+# Quickstack scene class
+# Provides running scenario details
+class quickstack::scene (
+) inherits quickstack::params {
+
+  $modules = join(scenario_classes("$scenario", $scenarii), ',')
+  $scenes = join(any2array($scenarii), ',')
+
+  notify {"quickstack::params::scenarii: ${scenes}":}
+
+  notify {"Puppet classes for scenario ${scenario}: ${modules}":}
+}


### PR DESCRIPTION
A scenario contains puppet classes and/or any other defined scenario.
The generated puppet classes is then included.

Serves CI/CD purposes and helps with AIO approach.

It's using Hieara YAML by adding scenario and scenarii parameters

Please check puppet/modules/quickstack/data/README.md

The included manifests have to be supported for Roles support.
Another commit to follow providing neutron manifests refactored
