### PR TITLE
Decoupling pacemaker/params for neutron

### DIFF
--- a/puppet/modules/quickstack/data/RedHat.yaml
+++ b/puppet/modules/quickstack/data/RedHat.yaml
@@ -1,13 +1,4 @@
 ---
-quickstack::params::db_ssl: 'false'
-quickstack::params::db_ssl_ca: ''
-quickstack::params::debug: 'false'
-quickstack::params::enabled: 'true'
-quickstack::params::memcached_port: '11211'
-quickstack::params::verbose: 'true'
-quickstack::params::cinder_backend_rbd: 'false'
-quickstack::params::glance_backend_rbd: 'false'
-
 quickstack::ceph::config::fsid: '904c8491-5c16-4dae-9cc3-6ce633a7f4cc'
 quickstack::ceph::config::mon_host:
   - "%{hiera('server1_ip')}"
@@ -22,6 +13,8 @@ quickstack::ceph::config::cluster_network: "%{hiera('network_internal')}.0/24"
 quickstack::ceph::config::osd_pool_size: '1'
 quickstack::ceph::config::osd_pool_default_size: '1'
 quickstack::ceph::config::osd_journal_size: '1000'
+
+quickstack::keystone::common::db_host: "%{hiera('db_vip')}"
 
 quickstack::nova_network::compute::amqp_host: "%{hiera('amqp_vip')}"
 quickstack::nova_network::compute::amqp_provider: "%{hiera('amqp_provider')}"
@@ -45,7 +38,7 @@ quickstack::nova_network::compute::network_overrides: "{'force_dhcp_release' => 
 quickstack::nova_network::compute::network_private_iface: "%{hiera('private_iface')}"
 quickstack::nova_network::compute::network_private_network: "%{hiera('private_network')}"
 quickstack::nova_network::compute::network_public_ip: "%{hiera('private_ip')}"
-quickstack::nova_network::compute::network_public_network: "%{hiera('public+network')}"
+quickstack::nova_network::compute::network_public_network: "%{hiera('public_network')}"
 quickstack::nova_network::compute::nova_host: "%{hiera('nova_vip_admin')}"
 quickstack::nova_network::compute::ssl: 'false'
 
@@ -108,11 +101,11 @@ quickstack::pacemaker::galera::wsrep_ssl_key: "%{hiera('db_key')}"
 quickstack::pacemaker::galera::wsrep_sst_method: rsync
 quickstack::pacemaker::galera::wsrep_sst_username: 'sst_user'
 
-quickstack::pacemaker::glance::backend: rbd
+quickstack::pacemaker::glance::backend: "%{hiera('glance_backend')}"
 quickstack::pacemaker::glance::db_ssl_ca: "%{hiera('quickstack::params::db_ssl_ca')}"
 quickstack::pacemaker::glance::filesystem_store_datadir: /var/lib/glance/images/
 quickstack::pacemaker::glance::pcmk_fs_device: "%{hiera('glance_device')}"
-quickstack::pacemaker::glance::pcmk_fs_dir: /var/lib/glance/images/
+quickstack::pacemaker::glance::pcmk_fs_dir: '/var/lib/glance/images/'
 quickstack::pacemaker::glance::pcmk_fs_manage: 'false'
 quickstack::pacemaker::glance::pcmk_fs_options: ''
 quickstack::pacemaker::glance::pcmk_fs_type: nfs
@@ -132,29 +125,37 @@ quickstack::pacemaker::horizon::horizon_key: "%{hiera('horizon_key')}"
 quickstack::pacemaker::horizon::keystone_default_role: '_member_'
 
 quickstack::pacemaker::keystone::admin_email: "%{hiera('admin_email')}"
-quickstack::pacemaker::keystone::admin_password: "%{hiera('admin_password')}"
-quickstack::pacemaker::keystone::admin_tenant: admin
-quickstack::pacemaker::keystone::admin_token: "%{hiera('admin_token')}"
-quickstack::pacemaker::keystone::db_ssl: 'false'
+quickstack::pacemaker::keystone::admin_tenant: 'admin'
+quickstack::pacemaker::keystone::db_ssl: "%{hiera('ssl')}"
 quickstack::pacemaker::keystone::db_ssl_ca: "%{hiera('db_ca')}"
