### PR TITLE
BZ #1170564 memcached should bind only on management interface

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
@@ -1,7 +1,7 @@
 class quickstack::pacemaker::memcached {
 
-  include ::memcached
   include quickstack::pacemaker::common
+  class {"::memcached": listen_ip => map_params("local_bind_addr"), }
   class {'::quickstack::firewall::memcached':}
 
   Exec['wait-for-settle'] -> Exec['pcs-memcached-server-set-up-on-this-node']


### PR DESCRIPTION
Suggesting this change which works following the example of other manifests like rabbitmq to bind on the management interface only using the local_bind_addr from params.pp:

  $local_bind_addr = find_ip("$private_network",
                            "$private_iface",
                            "$private_ip")
