### PR TITLE
BZ #1167414 - TCP Keepalive settings in rabbit config.

### DIFF
--- a/puppet/modules/quickstack/manifests/amqp/server/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/amqp/server/rabbitmq.pp
@@ -30,6 +30,13 @@ class quickstack::amqp::server::rabbitmq (
     default_user          => $amqp_username,
     default_pass          => $amqp_password,
     admin_enable          => false,
+    config_variables      => {"tcp_listen_options" =>
+                              "[binary,{packet,raw},
+                              {reuseaddr, true},
+                              {backlog, 128},
+                              {nodelay, true},
+                              {exit_on_close,false},
+                              {keepalive, true}]"},
     package_provider      => "yum",
     package_source        => undef,
     manage_repos          => false,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1167414

We already have the kernel sysctl changes in place, this patch adds the needed
config to rabbit itself as well.