-quickstack::pacemaker::keystone::debug: 'false'
-quickstack::pacemaker::keystone::ceilometer: 'false'
-quickstack::pacemaker::keystone::cinder: 'true'
-quickstack::pacemaker::keystone::glance: 'true'
-quickstack::pacemaker::keystone::heat: 'false'
-quickstack::pacemaker::keystone::heat_cfn: 'false'
-quickstack::pacemaker::keystone::keystonerc: 'true'
-quickstack::pacemaker::keystone::nova: 'true'
-quickstack::pacemaker::keystone::region: 'RegionOne'
-quickstack::pacemaker::keystone::swift: 'false'
+quickstack::pacemaker::keystone::debug: "%{hiera('debug')}"
+quickstack::pacemaker::keystone::ceilometer: "%{hiera('ceilometer')}"
+quickstack::pacemaker::keystone::cinder: "%{hiera('cinder')}"
+quickstack::pacemaker::keystone::glance: "%{hiera('glance')}"
+quickstack::pacemaker::keystone::heat: "%{hiera('heat')}"
+quickstack::pacemaker::keystone::heat_cfn: "%{hiera('heat_cfn')}"
+quickstack::pacemaker::keystone::keystonerc: "%{hiera('keystonerc')}"
+quickstack::pacemaker::keystone::nova: "%{hiera('nova')}"
+quickstack::pacemaker::keystone::region: "%{hiera('region')}"
+
+quickstack::pacemaker::keystone::swift: "%{hiera('swift')}"
 
 # quickstack::pacemaker::load_balancer:
 
 # quickstack::pacemaker::memcached:
 
-quickstack::pacemaker::neutron::core_plugin: neutron.plugins.ml2.plugin.Ml2Plugin
+quickstack::pacemaker::neutron::amqp_host: "%{hiera('ampq_vip')}"
+quickstack::pacemaker::neutron::amqp_port: "%{hiera('ampq_port')}"
+quickstack::pacemaker::neutron::amqp_username: "%{hiera('ampq_username')}"
+quickstack::pacemaker::neutron::allow_overlapping_ips: 'true'
+quickstack::pacemaker::neutron::auth_host: "%{hiera('keystone_vip')}"
+quickstack::pacemaker::neutron::cisco_vswitch_plugin: 'neutron.plugins.cisco.n1kv.n1kv_neutron_plugin.N1kvNeutronPluginV2'
+quickstack::pacemaker::neutron::cisco_nexus_plugin: ''
+quickstack::pacemaker::neutron::database_max_retries: '-1'
 quickstack::pacemaker::neutron::enable_tunneling: 'true'
-quickstack::pacemaker::neutron::external_network_bridge: br-ex
+quickstack::pacemaker::neutron::enabled: 'true'
+quickstack::pacemaker::neutron::external_network_bridge: 'br-ex'
+quickstack::pacemaker::neutron::manage_service: true'
 quickstack::pacemaker::neutron::ml2_flat_networks: ['*']
 quickstack::pacemaker::neutron::ml2_mechanism_drivers: ['openvswitch', 'l2population']
 quickstack::pacemaker::neutron::ml2_network_vlan_ranges: ['yourphysnet:10:50']
@@ -162,17 +163,32 @@ quickstack::pacemaker::neutron::ml2_security_group: 'true'
 quickstack::pacemaker::neutron::ml2_tenant_network_types: ['vxlan', 'vlan', 'gre', 'flat']
 quickstack::pacemaker::neutron::ml2_tunnel_id_ranges: ['20:100']
 quickstack::pacemaker::neutron::ml2_type_drivers: ['local', 'flat', 'vlan', 'gre', 'vxlan']
