### PR TITLE
BZ #1175869 - Add generic pcs create wrapper for juno.

### DIFF
--- a/puppet/modules/quickstack/manifests/keystone/common.pp
+++ b/puppet/modules/quickstack/manifests/keystone/common.pp
@@ -6,9 +6,14 @@
 # === Parameters
 #
 # [admin_token]. Auth token for keystone admin. Required.
+# [amqp_host]. Address where the amqp server resides.  Currently puppet-keystone
+#   only supports rabbit, but if qpid support is added, this param will be used
+#   for that as well. Optional, Defaults to 'localhost'.
+# [amqp_port]. Port where the amqp server accepts connections.  Optional.
+#   Defaults to '5672'.
 # [bind_host] Address that keystone binds to. Optional. Defaults to  '0.0.0.0'
-# [db_host] Host where DB resides. Optional. Defaults to 127.0.0.1..
-# [db_name] Name of keystone DB. Optional. Defaults to  'keystone'
+# [db_host] Host where DB resides. Optional. Defaults to '127.0.0.1'.
+# [db_name] Name of keystone DB. Optional. Defaults to  'keystone'.
 # [db_password] Password for keystone DB. Required.
 # [db_ssl] Boolean whether to use SSL for database. Defaults to false.
 # [db_ssl_ca] If db_ssl is true, this is used in the connection to define the CA. Default undef.
