### PR TITLE
BZ #1172366 - fix some pcmk constraints

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -221,15 +221,15 @@ class quickstack::pacemaker::neutron (
     ->
     quickstack::pacemaker::constraint::base { 'neutron-ovs-to-netns-cleanup-constr' :
       constraint_type => "order",
-      first_resource  => "neutron-ovs-cleanup",
-      second_resource => "neutron-netns-cleanup",
+      first_resource  => "neutron-ovs-cleanup-clone",
+      second_resource => "neutron-netns-cleanup-clone",
       first_action    => "start",
       second_action   => "start",
     }
     ->
     quickstack::pacemaker::constraint::base { 'neutron-cleanup-to-agents-constr' :
       constraint_type => "order",
-      first_resource  => "neutron-netns-cleanup",
+      first_resource  => "neutron-netns-cleanup-clone",
       second_resource => "neutron-agents",
       first_action    => "start",
       second_action   => "start",
@@ -274,18 +274,6 @@ class quickstack::pacemaker::neutron (
     quickstack::pacemaker::constraint::colocation { 'neutron-openvswitch-metadata-colo' :
       source => "neutron-metadata-agent",
       target => "neutron-openvswitch-agent",
-      score  => "INFINITY",
-    }
-    ->
-    quickstack::pacemaker::constraint::colocation { 'neutron-netns-ovs-cleanup-colo' :
-      source => "neutron-netns-cleanup",
-      target => "neutron-ovs-cleanup",
-      score  => "INFINITY",
-    }
-    ->
-    quickstack::pacemaker::constraint::colocation { 'neutron-agents-with-netns-cleanup-colo' :
-      source => "neutron-agents",
-      target => "neutron-netns-cleanup",
       score  => "INFINITY",
     }
   }

--- a/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
@@ -92,7 +92,6 @@ class quickstack::pacemaker::nosql (
     Exec['all-nosql-nodes-are-up'] ->
 
     quickstack::pacemaker::resource::service {'mongod':
-      group          => "$pcmk_nosql_group",
       options        => 'start timeout=10s',
       monitor_params => { 'start-delay' => '10s' },
       clone          => true,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1172366

Constraints with an incorrect name specified (i.e., no -clone) could
cause issues for pcs commands immediately following.  Also remove
groups for cloned resources.