-quickstack::pacemaker::neutron::ml2_vxlan_group: 224.0.0.1
+quickstack::pacemaker::neutron::ml2_vxlan_group: '224.0.0.1'
+quickstack::pacemaker::neutron::mysql_host:
+quickstack::pacemaker::neutron::network_device_mtu: ''
+quickstack::pacemaker::neutron::neutron_core_plugin:
+quickstack::pacemaker::neutron::neutron_priv_host: "%{hiera('neutron_vip_internal')}"
+quickstack::pacemaker::neutron::neutron_url:
+quickstack::pacemaker::neutron::neutron_conf_additional_params: "%{hiera('quickstack::params::neutron_conf_additional_params:')}"
+quickstack::pacemaker::neutron::nexus_config: {}
+quickstack::pacemaker::neutron::n1kv_vsm_ip: '0.0.0.0'
+quickstack::pacemaker::neutron::n1kv_vsm_password: "%{hiera('n1kv_vsm_password')}"
+quickstack::pacemaker::neutron::n1kv_plugin_additional_params:  "%{hiera('quickstack::params::n1kv_plugin_additional_params:')}"
+quickstack::pacemaker::neutron::nova_conf_additional_params: "%{hiera('quickstack::params::nova_conf_additional_params:')}"
 quickstack::pacemaker::neutron::ovs_bridge_mappings: ['ext-vlan:br-ex']
 quickstack::pacemaker::neutron::ovs_bridge_uplinks: ['br-ex:eth0']
 quickstack::pacemaker::neutron::ovs_tunnel_iface: "%{hiera('tunnel_iface')}"
 quickstack::pacemaker::neutron::ovs_tunnel_network: "%{hiera('tunnel_network')}"
 quickstack::pacemaker::neutron::ovs_tunnel_types: ['vxlan']
 quickstack::pacemaker::neutron::ovs_tunnel_types: []
-quickstack::pacemaker::neutron::ovs_vlan_ranges: ext-vlan:1000:2000
+quickstack::pacemaker::neutron::ovs_vlan_ranges: 'ext-vlan:1000:2000'
 quickstack::pacemaker::neutron::ovs_vxlan_udp_port: '4789'
-quickstack::pacemaker::neutron::tenant_network_type: vlan
+quickstack::pacemaker::neutron::rpc_backend: 'neutron.openstack.common.rpc.impl_kombu'
+quickstack::pacemaker::neutron::security_group_api: 'neutron'
+quickstack::pacemaker::neutron::tenant_network_type: 'vlan'
 quickstack::pacemaker::neutron::tunnel_id_ranges: 1:1000
+quickstack::pacemaker::neutron::verbose: 'false'
+quickstack::pacemaker::neutron::veth_mtu: ''
 
 quickstack::pacemaker::nova::auto_assign_floating_ip: 'true'
 quickstack::pacemaker::nova::default_floating_pool: nova
@@ -186,7 +202,7 @@ quickstack::pacemaker::params::admin_email: "%{hiera('admin_email')}"
 quickstack::pacemaker::params::amqp_group: amqp
 quickstack::pacemaker::params::amqp_port: '5672'
 quickstack::pacemaker::params::amqp_provider: "%{hiera('amqp_provider')}"
-quickstack::pacemaker::params::amqp_username: openstack
+quickstack::pacemaker::params::amqp_username: "%{hiera('amqp_username')}"
 quickstack::pacemaker::params::amqp_vip: "%{hiera('amqp_vip')}"
 quickstack::pacemaker::params::ceilometer_admin_vip: "%{hiera('ceilometer_vip_admin')}"
 quickstack::pacemaker::params::ceilometer_group: ceilometer
@@ -209,6 +225,7 @@ quickstack::pacemaker::params::cinder_private_vip: "%{hiera('cinder_vip_internal
 quickstack::pacemaker::params::cinder_public_vip: "%{hiera('cinder_vip_public')}"
 quickstack::pacemaker::params::cluster_control_ip: "%{hiera('cluster_control_ip')}"
 quickstack::pacemaker::params::db_group: 'db'
+quickstack::pacemaker::params::db_host: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::db_vip: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::glance_admin_vip: "%{hiera('glance_vip_admin')}"
 quickstack::pacemaker::params::glance_group: glance
@@ -252,11 +269,14 @@ quickstack::pacemaker::params::lb_backend_server_names:
   - "%{hiera('server3_name')}"
 quickstack::pacemaker::params::loadbalancer_group: 'loadbalancer'
 quickstack::pacemaker::params::loadbalancer_vip: "%{hiera('loadbalancer_vip')}"
+quickstack::pacemaker::params::mysql_host: "%{hiera('db_vip')}"
+quickstack::pacemaker::params::mysql_vip: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::neutron: "%{hiera('neutron')}"
 quickstack::pacemaker::params::neutron_admin_vip: "%{hiera('neutron_vip_admin')}"
 quickstack::pacemaker::params::neutron_group: 'neutron'
 quickstack::pacemaker::params::neutron_private_vip: "%{hiera('neutron_vip_internal')}"
 quickstack::pacemaker::params::neutron_public_vip: "%{hiera('neutron_vip_public')}"
