### PR TITLE
Fix setting of auth_url from glance cache.

### DIFF
--- a/puppet/modules/quickstack/manifests/glance.pp
+++ b/puppet/modules/quickstack/manifests/glance.pp
@@ -49,6 +49,8 @@ class quickstack::glance (
     $sql_connection = "mysql://${db_user}:${db_password}@${db_host}/${db_name}"
   }
 
+  $_auth_url = "http://${keystone_host}:5000/v2.0"
+
   $show_image_direct_url = $backend ? {
     'rbd' => true,
     default => false,
@@ -63,6 +65,7 @@ class quickstack::glance (
     auth_type             => 'keystone',
     auth_port             => '35357',
     auth_host             => $keystone_host,
+    auth_url              => $_auth_url,
     keystone_tenant       => 'services',
     keystone_user         => 'glance',
     keystone_password     => $user_password,


### PR DESCRIPTION
As noted in https://bugzilla.redhat.com/show_bug.cgi?id=1174389#c10 ,
glance-cache.conf:auth_url was set to http://localhost:5000/v2.0.  This is
because the glance::api module does not build this url from the auth_host we
were already passing in.  So, at least for now, we do this on the quickstack
side.
