### PR TITLE
BZ #1173217 - Errors in /var/log/ceilometer/collector.log.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -86,7 +86,7 @@ class quickstack::pacemaker::ceilometer (
     ->
     class { '::quickstack::ceilometer::control':
       amqp_provider              => map_params('amqp_provider'),
-      amqp_host                  => map_params('amqp_host'),
+      amqp_host                  => map_params('amqp_vip'),
       amqp_port                  => map_params('amqp_port'),
       amqp_username              => map_params('amqp_username'),
       amqp_password              => map_params('amqp_password'),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1173217

The rabbit host/hosts values were being incorrectly set, causing ceilometer to
attempt to call rabbit on the incorrect IP.