+quickstack::pacemaker::params::nosql_vip: "%{hiera('nosql_vip')}"
 quickstack::pacemaker::params::nova_admin_vip: "%{hiera('nova_vip_admin')}"
 quickstack::pacemaker::params::nova_group: 'nova'
 quickstack::pacemaker::params::nova_private_vip: "%{hiera('nova_vip_internal')}"
@@ -274,3 +294,44 @@ quickstack::pacemaker::rabbitmq::inet_dist_listen: '35672'
 quickstack::pacemaker::swift::swift_internal_vip: "%{hiera('swift_vip_internal')}"
 quickstack::pacemaker::swift::swift_storage_device: 'device1'
 quickstack::pacemaker::swift::swift_storage_ips: ["%{hiera('swift_storage1_ip')}"]
+
+quickstack::params::db_ssl: 'false'
+quickstack::params::db_ssl_ca: "%{hiera('db_ca')}"
+quickstack::params::debug: 'false'
+quickstack::params::enabled: 'true'
+quickstack::params::memcached_port: '11211'
+quickstack::params::verbose: 'true'
+quickstack::params::cinder_backend_rbd: 'false'
+quickstack::params::glance_backend_rbd: 'false'
+
+# Added for neutron AIO support
+quickstack::params::amqp_ca: "%{hiera('amqp_ca')}"
+quickstack::params::amqp_cert: "%{hiera('amqp_cert')}"
+quickstack::params::amqp_key: "%{hiera('amqp_key')}"
+quickstack::params::amqp_password: "%{hiera('amqp_password')}"
+quickstack::params::amqp_provider: "%{hiera('amqp_provider')}"
+quickstack::params::amqp_username: "%{hiera('amqp_username')}"
+quickstack::params::amqp_vip: "%{hiera('amqp_vip')}"
+quickstack::params::amqp_port: '5672'
+quickstack::params::amqp_ssl_port: '5671'
+quickstack::params::keystone_vip_admin: "%{hiera('keystone_vip_admin')}"
+quickstack::params::keystone_vip_internal: "%{hiera('keystone_vip_internal')}"
+quickstack::params::keystone_vip_public: "%{hiera('keystone_vip_public')}"
+quickstack::params::mysql_ca: "%{hiera('mysql_ca')}"
+quickstack::params::mysql_cert: "%{hiera('mysql_cert')}"
+quickstack::params::mysql_key: "%{hiera('mysql_key')}"
+
+quickstack::params::mysql_vip: "%{hiera('db_vip')}"
+quickstack::params::db_host: "%{hiera('db_vip')}"
+quickstack::params::mysql_host: "%{hiera('db_vip')}"
+
+# quickstack::params::nova_conf_additional_params: { 'quota_instances' => 'default',
+#                                    'quota_cores' => 'default',
+#                                    'quota_ram' => 'default',
+#                                    'quota_floating_ips' => 'default',
+#                                    'quota_fixed_ips' => 'default',
+#                                    'quota_driver' => 'default',
+#                                    }
+quickstack::params::region: "%{hiera('region')}"
+quickstack::params::ssl: 'false'
+#quickstack::params::service_plugins: [ 'dhcp', 'l3' ]

--- a/puppet/modules/quickstack/data/defaults.yaml
+++ b/puppet/modules/quickstack/data/defaults.yaml
@@ -1,52 +1,39 @@
 ---
 scenario: 'HA'
 
+## Infra
+# Top
 admin_email: 'admin@example.com'
 
-amqp_provider: 'rabbitmq'
+# AMQP
 amqp: 'true'
-cinder: 'false'
+amqp_vip: "%{hiera('network_admin')}.200"
+amqp_username: 'Openstack'
+amqp_password: "%{hiera('password')}"
+amqp_provider: 'rabbitmq'
+
+# DBMS
+db_vip: "%{hiera('network_admin')}.201"
+dbms: 'mysql'
+mysql: 'true'
+
+## Openstack
+region: 'RegionOne'
+
+## Switches
+ceilometer: 'true'
+cinder: 'true'
+debug: 'true'
 glance: 'true'
-fencing: 'disabled'
+heat_cfn: 'true'
 heat: 'true'
 horizon: 'true'
