### PR TITLE
BZ #1167414 - rabbitmq tcp keepalive

### DIFF
--- a/puppet/modules/quickstack/manifests/amqp/server/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/amqp/server/rabbitmq.pp
@@ -33,5 +33,18 @@ class quickstack::amqp::server::rabbitmq (
     package_provider      => "yum",
     package_source        => undef,
     manage_repos          => false,
+    # set the parameter tcp_keepalive to false -- but don't be misled!
+    # the parameter is false (but the behaviour is really true) so
+    # that we can set tcp_listen_options correctly within the puppet
+    # template, rabbitmq.config.erb
+    tcp_keepalive         => false,
+    config_variables => {
+      'tcp_listen_options' => "[binary,{packet, raw},
+                              {reuseaddr, true},
+                              {backlog, 128},
+                              {nodelay, true},
+                              {exit_on_close, false},
+                              {keepalive, true}]"
+    },
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -45,6 +45,19 @@ class quickstack::pacemaker::rabbitmq (
         'RABBITMQ_NODENAME'     => "rabbit@$this_node",
       },
       service_manage           => $_enabled,
+      # set the parameter tcp_keepalive to false -- but don't be misled!
+      # the parameter is false (but the behaviour is really true) so
+      # that we can set tcp_listen_options correctly within the puppet
+      # template, rabbitmq.config.erb
+      tcp_keepalive         => false,
+      config_variables => {
+        'tcp_listen_options' => "[binary,{packet, raw},
+                                {reuseaddr, true},
+                                {backlog, 128},
+                                {nodelay, true},
+                                {exit_on_close, false},
+                                {keepalive, true}]"
+      },
     }
 
     class {'::quickstack::load_balancer::amqp':


### PR DESCRIPTION
With apologies for forgetting post this yesterday.

https://bugzilla.redhat.com/show_bug.cgi?id=1167414

Set tcp_listen_options in /etc/rabbitmq/rabbitmq.config
