### PR TITLE
Removed standard function each

### DIFF
--- a/puppet/modules/quickstack/data/README.md
+++ b/puppet/modules/quickstack/data/README.md
@@ -1,16 +1,5 @@
 # Hiera built-in data for Quicsktack
 
-## Prerequesites
-* Puppet must be setup with future parser option  
-
-- Add following to /etc/puppet/puppet.conf main section: `parser = future`
-or   
-- run following  
-```
-yum -y install augeas
-augtool set /files/etc/puppet/puppet.conf/main/parser future
-```
-
 ## Setup  
 * Install Puppet and Git RPMs  
 `yum install -y puppet git`
@@ -18,7 +7,7 @@ augtool set /files/etc/puppet/puppet.conf/main/parser future
 * Install openstack-puppet-modules RPM  
 `yum -y install openstack-puppet-modules`
 
-* Install Quickstack module from Openstack-Foreman-Installer RPM (RHEL-6-Server-OS-Foreman repo). Or alternatively use github source  
+* Install Quickstack module from Openstack-Foreman-Installer RPM (RHEL-6-Server-OS-Foreman repo).
 `yum -y install openstack-foreman-installer`
 
 * Create following link for Hiera to work with Puppet (BZ#1108039)  
@@ -64,7 +53,7 @@ Run Puppet on each node
 YAML parameters are propagated only when the Foreman setting for ENC parameters is turned off.
 
 ## Notes  
-* Tested on RHO5/RHEL7
+* Tested on RHEL7/OSP6
 * Setenforce 0 - Nova scheduler: missing SELinux AVC (BZ#1149975)
 * Scenarios scaffold in progress
 * The Openstack Puppet Modules includes module-data which allows YAML data to be built-in

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/quick_include.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/quick_include.rb
@@ -1,0 +1,13 @@
+module Puppet::Parser::Functions
+  newfunction(:quick_include, :arity => 1, :doc => "Like hiera_include
+  function. Using an array as first and only parameter instead
+  ") do |args|
+    answer = args[0]
+    if answer && !answer.empty?
+      method = Puppet::Parser::Functions.function(:include)
+      send(method, [answer])
+    else
+      raise Puppet::ParseError, "Could not find data item #{answer}"
+    end
+  end
+end

--- a/puppet/modules/quickstack/manifests/init.pp
+++ b/puppet/modules/quickstack/manifests/init.pp
@@ -3,8 +3,6 @@ class quickstack () inherits quickstack::params {
   $list = scenario_classes("$scenario", $scenarii)
 
   notify {"running $scenario":}
-  $list.each |$e| {
-    include "$e"
-  }
+  quick_include($list)
 }
 

--- a/puppet/modules/quickstack/manifests/scene.pp
+++ b/puppet/modules/quickstack/manifests/scene.pp
@@ -3,8 +3,8 @@
 class quickstack::scene (
 ) inherits quickstack::params {
 
-  $modules = join(scenario_classes("$scenario", $scenarii), ',')
-  $scenes = join(any2array($scenarii), ',')
+  $modules = join(scenario_classes("$scenario", $scenarii), ', ')
+  $scenes = join(any2array($scenarii), ', ')
 
   notify {"quickstack::params::scenarii: ${scenes}":}
 


### PR DESCRIPTION
Function 'each' requires parser=future which we don't want to use

This patch replaces the class include with a custom function binding the
classes. This is the same approach as hiera_include which we used before
adding the Scenes layer.