+keystonerc: 'true'
 keystone: 'true'
-mysql: 'true'
 neutron: 'true'
 nova: 'true'
-swift: 'false'
-
-network_admin: '192.168.1'
-network_internal: '192.168.2'
-network_public: '192.168.3'
-
-private_iface: 'eth2'
-private_ip: ''
-private_network: "%{hiera('network_internal')}.0"
-public_network: "%{hiera('network_public')}.0"
-tunnel_iface: 'eth2'
-tunnel_network: ''
-
-server1_name: 'controller1'
-server1_ip: "%{hiera('network_admin')}.11"
-server2_name: 'controller2'
-server2_ip: "%{hiera('network_admin')}.12"
-server3_name: 'controller3'
-server3_ip: "%{hiera('network_admin')}.13"
-
-storage1_ip: "%{hiera('network_internal')}.14"
-storage2_ip: "%{hiera('network_internal')}.15"
-storage3_ip: "%{hiera('network_internal')}.16"
-
-cluster_control_ip: "%{hiera('server1_ip')}"
-swift_storage1_ip: "%{hiera('storage1_ip')}"
-glance_device: "%{hiera('storage2_ip')}:/mnt/glance"
-nfs_share1: "%{hiera('storage3_ip')}:/mnt/cinder"
-
-# Infra VIPs
-amqp_vip: "%{hiera('network_admin')}.200"
-db_vip: "%{hiera('network_admin')}.201"
-loadbalancer_vip: "%{hiera('network_admin')}.202"
+swift: 'true'
+ssl: 'true'
 
 # Openstack VIPs
 ceilometer_vip: '203'
@@ -57,9 +44,44 @@ heat_vip: '207'
 horizon_vip: '208'
 keystone_vip: '209'
 neutron_vip: '210'
-nova_vip: '211'
-swift_vip: '212'
+nosql_vip: '211'
+nova_vip: '212'
+swift_vip: '213'
 
+# HA
+fencing: 'disabled'
+cluster_control_ip: "%{hiera('server1_ip')}"
+loadbalancer_vip: "%{hiera('network_admin')}.202"
+server1_name: 'controller1'
+server1_ip: "%{hiera('network_internal')}.11"
+server2_name: 'controller2'
+server2_ip: "%{hiera('network_internal')}.12"
+server3_name: 'controller3'
+server3_ip: "%{hiera('network_internal')}.13"
+
+# Network
+network_admin: '192.168.1'
+network_internal: '192.168.2'
+network_public: '192.168.3'
+private_iface: 'eth2'
+private_ip: ''
+private_network: "%{hiera('network_internal')}.0"
+public_network: "%{hiera('network_public')}.0"
+tunnel_iface: 'eth2'
+tunnel_network: ''
+
+# Storage VIPs
+storage1_ip: "%{hiera('network_internal')}.14"
+storage2_ip: "%{hiera('network_internal')}.15"
+storage3_ip: "%{hiera('network_internal')}.16"
+swift_storage1_ip: "%{hiera('storage1_ip')}"
+
+# Storage defaults
+glance_backend: 'file'
+glance_device: "%{hiera('storage2_ip')}:/mnt/glance"
+nfs_share1: "%{hiera('storage3_ip')}:/mnt/cinder"
+
+# Openstack services - VIP mapping
 ceilometer_vip_admin: "%{hiera('network_admin')}.%{hiera('ceilometer_vip')}"
 ceilometer_vip_internal: "%{hiera('network_internal')}.%{hiera('ceilometer_vip')}"
 ceilometer_vip_public: "%{hiera('network_public')}.%{hiera('ceilometer_vip')}"
@@ -90,3 +112,20 @@ nova_vip_public: "%{hiera('network_public')}.%{hiera('nova_vip')}"
 swift_vip_admin: "%{hiera('network_admin')}.%{hiera('swift_vip')}"
 swift_vip_internal: "%{hiera('network_internal')}.%{hiera('swift_vip')}"
 swift_vip_public: "%{hiera('network_admin')}.%{hiera('swift_vip')}"
