### PR TITLE
BZ #1172366 - better verification of pacemaker resource creation

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/resource/service.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/service.pp
@@ -15,13 +15,13 @@ define quickstack::pacemaker::resource::service($group='',
                                 ensure         => $ensure,
                                 options        => $options}
 
-    anchor { "qprs start $name": } 
+    anchor { "qprs start $name": }
     -> Pcmk_Resource["$name"]
     -> exec {"wait for pcmk_resource $name":
         timeout   => 3600,
         tries     => 360,
         try_sleep => 10,
-        command   => "/usr/sbin/pcs resource show $name",
+        command   => "/usr/sbin/cibadmin --query --xpath \"//lrm_resource[@id='$name']\"",
     }
     -> anchor { "qprs end $name": }
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1172366

When adding a pacemaker resource, really make sure it has been
added so that other resources that depend on it will not fail.
