### PR TITLE
BZ #1173730 - pacemaker traffic optionally on a different network

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -49,14 +49,25 @@ class quickstack::pacemaker::common (
     $setup_cluster = false
   }
 
-  $pacemaker_members = join(map_params("lb_backend_server_names")," ")
+  $pacemaker_members = join(map_params("pcmk_server_names")," ")
 
   $num_hosts_idx = size(map_params("lb_backend_server_names"))-1
-  quickstack::pacemaker::hosts{ "$num_hosts_idx":
+  quickstack::pacemaker::hosts{ "lb $num_hosts_idx":
     index            => $num_hosts_idx,
     ip_address_array => map_params("lb_backend_server_addrs"),
     hostname_array   => map_params("lb_backend_server_names"),
-  } ->
+  }
+  -> Package['rpcbind']
+
+  if (map_params("pcmk_server_names") != map_params("lb_backend_server_names")) {
+    $clu_num_hosts_idx = size(map_params("pcmk_server_names"))-1
+    quickstack::pacemaker::hosts{ "clu $clu_num_hosts_idx":
+      index            => $clu_num_hosts_idx,
+      ip_address_array => map_params("pcmk_server_addrs"),
+      hostname_array   => map_params("pcmk_server_names"),
+    }
+    -> Package['rpcbind']
+  }
 
   package {'rpcbind': } ->
   service {'rpcbind':

--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -29,7 +29,7 @@ class quickstack::pacemaker::galera (
 
     # defined for galera.cnf template
     $wsrep_provider         = '/usr/lib64/galera/libgalera_smm.so'
-    $wsrep_bind_address     = map_params("local_bind_addr")
+    $wsrep_bind_address     = map_params("pcmk_bind_addr")
     $wsrep_provider_options = wsrep_options({
       'socket.ssl'      => $wsrep_ssl,
       'socket.ssl_key'  => $wsrep_ssl_key,
@@ -41,8 +41,8 @@ class quickstack::pacemaker::galera (
 
     class {"::quickstack::load_balancer::galera":
       frontend_pub_host    => map_params("db_vip"),
-      backend_server_names => map_params("lb_backend_server_names"),
-      backend_server_addrs => map_params("lb_backend_server_addrs"),
+      backend_server_names => map_params("pcmk_server_names"),
+      backend_server_addrs => map_params("pcmk_server_addrs"),
     }
 
     Class['::quickstack::pacemaker::common']
@@ -63,7 +63,7 @@ class quickstack::pacemaker::galera (
         package_name => 'mariadb-galera-server',
         override_options => {
         'mysqld' => {
-          'bind-address' => map_params("local_bind_addr"),
+          'bind-address' => map_params("pcmk_bind_addr"),
           'default_storage_engine' => "InnoDB",
           # maybe below?
           max_connections => "1024",
@@ -142,7 +142,7 @@ class quickstack::pacemaker::galera (
     }
     ->
     quickstack::pacemaker::resource::galera {'galera':
-      gcomm_addrs => map_params("lb_backend_server_names")
+      gcomm_addrs => map_params("pcmk_server_names")
     }
     ->
     # one last clustercheck to make sure service is up

--- a/puppet/modules/quickstack/manifests/pacemaker/hosts.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/hosts.pp
@@ -19,7 +19,7 @@ define quickstack::pacemaker::hosts (
 
     #recurse
     $next = $index -1
-    quickstack::pacemaker::hosts {$next:
+    quickstack::pacemaker::hosts {"$name $next":
       index            => $next,
       ip_address_array => $ip_address_array,
       hostname_array   => $hostname_array

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -61,7 +61,9 @@ class quickstack::pacemaker::params (
   $loadbalancer_vip          = '',
   $loadbalancer_group        = 'loadbalancer',
   $lb_backend_server_names   = '',
-  $lb_backend_server_addrs   = '', # should this and cluster_members be merged?
+  $lb_backend_server_addrs   = '',
+  $pcmk_server_names         = '',
+  $pcmk_server_addrs         = '',
   $keystone_public_vip       = '',
   $keystone_private_vip      = '',
   $keystone_admin_vip        = '',
@@ -84,6 +86,9 @@ class quickstack::pacemaker::params (
   $nova_group                = 'nova',
   $nova_db_password          = '',
   $nova_user_password        = '',
+  $pcmk_ip                   = '',
+  $pcmk_iface                = '',
+  $pcmk_network              = '',
   $private_ip                = '',
   $private_iface             = '',
   $private_network           = '',
@@ -100,6 +105,9 @@ class quickstack::pacemaker::params (
   $local_bind_addr = find_ip("$private_network",
                             "$private_iface",
                             "$private_ip")
+  $pcmk_bind_addr = find_ip("$pcmk_network",
+                            "$pcmk_iface",
+                            "$pcmk_ip")
 
   include quickstack::pacemaker::common
   include quickstack::pacemaker::load_balancer


### PR DESCRIPTION
The variables $lb_backend_server_names/addrs still define the "management" network.  pacemaker and galera traffic now occurs on a new network defined by $pcmk_server_names/addrs, AKA the "cluster management" network.  Optionally, $pcmk_server_names/addrs may have the same values as $lb_backend_server_names/addrs (i.e., use the same network for the management and cluster management networks).

Footnote: the pacemaker galera resource agent assumes that galera hostnames (used in the galera cluster configuration value wsrep_cluster_address) are consistent with pacemaker members, so for now we have no choice but to be consistent with that assumption, that interal galera and pacemaker traffic occur on the same network.