+
+# SSL
+ca: '/etc/pki/CA/cacert.pem'
+
+amqp_ca: "%{hiera('ca')}"
+amqp_cert: '/etc/pki/tls/certs/amqp.crt'
+amqp_key: '/etc/pki/tls/private/amqp.key'
+db_ca: "%{hiera('ca')}"
+db_cert: '/etc/pki/tls/certs/db.crt'
+db_key: '/etc/pki/tls/private/db.key'
+horizon_ca: "%{hiera('ca')}"
+horizon_cert: '/etc/pki/tls/certs/horizon.crt'
+horizon_key: '/etc/pki/tls/private/horizon.key'
+mysql_ca: "%{hiera('ca')}"
+mysql_cert: '/etc/pki/tls/certs/mysql.crt'
+mysql_key: '/etc/pki/tls/private/mysql.key'
+

--- a/puppet/modules/quickstack/manifests/pacemaker/base.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/base.pp
@@ -1,0 +1,25 @@
+class quickstack::pacemaker::base (
+  ) inherits quickstack::pacemaker::params {
+
+  include quickstack::pacemaker::common
+  include quickstack::pacemaker::load_balancer
+  include quickstack::pacemaker::galera
+  include quickstack::pacemaker::qpid
+  include quickstack::pacemaker::keystone
+  include quickstack::pacemaker::swift
+  include quickstack::pacemaker::glance
+  include quickstack::pacemaker::nova
+  include quickstack::pacemaker::cinder
+  include quickstack::pacemaker::heat
+
+  Class['::quickstack::pacemaker::common'] ->
+  Class['::quickstack::pacemaker::load_balancer'] ->
+  Class['::quickstack::pacemaker::galera'] ->
+  Class['::quickstack::pacemaker::qpid'] ->
+  Class['::quickstack::pacemaker::keystone'] ->
+  Class['::quickstack::pacemaker::swift'] ->
+  Class['::quickstack::pacemaker::glance'] ->
+  Class['::quickstack::pacemaker::nova'] ->
+  Class['::quickstack::pacemaker::cinder'] ->
+  Class['::quickstack::pacemaker::heat']
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -40,8 +40,9 @@ class quickstack::pacemaker::common (
   $fence_xvm_port                 = "",
   $fence_xvm_manage_key_file      = "false",
   $fence_xvm_key_file_password    = "",
-) {
-  include quickstack::pacemaker::params
+) inherits quickstack::pacemaker::base {
+
+  include quickstack::pacemaker::base
 
   if has_interface_with("ipaddress", map_params("cluster_control_ip")) {
     $setup_cluster = true

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -105,29 +105,4 @@ class quickstack::pacemaker::params (
   $local_bind_addr = find_ip("$private_network",
                             "$private_iface",
                             "$private_ip")
-  $pcmk_bind_addr = find_ip("$pcmk_network",
-                            "$pcmk_iface",
-                            "$pcmk_ip")
-
-  include quickstack::pacemaker::common
-  include quickstack::pacemaker::load_balancer
-  include quickstack::pacemaker::galera
-  include quickstack::pacemaker::qpid
-  include quickstack::pacemaker::keystone
-  include quickstack::pacemaker::swift
-  include quickstack::pacemaker::glance
-  include quickstack::pacemaker::nova
-  include quickstack::pacemaker::cinder
-  include quickstack::pacemaker::heat
-
-  Class['::quickstack::pacemaker::common'] ->
-  Class['::quickstack::pacemaker::load_balancer'] ->
-  Class['::quickstack::pacemaker::galera'] ->
-  Class['::quickstack::pacemaker::qpid'] ->
-  Class['::quickstack::pacemaker::keystone'] ->
-  Class['::quickstack::pacemaker::swift'] ->
-  Class['::quickstack::pacemaker::glance'] ->
-  Class['::quickstack::pacemaker::nova'] ->
-  Class['::quickstack::pacemaker::cinder'] ->
-  Class['::quickstack::pacemaker::heat']
 }


### PR DESCRIPTION
  Added new pacemaker::base
  Inherits done so common -> base -> params
  This way variable propagation is safe and easier to manage

  Any variable defined but not assigned by either Hiera or ENC (Foreman)
  will automatically trigger an error, like $foo in the following:

  class modulexyz (
    $foo,
  ) {}

  $ puppet apply -e "include modulexyz"
  Error: Must pass foo to Class[Modulexyz] at line 1 on node

  This can help save lots of testing and frustration with nil values comming up
  the stack

  Also added nosql_vip params to hiera

  YAML data update and default reorg