@@ -38,6 +43,8 @@
 
 class quickstack::keystone::common (
   $admin_token,
+  $amqp_host                   = 'localhost',
+  $amqp_port                   = '5672',
   $bind_host                   = '0.0.0.0',
   $db_host                     = '127.0.0.1',
   $db_name                     = 'keystone',
@@ -76,6 +83,8 @@ class quickstack::keystone::common (
     enabled          => $enabled,
     idle_timeout     => $idle_timeout,
     log_facility     => $log_facility,
+    rabbit_host      => $amqp_host,
+    rabbit_port      => $amqp_port,
     service_provider => $service_provider,
     sql_connection   => $sql_conn,
     token_driver     => $token_driver,

--- a/puppet/modules/quickstack/manifests/neutron/plugins/nexus_creds.pp
+++ b/puppet/modules/quickstack/manifests/neutron/plugins/nexus_creds.pp
@@ -1,0 +1,16 @@
+define quickstack::neutron::plugins::nexus_creds {
+  $args = split($title, '/')
+  neutron_plugin_cisco_credentials {
+    "${args[0]}/username": value     => $args[1];
+    "${args[0]}/password": value => $args[2];
+  }
+  exec {"${title}":
+    unless => "/bin/cat /var/lib/neutron/.ssh/known_hosts
+    | /bin/grep ${args[0]}",
+    command => "/usr/bin/ssh-keyscan -t rsa ${args[0]}
+    >> /var/lib/neutron/.ssh/known_hosts",
+    user        => 'neutron',
+    require => Package['neutron']
+  }
+}
+

--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -125,24 +125,22 @@ class quickstack::pacemaker::ceilometer (
       monitor_params => {'start-delay'     => '10s'},
     }
     ->
-    quickstack::pacemaker::resource::service {
+    quickstack::pacemaker::resource::generic {
       ["openstack-ceilometer-collector",
       "openstack-ceilometer-api",
       "openstack-ceilometer-alarm-evaluator",
       "openstack-ceilometer-alarm-notifier",
       "openstack-ceilometer-notification"]:
-      clone => true,
-      options => 'start-delay=10s',
-      monitor_params => {'start-delay' => '10s'},
+      clone_opts      => "interleave=true",
+      resource_params => 'start-delay=10s',
+      #monitor_params  => {'start-delay'     => '10s'},
     }
     ->
-    pcmk_resource { "ceilometer-delay":
-      ensure          => 'present',
+    # Delay doesnt support --clone in our version of pcs, just like ocf
+    quickstack::pacemaker::resource::generic { "ceilometer-delay":
+      resource_name   => "",
+      resource_params => "startdelay=10 clone interleave=true",
       resource_type   => "Delay",
-      resource_params => 'startdelay=10',
-      group           => '',
-      clone           => true,
-      interval        => '30s',
     }
     ->
     quickstack::pacemaker::constraint::base { "central-collector-constr":

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -119,10 +119,11 @@ class quickstack::pacemaker::horizon (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include horizon",
     }
     ->
-    quickstack::pacemaker::resource::service {"$::horizon::params::http_service":
-      clone => true,
-      options => 'start-delay=10s',
-      monitor_params => {'start-delay' => '20s'},
+    quickstack::pacemaker::resource::generic {"horizon":
+      clone_opts            => "interleave=true",
+      resource_name         => "$::horizon::params::http_service",
+      resource_params       => 'start-delay=10s',
+      #      monitor_params => {'start-delay'     => '20s'},
     }
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -86,23 +86,25 @@ class quickstack::pacemaker::keystone (
       unless   => "/tmp/ha-all-in-one-util.bash i_am_vip $keystone_private_vip || /tmp/ha-all-in-one-util.bash property_exists keystone",
     } ->
     class {"::quickstack::keystone::common":
-      admin_token                 => "$admin_token",
-      bind_host                   => map_params("local_bind_addr"),
-      db_host                     => map_params("db_vip"),
-      db_name                     => "$db_name",
-      db_password                 => map_params("keystone_db_password"),
-      db_ssl                      => str2bool_i("$db_ssl"),
-      db_ssl_ca                   => "$db_ssl_ca",
-      db_type                     => "$db_type",
-      db_user                     => "$db_user",
-      debug                       => str2bool_i("$debug"),
-      enabled                     => $_enabled,
-      idle_timeout                => "$idle_timeout",
-      log_facility                => "$log_facility",
-      token_driver                => "$token_driver",
-      token_format                => "$token_format",
-      use_syslog                  => str2bool_i("$use_syslog"),
-      verbose                     => str2bool_i("$verbose"),
+      admin_token  => "$admin_token",
+      amqp_host    => map_params("amqp_vip"),
+      amqp_port    => map_params("amqp_port"),
+      bind_host    => map_params("local_bind_addr"),
+      db_host      => map_params("db_vip"),
+      db_name      => "$db_name",
+      db_password  => map_params("keystone_db_password"),
+      db_ssl       => str2bool_i("$db_ssl"),
+      db_ssl_ca    => "$db_ssl_ca",
+      db_type      => "$db_type",
+      db_user      => "$db_user",
+      debug        => str2bool_i("$debug"),
+      enabled      => $_enabled,
+      idle_timeout => "$idle_timeout",
+      log_facility => "$log_facility",
+      token_driver => "$token_driver",
+      token_format => "$token_format",
+      use_syslog   => str2bool_i("$use_syslog"),
+      verbose      => str2bool_i("$verbose"),
     } ->
     class {"::quickstack::keystone::endpoints":
       admin_address               => map_params("keystone_admin_vip"),
@@ -170,9 +172,9 @@ class quickstack::pacemaker::keystone (
       try_sleep => 10,
       command   => "/tmp/ha-all-in-one-util.bash all_members_include keystone",
     } ->
-    quickstack::pacemaker::resource::service {'openstack-keystone':
-      clone   => true,
-      options => 'start-delay=10s',
+    quickstack::pacemaker::resource::generic {'keystone':
+      clone_opts    => "interleave=true",
+      resource_name => "openstack-keystone",
     }
     # TODO: Consider if we should pre-emptively purge any directories keystone has
     # created in /tmp

--- a/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
@@ -23,7 +23,7 @@ class quickstack::pacemaker::load_balancer {
     command   => "/tmp/ha-all-in-one-util.bash all_members_include haproxy",
 
   } ->
-  quickstack::pacemaker::resource::service {'haproxy':
-    clone => true,
+  quickstack::pacemaker::resource::generic {'haproxy':
+    clone_opts => "interleave=true",
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
@@ -16,9 +16,8 @@ class quickstack::pacemaker::memcached {
     try_sleep => 10,
     command   => "/tmp/ha-all-in-one-util.bash all_members_include memcached",
   } ->
-  quickstack::pacemaker::resource::service { 'memcached':
-    clone   => true,
-    options => 'start-delay=10s',
+  quickstack::pacemaker::resource::generic { 'memcached':
+    clone_opts => "interleave=true",
   }
 
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -47,10 +47,10 @@ class quickstack::pacemaker::nova (
     }
 
     if ($scheduler_host_subset_size == '1') {
-      $sched_clone = false
+      $sched_clone = ""
       $_nova_scheduler_resource = "openstack-nova-scheduler"
     } else {
-      $sched_clone = true
+      $sched_clone = "interleave=true"
       $_nova_scheduler_resource = "openstack-nova-scheduler-clone"
     }
 
@@ -122,17 +122,17 @@ class quickstack::pacemaker::nova (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include nova",
     }
     ->
-    quickstack::pacemaker::resource::service {['openstack-nova-consoleauth',
+    quickstack::pacemaker::resource::generic {['openstack-nova-consoleauth',
                               'openstack-nova-novncproxy',
                               'openstack-nova-api',
                               'openstack-nova-conductor' ]:
-      clone   => true,
-      options => 'start-delay=10s',
+      clone_opts      => "interleave=true",
+      resource_params => 'start-delay=10s',
     }
     ->
-    quickstack::pacemaker::resource::service {'openstack-nova-scheduler':
-      clone   => $sched_clone,
-      options => 'start-delay=10s',
+    quickstack::pacemaker::resource::generic {'openstack-nova-scheduler':
+      clone_opts      => $sched_clone,
+      resource_params => 'start-delay=10s',
     }
     ->
     quickstack::pacemaker::constraint::base { 'nova-console-vnc-constr' :

--- a/puppet/modules/quickstack/manifests/pacemaker/resource/generic.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/generic.pp
@@ -1,0 +1,70 @@
+define quickstack::pacemaker::resource::generic(
+  $clone_opts      = undef,
+  $operation_opts  = undef,
+  $resource_name   = "${title}",
+  $resource_params = undef,
+  $resource_type   = "systemd",
+  $tries           = '4',
+) {
+  include quickstack::pacemaker::params
+
+  if has_interface_with("ipaddress", map_params("cluster_control_ip")){
+
+    if $resource_name != "" {
+      $_resource_name = ":${resource_name}"
+    } else {
+      $_resource_name = ""
+    }
+
+    if $clone_opts != undef {
+      $_clone_opts = "--clone ${clone_opts}"
+    } else {
+      $_clone_opts = ""
+    }
+
+    if $operation_opts != undef {
+      $_operation_opts = "op ${operation_opts}"
+    } else {
+      $_operation_opts = ""
+    }
+
+    if $resource_params != undef {
+      $_resource_params = "${resource_params}"
+    } else {
+      $_resource_params = ""
+    }
+
+    $pcs_command = "/usr/sbin/pcs resource create ${title} \
+    ${resource_type}${_resource_name} ${_resource_params} ${_clone_opts} ${_operation_opts}"
+
+    anchor { "qprs start $name": }
+    ->
+    # We may need/want to set log level here?
+    notify {"pcs command: ${title}":
+      message => "running: ${pcs_command}",
+    }
+    ->
+    # probably want to move this to puppet-pacemaker eventually
+    exec {"create ${title} resource":
+      command   => $pcs_command,
+      tries     => $tries,
+      try_sleep => 30,
+      unless    => "/usr/sbin/pcs resource show ${title}"
+    }
+    ->
+    exec {"wait for ${title} resource":
+      timeout   => 3600,
+      tries     => 360,
+      try_sleep => 10,
+      command   => "/usr/sbin/pcs resource show ${title}",
+    }
+    ->
+    # FIXME: All I can say is 'ICK'.  But this is what we were told to do by
+    # pacemaker team.
+    exec {"really wait for ${title} resource":
+      path          => ["/usr/bin", "/usr/sbin", "/bin"],
+      command => "sleep 5",
+    }
+    -> anchor { "qprs end ${title}": }
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -92,8 +92,9 @@ class quickstack::pacemaker::swift (
       try_sleep => 10,
       command   => "/tmp/ha-all-in-one-util.bash all_members_include swift",
     } ->
-    quickstack::pacemaker::resource::service {'openstack-swift-proxy':
-      clone => true,
+    quickstack::pacemaker::resource::generic {'swift-proxy':
+      clone_opts    => "interleave=true",
+      resource_name => "openstack-swift-proxy",
     } ->
     quickstack::pacemaker::resource::service {'openstack-swift-object-expirer':
       group => "$swift_group",
@@ -102,7 +103,7 @@ class quickstack::pacemaker::swift (
     ->
     quickstack::pacemaker::constraint::base { 'swift-object-expirer-constr' :
       constraint_type => "order",
-      first_resource  => "openstack-swift-proxy-clone",
+      first_resource  => "swift-proxy-clone",
       second_resource => "openstack-swift-object-expirer",
       first_action    => "start",
       second_action   => "start",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1175869

This adds:
- the initial wrapper to allow us to call commands as needed for juno +
  pacemaker (syntax not yet supported in puppet-pacemaker, we can remove when and
  if it gets in there).
- neutron-server to create its resource with the wrapper.