### PR TITLE
capitalized-variable-names-not-allowed

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/rsync/get.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rsync/get.pp
@@ -40,30 +40,30 @@ define quickstack::pacemaker::rsync::get (
   include '::quickstack::rsync::common'
 
   if $keyfile {
-    $Mykeyfile = $keyfile
+    $mykeyfile = $keyfile
   } else {
-    $Mykeyfile = "/home/${user}/.ssh/id_rsa"
+    $mykeyfile = "/home/${user}/.ssh/id_rsa"
   }
 
   if $user {
-    $MyUser = "-e 'ssh -i ${Mykeyfile} -l ${user}' ${user}@"
+    $myuser = "-e 'ssh -i ${mykeyfile} -l ${user}' ${user}@"
   }
 
   if $purge {
-    $MyPurge = '--delete'
+    $mypurge = '--delete'
   }
 
   if $exclude {
-    $MyExclude = "--exclude=${exclude}"
+    $myexclude = "--exclude=${exclude}"
   }
 
   if $path {
-    $MyPath = $path
+    $mypath = $path
   } else {
-    $MyPath = $name
+    $mypath = $name
   }
 
-  $rsync_options = "-${override_options} ${MyPurge} ${MyExclude} ${MyUser}${source} ${MyPath}"
+  $rsync_options = "-${override_options} ${mypurge} ${myexclude} ${myuser}${source} ${mypath}"
 
   exec { "rsync ${name}":
     command   => "rsync -q ${rsync_options}",


### PR DESCRIPTION
Actually I discovered that one using parser future
But I think it's good follow standards for consistency

https://docs.puppetlabs.com/puppet/latest/reference/experiments_future.html#capitalized-variable-names-not-allowed