### PR TITLE
Neutron network

### DIFF
--- a/puppet/modules/quickstack/data/RedHat.yaml
+++ b/puppet/modules/quickstack/data/RedHat.yaml
@@ -1,5 +1,38 @@
 ---
-quickstack::ceph::config::fsid: '904c8491-5c16-4dae-9cc3-6ce633a7f4cc'
+neutron_conf_additional_params:
+  default_quota: default
+  quota_network: default
+  quota_subnet: default
+  quota_port: default
+  quota_security_group: default
+  quota_security_group_rule: default
+  quota_vip: default
+  quota_pool: default
+  quota_router: default
+  quota_floatingip: default
+  network_auto_schedule: default
+
+nova_conf_additional_params:
+  quota_instances: default
+  quota_cores: default
+  quota_ram: default
+  quota_floating_ips: default
+  quota_fixed_ips: default
+  quota_driver: default
+
+n1kv_plugin_additional_params:
+  default_policy_profile: default-pp
+  network_node_policy_profile: default-pp
+  poll_duration: '10'
+  http_pool_size: '4'
+  http_timeout: '120'
+  firewall_driver: 'neutron.agent.firewall.NoopFirewallDriver'
+  enable_sync_on_start: 'true'
+  restrict_policy_profiles: 'false'
+
+quickstack::ceph::config::fsid: "%{hiera('ceph_fsid')}"
+quickstack::ceph::config::cluster_network: "%{hiera('network_internal')}.0/24"
+quickstack::ceph::config::images_key: "%{hiera('ceph_images_key')}"
 quickstack::ceph::config::mon_host:
   - "%{hiera('server1_ip')}"
   - "%{hiera('server2_ip')}"
@@ -8,24 +41,98 @@ quickstack::ceph::config::mon_initial_members:
   - "%{hiera('server1_name')}"
   - "%{hiera('server2_name')}"
   - "%{hiera('server3_name')}"
-quickstack::ceph::config::public_network: "%{hiera('network_public')}.0/24"
-quickstack::ceph::config::cluster_network: "%{hiera('network_internal')}.0/24"
-quickstack::ceph::config::osd_pool_size: '1'
-quickstack::ceph::config::osd_pool_default_size: '1'
 quickstack::ceph::config::osd_journal_size: '1000'
+quickstack::ceph::config::osd_pool_default_size: '1'
+quickstack::ceph::config::osd_pool_size: '1'
+quickstack::ceph::config::public_network: "%{hiera('network_public')}.0/24"
+quickstack::ceph::config::volumes_key: "%{hiera('ceph_volumes_key')}"
+
+quickstack::firewall::network::tunnels::tunnel_types_details:
+  "002 gre":
+    proto: 'gre'
+  "002 vxlan":
+    proto: 'udp'
+    dport: '4789'
 
 quickstack::keystone::common::db_host: "%{hiera('db_vip')}"
+
+quickstack::network::agents::ovs::bridge_mappings: ['ext-vlan:br-ex']
+quickstack::network::agents::ovs::bridge_uplinks: ['br-ex:eth0']
+quickstack::network::agents::ovs::enable_tunneling: 'true'
+
+quickstack::network::base::allow_overlapping_ips: "%{hiera('allow_overlapping_ips')}"
+quickstack::network::base::network_device_mtu: ''
+quickstack::network::base::neutron_core_plugin: neutron.plugins.ml2.plugin.Ml2Plugin
+quickstack::network::base::tunnel_iface: "%{hiera('tunnel_iface')}"
+quickstack::network::base::tunnel_network: "%{hiera('tunnel_network')}"
+
+# quickstack::network::params::n1kv_plugin_additional_params:  "%{hiera('n1kv_plugin_additional_params')}"
+# quickstack::network::params::neutron_conf_additional_params: "%{hiera('neutron_conf_additional_params')}"
+# quickstack::network::params::nova_conf_additional_params: "%{hiera('nova_conf_additional_params')}"
+
+quickstack::network::params::external_network_bridge: "%{hiera('external_network_bridge')}"
+quickstack::network::params::network_device_mtu: ''
+quickstack::network::params::neutron_database_max_retries: '-1'
+quickstack::network::params::neutron_metadata_proxy_secret: "%{hiera('neutron_metadata_proxy_secret')}"
+quickstack::network::params::neutron_user_password: "%{hiera('neutron_user_password')}"
+quickstack::network::params::neutron_verbose: 'false'
+quickstack::network::params::neutron_vip_admin: "%{hiera('neutron_vip_admin')}"
+quickstack::network::params::neutron_vip_internal: "%{hiera('neutron_vip_internal')}"
+quickstack::network::params::neutron_vip_public: "%{hiera('neutron_vip_public')}"
+quickstack::network::params::pcs_setup_neutron: 'true'
+quickstack::network::params::tunnel_id_ranges: ['20:100']
+quickstack::network::params::tunnel_iface: "%{hiera('tunnel_iface')}"
+quickstack::network::params::tunnel_network: "%{hiera('tunnel_network')}"
+quickstack::network::params::tunnel_types: ['vxlan']
+quickstack::network::params::security_group_api: 'neutron'
+quickstack::network::params::veth_mtu: ''
+quickstack::network::params::vxlan_udp_port: '4789'
+quickstack::network::params::n1kv_plugin_additional_params:
+  default_policy_profile: default-pp
+  network_node_policy_profile: default-pp
+  poll_duration: '10'
+  http_pool_size: '4'
+  http_timeout: '120'
+  firewall_driver: 'neutron.agent.firewall.NoopFirewallDriver'
+  enable_sync_on_start: 'true'
+  restrict_policy_profiles: 'false'
+quickstack::network::params::neutron_conf_additional_params:
+  default_quota: default
+  quota_network: default
+  quota_subnet: default
+  quota_port: default
+  quota_security_group: default
+  quota_security_group_rule: default
+  quota_vip: default
+  quota_pool: default
+  quota_router: default
+  quota_floatingip: default
+  network_auto_schedule: default
+
+
+quickstack::network::plugins::ml2::flat_networks: ['*']
+quickstack::network::plugins::ml2::mechanism_drivers: ['openvswitch', 'l2population']
+quickstack::network::plugins::ml2::network_vlan_ranges: ['yourphysnet:10:50']
+quickstack::network::plugins::ml2::security_group: 'true'
+quickstack::network::plugins::ml2::tenant_network_types: ['vxlan', 'vlan', 'gre', 'flat']
+quickstack::network::plugins::ml2::tunnel_id_ranges: ['20:100']
+quickstack::network::plugins::ml2::type_drivers: ['local', 'flat', 'vlan', 'gre', 'vxlan']
+quickstack::network::plugins::ml2::vni_ranges: ['10:100']
+quickstack::network::plugins::ml2::vxlan_group: '224.0.0.1'
+
+quickstack::network::plugins::ovs::l2_population: 'true'
+quickstack::network::plugins::ovs::tenant_network_type: 'vxlan'
+quickstack::network::plugins::ovs::vlan_ranges: 'ext-vlan:1000:2000'
+quickstack::network::plugins::ovs::tunnel_id_ranges: '20:100'
 
 quickstack::nova_network::compute::amqp_host: "%{hiera('amqp_vip')}"
 quickstack::nova_network::compute::amqp_provider: "%{hiera('amqp_provider')}"
 quickstack::nova_network::compute::amqp_ssl_port: '5671'
 quickstack::nova_network::compute::auth_host: "%{hiera('keystone_vip_admin')}"
-
 quickstack::nova_network::compute::cinder_backend_gluster: 'false'
 quickstack::nova_network::compute::cinder_backend_nfs: 'true'
 quickstack::nova_network::compute::glance_host: "%{hiera('glance_vip_admin')}"
 quickstack::nova_network::compute::mysql_ca: /etc/ipa/ca.crt
-
 quickstack::nova_network::compute::mysql_host: "%{hiera('db_vip')}"
 quickstack::nova_network::compute::network_create_networks: 'true'
 quickstack::nova_network::compute::network_fixed_range: '10.0.0.0/24'
@@ -33,12 +140,12 @@ quickstack::nova_network::compute::network_floating_range: '10.0.1.0/24'
 quickstack::nova_network::compute::network_manager: FlatDHCPManager
 quickstack::nova_network::compute::network_network_size: ''
 quickstack::nova_network::compute::network_num_networks: 1
-
 quickstack::nova_network::compute::network_overrides: "{'force_dhcp_release' => false}"
 quickstack::nova_network::compute::network_private_iface: "%{hiera('private_iface')}"
 quickstack::nova_network::compute::network_private_network: "%{hiera('private_network')}"
 quickstack::nova_network::compute::network_public_ip: "%{hiera('private_ip')}"
 quickstack::nova_network::compute::network_public_network: "%{hiera('public_network')}"
+quickstack::nova_network::compute::nova_db_password: "%{hiera('nova_db_password')}"
 quickstack::nova_network::compute::nova_host: "%{hiera('nova_vip_admin')}"
 quickstack::nova_network::compute::ssl: 'false'
 
@@ -56,6 +163,7 @@ quickstack::pacemaker::cinder::db_ssl: 'false'
 quickstack::pacemaker::cinder::db_ssl_ca: "%{hiera('db_ca')}"
 quickstack::pacemaker::cinder::debug: 'false'
 quickstack::pacemaker::cinder::eqlx_chap_login: ['chapadmin']
+quickstack::pacemaker::cinder::eqlx_chap_password: ['']
 quickstack::pacemaker::cinder::eqlx_group_name: ['group-0']
 quickstack::pacemaker::cinder::eqlx_pool: ['default']
 quickstack::pacemaker::cinder::eqlx_use_chap: [false]
@@ -67,29 +175,35 @@ quickstack::pacemaker::cinder::rbd_ceph_conf: /etc/ceph/ceph.conf
 quickstack::pacemaker::cinder::rbd_flatten_volume_from_snapshot: 'false'
 quickstack::pacemaker::cinder::rbd_max_clone_depth: '5'
 quickstack::pacemaker::cinder::rbd_pool: volumes
+quickstack::pacemaker::cinder::rbd_secret_uuid: "%{hiera('rbd_secret_uuid')}"
 quickstack::pacemaker::cinder::rbd_user: volumes
 quickstack::pacemaker::cinder::rpc_backend: cinder.openstack.common.rpc.impl_kombu
 quickstack::pacemaker::cinder::san_ip: ['']
 quickstack::pacemaker::cinder::san_login: ['grpadmin']
+quickstack::pacemaker::cinder::san_password: ['']
 quickstack::pacemaker::cinder::san_thin_provision: [false]
 quickstack::pacemaker::cinder::verbose: 'false'
 quickstack::pacemaker::cinder::volume: 'true'
 
 quickstack::pacemaker::common::fence_ipmilan_address: ''
 quickstack::pacemaker::common::fence_ipmilan_expose_lanplus: 'true'
-quickstack::pacemaker::common::fence_ipmilan_hostlist: ''
 quickstack::pacemaker::common::fence_ipmilan_host_to_address: []
+quickstack::pacemaker::common::fence_ipmilan_hostlist: ''
 quickstack::pacemaker::common::fence_ipmilan_interval: 60s
 quickstack::pacemaker::common::fence_ipmilan_lanplus_options: ''
+quickstack::pacemaker::common::fence_ipmilan_password: "%{hiera('fence_ipmilan_password')}"
 quickstack::pacemaker::common::fence_ipmilan_username: ''
 quickstack::pacemaker::common::fence_xvm_clu_iface: 'eth2'
 quickstack::pacemaker::common::fence_xvm_clu_network: ''
+quickstack::pacemaker::common::fence_xvm_key_file_password: "%{hiera('fence_xvm_key_file_password')}"
 quickstack::pacemaker::common::fence_xvm_manage_key_file: 'false'
 quickstack::pacemaker::common::fencing_type: "%{hiera('fencing')}"
 quickstack::pacemaker::common::pacemaker_cluster_members: "%{hiera('server1_ip')} %{hiera('server2_ip')} %{hiera('server3_ip')}"
 quickstack::pacemaker::common::pacemaker_cluster_name: openstackHA
 
+quickstack::pacemaker::galera::galera_monitor_password: "%{hiera('galera_monitor_password')}"
 quickstack::pacemaker::galera::galera_monitor_username: monitor_user
+quickstack::pacemaker::galera::mysql_root_password: "%{hiera('mysql_root_password')}"
 quickstack::pacemaker::galera::wsrep_cluster_members:
   - "%{hiera('server1_ip')}"
   - "%{hiera('server2_ip')}"
@@ -99,10 +213,12 @@ quickstack::pacemaker::galera::wsrep_ssl: 'false'
 quickstack::pacemaker::galera::wsrep_ssl_cert: "%{hiera('db_cert')}"
 quickstack::pacemaker::galera::wsrep_ssl_key: "%{hiera('db_key')}"
 quickstack::pacemaker::galera::wsrep_sst_method: rsync
+quickstack::pacemaker::galera::wsrep_sst_password: "%{hiera('galera_wsrep_sst_password')}"
 quickstack::pacemaker::galera::wsrep_sst_username: 'sst_user'
+quickstack::pacemaker::glance::swift_store_key: ''
 
 quickstack::pacemaker::glance::backend: "%{hiera('glance_backend')}"
-quickstack::pacemaker::glance::db_ssl_ca: "%{hiera('quickstack::params::db_ssl_ca')}"
+quickstack::pacemaker::glance::db_ssl_ca: "%{hiera('db_ca')}"
 quickstack::pacemaker::glance::filesystem_store_datadir: /var/lib/glance/images/
 quickstack::pacemaker::glance::pcmk_fs_device: "%{hiera('glance_device')}"
 quickstack::pacemaker::glance::pcmk_fs_dir: '/var/lib/glance/images/'
@@ -123,38 +239,40 @@ quickstack::pacemaker::horizon::horizon_ca: "%{hiera('horizon_ca')}"
 quickstack::pacemaker::horizon::horizon_cert: "%{hiera('horizon_cert')}"
 quickstack::pacemaker::horizon::horizon_key: "%{hiera('horizon_key')}"
 quickstack::pacemaker::horizon::keystone_default_role: '_member_'
+quickstack::pacemaker::horizon::secret_key: "%{hiera('horizon_secret_key')}"
 
 quickstack::pacemaker::keystone::admin_email: "%{hiera('admin_email')}"
+quickstack::pacemaker::keystone::admin_password: "%{hiera('keystone_admin_password')}"
 quickstack::pacemaker::keystone::admin_tenant: 'admin'
+quickstack::pacemaker::keystone::admin_token: "%{hiera('keystone_admin_token')}"
+quickstack::pacemaker::keystone::ceilometer: "%{hiera('ceilometer')}"
+quickstack::pacemaker::keystone::cinder: "%{hiera('cinder')}"
 quickstack::pacemaker::keystone::db_ssl: "%{hiera('ssl')}"
 quickstack::pacemaker::keystone::db_ssl_ca: "%{hiera('db_ca')}"
 quickstack::pacemaker::keystone::debug: "%{hiera('debug')}"
-quickstack::pacemaker::keystone::ceilometer: "%{hiera('ceilometer')}"
-quickstack::pacemaker::keystone::cinder: "%{hiera('cinder')}"
 quickstack::pacemaker::keystone::glance: "%{hiera('glance')}"
 quickstack::pacemaker::keystone::heat: "%{hiera('heat')}"
 quickstack::pacemaker::keystone::heat_cfn: "%{hiera('heat_cfn')}"
 quickstack::pacemaker::keystone::keystonerc: "%{hiera('keystonerc')}"
 quickstack::pacemaker::keystone::nova: "%{hiera('nova')}"
 quickstack::pacemaker::keystone::region: "%{hiera('region')}"
-
 quickstack::pacemaker::keystone::swift: "%{hiera('swift')}"
 
 # quickstack::pacemaker::load_balancer:
 
 # quickstack::pacemaker::memcached:
 
+quickstack::pacemaker::neutron::allow_overlapping_ips: 'true'
 quickstack::pacemaker::neutron::amqp_host: "%{hiera('ampq_vip')}"
 quickstack::pacemaker::neutron::amqp_port: "%{hiera('ampq_port')}"
 quickstack::pacemaker::neutron::amqp_username: "%{hiera('ampq_username')}"
-quickstack::pacemaker::neutron::allow_overlapping_ips: 'true'
 quickstack::pacemaker::neutron::auth_host: "%{hiera('keystone_vip')}"
-quickstack::pacemaker::neutron::cisco_vswitch_plugin: 'neutron.plugins.cisco.n1kv.n1kv_neutron_plugin.N1kvNeutronPluginV2'
 quickstack::pacemaker::neutron::cisco_nexus_plugin: ''
+quickstack::pacemaker::neutron::cisco_vswitch_plugin: 'neutron.plugins.cisco.n1kv.n1kv_neutron_plugin.N1kvNeutronPluginV2'
 quickstack::pacemaker::neutron::database_max_retries: '-1'
 quickstack::pacemaker::neutron::enable_tunneling: 'true'
 quickstack::pacemaker::neutron::enabled: 'true'
-quickstack::pacemaker::neutron::external_network_bridge: 'br-ex'
+quickstack::pacemaker::neutron::external_network_bridge: "%{hiera('external_network_bridge')}"
 quickstack::pacemaker::neutron::manage_service: true'
 quickstack::pacemaker::neutron::ml2_flat_networks: ['*']
 quickstack::pacemaker::neutron::ml2_mechanism_drivers: ['openvswitch', 'l2population']
@@ -165,16 +283,13 @@ quickstack::pacemaker::neutron::ml2_tunnel_id_ranges: ['20:100']
 quickstack::pacemaker::neutron::ml2_type_drivers: ['local', 'flat', 'vlan', 'gre', 'vxlan']
 quickstack::pacemaker::neutron::ml2_vxlan_group: '224.0.0.1'
 quickstack::pacemaker::neutron::mysql_host:
-quickstack::pacemaker::neutron::network_device_mtu: ''
-quickstack::pacemaker::neutron::neutron_core_plugin:
-quickstack::pacemaker::neutron::neutron_priv_host: "%{hiera('neutron_vip_internal')}"
-quickstack::pacemaker::neutron::neutron_url:
-quickstack::pacemaker::neutron::neutron_conf_additional_params: "%{hiera('quickstack::params::neutron_conf_additional_params:')}"
-quickstack::pacemaker::neutron::nexus_config: {}
 quickstack::pacemaker::neutron::n1kv_vsm_ip: '0.0.0.0'
 quickstack::pacemaker::neutron::n1kv_vsm_password: "%{hiera('n1kv_vsm_password')}"
-quickstack::pacemaker::neutron::n1kv_plugin_additional_params:  "%{hiera('quickstack::params::n1kv_plugin_additional_params:')}"
-quickstack::pacemaker::neutron::nova_conf_additional_params: "%{hiera('quickstack::params::nova_conf_additional_params:')}"
+quickstack::pacemaker::neutron::network_device_mtu: ''
+quickstack::pacemaker::neutron::neutron_core_plugin: neutron.plugins.ml2.plugin.Ml2Plugin
+quickstack::pacemaker::neutron::neutron_priv_host: "%{hiera('neutron_vip_internal')}"
+quickstack::pacemaker::neutron::neutron_url: '127.0.0.1'
+quickstack::pacemaker::neutron::nexus_config: {}
 quickstack::pacemaker::neutron::ovs_bridge_mappings: ['ext-vlan:br-ex']
 quickstack::pacemaker::neutron::ovs_bridge_uplinks: ['br-ex:eth0']
 quickstack::pacemaker::neutron::ovs_tunnel_iface: "%{hiera('tunnel_iface')}"
@@ -190,16 +305,22 @@ quickstack::pacemaker::neutron::tunnel_id_ranges: 1:1000
 quickstack::pacemaker::neutron::verbose: 'false'
 quickstack::pacemaker::neutron::veth_mtu: ''
 
+# quickstack::pacemaker::neutron::n1kv_plugin_additional_params:  "%{hiera('n1kv_plugin_additional_params')}"
+# quickstack::pacemaker::neutron::neutron_conf_additional_params: "%{hiera('neutron_conf_additional_params')}"
+# quickstack::pacemaker::neutron::nova_conf_additional_params: "%{hiera('nova_conf_additional_params')}"
+
 quickstack::pacemaker::nova::auto_assign_floating_ip: 'true'
 quickstack::pacemaker::nova::default_floating_pool: nova
 quickstack::pacemaker::nova::force_dhcp_release: 'false'
 quickstack::pacemaker::nova::image_service: nova.image.glance.GlanceImageService
 quickstack::pacemaker::nova::multi_host: 'true'
+quickstack::pacemaker::nova::neutron_metadata_proxy_secret: "%{hiera('neutron_metadata_proxy_secret')}"
 quickstack::pacemaker::nova::rpc_backend: nova.openstack.common.rpc.impl_kombu
 quickstack::pacemaker::nova::scheduler_host_subset_size: '30'
 
 quickstack::pacemaker::params::admin_email: "%{hiera('admin_email')}"
 quickstack::pacemaker::params::amqp_group: amqp
+quickstack::pacemaker::params::amqp_password: "%{hiera('amqp_password')}"
 quickstack::pacemaker::params::amqp_port: '5672'
 quickstack::pacemaker::params::amqp_provider: "%{hiera('amqp_provider')}"
 quickstack::pacemaker::params::amqp_username: "%{hiera('amqp_username')}"
@@ -208,39 +329,50 @@ quickstack::pacemaker::params::ceilometer_admin_vip: "%{hiera('ceilometer_vip_ad
 quickstack::pacemaker::params::ceilometer_group: ceilometer
 quickstack::pacemaker::params::ceilometer_private_vip: "%{hiera('ceilometer_vip_internal')}"
 quickstack::pacemaker::params::ceilometer_public_vip: "%{hiera('ceilometer_vip_public')}"
+quickstack::pacemaker::params::ceilometer_user_password: "%{hiera('ceilometer_user_password')}"
+quickstack::pacemaker::params::ceph_cluster_network: "%{hiera('network_internal')}.0/24"
 quickstack::pacemaker::params::ceph_fsid: '904c8491-5c16-4dae-9cc3-6ce633a7f4cc'
+quickstack::pacemaker::params::ceph_images_key: "%{hiera('ceph_images_key')}"
 quickstack::pacemaker::params::ceph_mon_host:
   - "%{hiera('server1_ip')}"
   - "%{hiera('server2_ip')}"
   - "%{hiera('server3_ip')}"
 quickstack::pacemaker::params::ceph_mon_initial_members: ['c1a1', 'c1a2', 'c1a3']
-quickstack::pacemaker::params::ceph_public_network: "%{hiera('network_public')}.0/24"
-quickstack::pacemaker::params::ceph_cluster_network: "%{hiera('network_internal')}.0/24"
-quickstack::pacemaker::params::ceph_osd_pool_size: '1'
-quickstack::pacemaker::params::ceph_osd_pool_default_size: '1'
 quickstack::pacemaker::params::ceph_osd_journal_size: '1000'
+quickstack::pacemaker::params::ceph_osd_pool_default_size: '1'
+quickstack::pacemaker::params::ceph_osd_pool_size: '1'
+quickstack::pacemaker::params::ceph_public_network: "%{hiera('network_public')}.0/24"
+quickstack::pacemaker::params::ceph_volumes_key: "%{hiera('ceph_volumes_key')}"
 quickstack::pacemaker::params::cinder_admin_vip: "%{hiera('cinder_vip_admin')}"
+quickstack::pacemaker::params::cinder_db_password: "%{hiera('cinder_db_password')}"
 quickstack::pacemaker::params::cinder_group: 'cinder'
 quickstack::pacemaker::params::cinder_private_vip: "%{hiera('cinder_vip_internal')}"
 quickstack::pacemaker::params::cinder_public_vip: "%{hiera('cinder_vip_public')}"
+quickstack::pacemaker::params::cinder_user_password: "%{hiera('cinder_user_password')}"
 quickstack::pacemaker::params::cluster_control_ip: "%{hiera('cluster_control_ip')}"
 quickstack::pacemaker::params::db_group: 'db'
 quickstack::pacemaker::params::db_host: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::db_vip: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::glance_admin_vip: "%{hiera('glance_vip_admin')}"
+quickstack::pacemaker::params::glance_db_password: "%{hiera('glance_db_password')}"
 quickstack::pacemaker::params::glance_group: glance
 quickstack::pacemaker::params::glance_private_vip: "%{hiera('glance_vip_internal')}"
 quickstack::pacemaker::params::glance_public_vip: "%{hiera('glance_vip_public')}"
+quickstack::pacemaker::params::glance_user_password: "%{hiera('glance_user_password')}"
 quickstack::pacemaker::params::heat_admin_vip: "%{hiera('heat_vip_admin')}"
+quickstack::pacemaker::params::heat_auth_encryption_key: "%{hiera('heat_auth_encryption_key')}"
 quickstack::pacemaker::params::heat_cfn_admin_vip: "%{hiera('heat_cfn_vip_admin')}"
 quickstack::pacemaker::params::heat_cfn_enabled: "%{hiera('heat')}"
 quickstack::pacemaker::params::heat_cfn_group: 'heat_cfn'
 quickstack::pacemaker::params::heat_cfn_private_vip: "%{hiera('heat_cfn_vip_internal')}"
 quickstack::pacemaker::params::heat_cfn_public_vip: "%{hiera('heat_cfn_vip_public')}"
+quickstack::pacemaker::params::heat_cfn_user_password: "%{hiera('heat_cfn_user_password')}"
 quickstack::pacemaker::params::heat_cloudwatch_enabled: "%{hiera('heat')}"
+quickstack::pacemaker::params::heat_db_password: "%{hiera('heat_db_password')}"
 quickstack::pacemaker::params::heat_group: 'heat'
 quickstack::pacemaker::params::heat_private_vip: "%{hiera('heat_vip_internal')}"
 quickstack::pacemaker::params::heat_public_vip: "%{hiera('heat_vip_public')}"
+quickstack::pacemaker::params::heat_user_password: "%{hiera('heat_user_password')}"
 quickstack::pacemaker::params::horizon_admin_vip: "%{hiera('horizon_vip_admin')}"
 quickstack::pacemaker::params::horizon_group: horizon
 quickstack::pacemaker::params::horizon_private_vip: "%{hiera('horizon_vip_internal')}"
@@ -256,82 +388,83 @@ quickstack::pacemaker::params::include_neutron: "%{hiera('neutron')}"
 quickstack::pacemaker::params::include_nova: "%{hiera('nova')}"
 quickstack::pacemaker::params::include_swift: "%{hiera('swift')}"
 quickstack::pacemaker::params::keystone_admin_vip: "%{hiera('keystone_vip_admin')}"
+quickstack::pacemaker::params::keystone_db_password: "%{hiera('keystone_db_password')}"
 quickstack::pacemaker::params::keystone_group: keystone
 quickstack::pacemaker::params::keystone_private_vip: "%{hiera('keystone_vip_internal')}"
 quickstack::pacemaker::params::keystone_public_vip: "%{hiera('keystone_vip_public')}"
-quickstack::pacemaker::params::lb_backend_server_addrs:
-  - "%{hiera('server1_ip')}"
-  - "%{hiera('server2_ip')}"
-  - "%{hiera('server3_ip')}"
+quickstack::pacemaker::params::keystone_user_password: "%{hiera('keystone_user_password')}"
 quickstack::pacemaker::params::lb_backend_server_names:
   - "%{hiera('server1_name')}"
   - "%{hiera('server2_name')}"
   - "%{hiera('server3_name')}"
+quickstack::pacemaker::params::lb_backend_server_addrs:
+  - "%{hiera('server1_ip')}"
+  - "%{hiera('server2_ip')}"
+  - "%{hiera('server3_ip')}"
 quickstack::pacemaker::params::loadbalancer_group: 'loadbalancer'
 quickstack::pacemaker::params::loadbalancer_vip: "%{hiera('loadbalancer_vip')}"
 quickstack::pacemaker::params::mysql_host: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::mysql_vip: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::neutron: "%{hiera('neutron')}"
 quickstack::pacemaker::params::neutron_admin_vip: "%{hiera('neutron_vip_admin')}"
+quickstack::pacemaker::params::neutron_db_password: "%{hiera('neutron_db_password')}"
 quickstack::pacemaker::params::neutron_group: 'neutron'
+quickstack::pacemaker::params::neutron_metadata_proxy_secret: "%{hiera('neutron_metadata_proxy_secret')}"
 quickstack::pacemaker::params::neutron_private_vip: "%{hiera('neutron_vip_internal')}"
 quickstack::pacemaker::params::neutron_public_vip: "%{hiera('neutron_vip_public')}"
+quickstack::pacemaker::params::neutron_user_password: "%{hiera('neutron_user_password')}"
 quickstack::pacemaker::params::nosql_vip: "%{hiera('nosql_vip')}"
 quickstack::pacemaker::params::nova_admin_vip: "%{hiera('nova_vip_admin')}"
+quickstack::pacemaker::params::nova_db_password: "%{hiera('nova_db_password')}"
 quickstack::pacemaker::params::nova_group: 'nova'
 quickstack::pacemaker::params::nova_private_vip: "%{hiera('nova_vip_internal')}"
 quickstack::pacemaker::params::nova_public_vip: "%{hiera('nova_vip_public')}"
+quickstack::pacemaker::params::nova_user_password: "%{hiera('nova_user_password')}"
 quickstack::pacemaker::params::private_iface: "%{hiera('private_iface')}"
 quickstack::pacemaker::params::private_ip: "%{hiera('private_ip')}"
 quickstack::pacemaker::params::private_network: "%{hiera('private_network')}"
-quickstack::pacemaker::params::swift_group: 'swift'
 quickstack::pacemaker::params::swift_admin_vip: "%{hiera('swift_vip_admin')}"
+quickstack::pacemaker::params::swift_group: 'swift'
 quickstack::pacemaker::params::swift_internal_vip: "%{hiera('swift_vip_internal')}"
 quickstack::pacemaker::params::swift_public_vip: "%{hiera('swift_vip_public')}"
+quickstack::pacemaker::params::swift_user_password: "%{hiera('swift_user_password')}"
 
 quickstack::pacemaker::rabbitmq::inet_dist_listen: '35672'
 
 quickstack::pacemaker::swift::swift_internal_vip: "%{hiera('swift_vip_internal')}"
+quickstack::pacemaker::swift::swift_shared_secret: "%{hiera('swift_shared_secret')}"
 quickstack::pacemaker::swift::swift_storage_device: 'device1'
 quickstack::pacemaker::swift::swift_storage_ips: ["%{hiera('swift_storage1_ip')}"]
 
-quickstack::params::db_ssl: 'false'
-quickstack::params::db_ssl_ca: "%{hiera('db_ca')}"
-quickstack::params::debug: 'false'
-quickstack::params::enabled: 'true'
-quickstack::params::memcached_port: '11211'
-quickstack::params::verbose: 'true'
-quickstack::params::cinder_backend_rbd: 'false'
-quickstack::params::glance_backend_rbd: 'false'
-
-# Added for neutron AIO support
 quickstack::params::amqp_ca: "%{hiera('amqp_ca')}"
 quickstack::params::amqp_cert: "%{hiera('amqp_cert')}"
 quickstack::params::amqp_key: "%{hiera('amqp_key')}"
 quickstack::params::amqp_password: "%{hiera('amqp_password')}"
+quickstack::params::amqp_port: '5672'
 quickstack::params::amqp_provider: "%{hiera('amqp_provider')}"
+quickstack::params::amqp_ssl_port: '5671'
 quickstack::params::amqp_username: "%{hiera('amqp_username')}"
 quickstack::params::amqp_vip: "%{hiera('amqp_vip')}"
-quickstack::params::amqp_port: '5672'
-quickstack::params::amqp_ssl_port: '5671'
+quickstack::params::ceilometer_metering_secret: "%{hiera('ceilometer_metering_secret')}"
+quickstack::params::ceilometer_user_password: "%{hiera('ceilometer_user_password')}"
+quickstack::params::cinder_backend_rbd: 'false'
+quickstack::params::db_host: "%{hiera('db_vip')}"
+quickstack::params::db_ssl: "%{hiera('ssl')}"
+quickstack::params::db_ssl_ca: "%{hiera('db_ca')}"
+quickstack::params::debug: "%{hiera('debug')}"
+quickstack::params::enabled: 'true'
+quickstack::params::glance_backend_rbd: 'false'
 quickstack::params::keystone_vip_admin: "%{hiera('keystone_vip_admin')}"
 quickstack::params::keystone_vip_internal: "%{hiera('keystone_vip_internal')}"
 quickstack::params::keystone_vip_public: "%{hiera('keystone_vip_public')}"
+quickstack::params::memcached_port: '11211'
 quickstack::params::mysql_ca: "%{hiera('mysql_ca')}"
 quickstack::params::mysql_cert: "%{hiera('mysql_cert')}"
-quickstack::params::mysql_key: "%{hiera('mysql_key')}"
-
-quickstack::params::mysql_vip: "%{hiera('db_vip')}"
-quickstack::params::db_host: "%{hiera('db_vip')}"
 quickstack::params::mysql_host: "%{hiera('db_vip')}"
-
-# quickstack::params::nova_conf_additional_params: { 'quota_instances' => 'default',
-#                                    'quota_cores' => 'default',
-#                                    'quota_ram' => 'default',
-#                                    'quota_floating_ips' => 'default',
-#                                    'quota_fixed_ips' => 'default',
-#                                    'quota_driver' => 'default',
-#                                    }
+quickstack::params::mysql_key: "%{hiera('mysql_key')}"
+quickstack::params::mysql_vip: "%{hiera('db_vip')}"
 quickstack::params::region: "%{hiera('region')}"
-quickstack::params::ssl: 'false'
+quickstack::params::ssl: "%{hiera('ssl')}"
+quickstack::params::verbose: "%{hiera('ssl')}"
+
 #quickstack::params::service_plugins: [ 'dhcp', 'l3' ]

--- a/puppet/modules/quickstack/data/RedHat.yaml
+++ b/puppet/modules/quickstack/data/RedHat.yaml
@@ -1,13 +1,4 @@
 ---
-quickstack::params::db_ssl: 'false'
-quickstack::params::db_ssl_ca: ''
-quickstack::params::debug: 'false'
-quickstack::params::enabled: 'true'
-quickstack::params::memcached_port: '11211'
-quickstack::params::verbose: 'true'
-quickstack::params::cinder_backend_rbd: 'false'
-quickstack::params::glance_backend_rbd: 'false'
-
 quickstack::ceph::config::fsid: '904c8491-5c16-4dae-9cc3-6ce633a7f4cc'
 quickstack::ceph::config::mon_host:
   - "%{hiera('server1_ip')}"
@@ -22,6 +13,8 @@ quickstack::ceph::config::cluster_network: "%{hiera('network_internal')}.0/24"
 quickstack::ceph::config::osd_pool_size: '1'
 quickstack::ceph::config::osd_pool_default_size: '1'
 quickstack::ceph::config::osd_journal_size: '1000'
+
+quickstack::keystone::common::db_host: "%{hiera('db_vip')}"
 
 quickstack::nova_network::compute::amqp_host: "%{hiera('amqp_vip')}"
 quickstack::nova_network::compute::amqp_provider: "%{hiera('amqp_provider')}"
@@ -45,7 +38,7 @@ quickstack::nova_network::compute::network_overrides: "{'force_dhcp_release' => 
 quickstack::nova_network::compute::network_private_iface: "%{hiera('private_iface')}"
 quickstack::nova_network::compute::network_private_network: "%{hiera('private_network')}"
 quickstack::nova_network::compute::network_public_ip: "%{hiera('private_ip')}"
-quickstack::nova_network::compute::network_public_network: "%{hiera('public+network')}"
+quickstack::nova_network::compute::network_public_network: "%{hiera('public_network')}"
 quickstack::nova_network::compute::nova_host: "%{hiera('nova_vip_admin')}"
 quickstack::nova_network::compute::ssl: 'false'
 
@@ -108,11 +101,11 @@ quickstack::pacemaker::galera::wsrep_ssl_key: "%{hiera('db_key')}"
 quickstack::pacemaker::galera::wsrep_sst_method: rsync
 quickstack::pacemaker::galera::wsrep_sst_username: 'sst_user'
 
-quickstack::pacemaker::glance::backend: rbd
+quickstack::pacemaker::glance::backend: "%{hiera('glance_backend')}"
 quickstack::pacemaker::glance::db_ssl_ca: "%{hiera('quickstack::params::db_ssl_ca')}"
 quickstack::pacemaker::glance::filesystem_store_datadir: /var/lib/glance/images/
 quickstack::pacemaker::glance::pcmk_fs_device: "%{hiera('glance_device')}"
-quickstack::pacemaker::glance::pcmk_fs_dir: /var/lib/glance/images/
+quickstack::pacemaker::glance::pcmk_fs_dir: '/var/lib/glance/images/'
 quickstack::pacemaker::glance::pcmk_fs_manage: 'false'
 quickstack::pacemaker::glance::pcmk_fs_options: ''
 quickstack::pacemaker::glance::pcmk_fs_type: nfs
@@ -132,29 +125,37 @@ quickstack::pacemaker::horizon::horizon_key: "%{hiera('horizon_key')}"
 quickstack::pacemaker::horizon::keystone_default_role: '_member_'
 
 quickstack::pacemaker::keystone::admin_email: "%{hiera('admin_email')}"
-quickstack::pacemaker::keystone::admin_password: "%{hiera('admin_password')}"
-quickstack::pacemaker::keystone::admin_tenant: admin
-quickstack::pacemaker::keystone::admin_token: "%{hiera('admin_token')}"
-quickstack::pacemaker::keystone::db_ssl: 'false'
+quickstack::pacemaker::keystone::admin_tenant: 'admin'
+quickstack::pacemaker::keystone::db_ssl: "%{hiera('ssl')}"
 quickstack::pacemaker::keystone::db_ssl_ca: "%{hiera('db_ca')}"
-quickstack::pacemaker::keystone::debug: 'false'
-quickstack::pacemaker::keystone::ceilometer: 'false'
-quickstack::pacemaker::keystone::cinder: 'true'
-quickstack::pacemaker::keystone::glance: 'true'
-quickstack::pacemaker::keystone::heat: 'false'
-quickstack::pacemaker::keystone::heat_cfn: 'false'
-quickstack::pacemaker::keystone::keystonerc: 'true'
-quickstack::pacemaker::keystone::nova: 'true'
-quickstack::pacemaker::keystone::region: 'RegionOne'
-quickstack::pacemaker::keystone::swift: 'false'
+quickstack::pacemaker::keystone::debug: "%{hiera('debug')}"
+quickstack::pacemaker::keystone::ceilometer: "%{hiera('ceilometer')}"
+quickstack::pacemaker::keystone::cinder: "%{hiera('cinder')}"
+quickstack::pacemaker::keystone::glance: "%{hiera('glance')}"
+quickstack::pacemaker::keystone::heat: "%{hiera('heat')}"
+quickstack::pacemaker::keystone::heat_cfn: "%{hiera('heat_cfn')}"
+quickstack::pacemaker::keystone::keystonerc: "%{hiera('keystonerc')}"
+quickstack::pacemaker::keystone::nova: "%{hiera('nova')}"
+quickstack::pacemaker::keystone::region: "%{hiera('region')}"
+
+quickstack::pacemaker::keystone::swift: "%{hiera('swift')}"
 
 # quickstack::pacemaker::load_balancer:
 
 # quickstack::pacemaker::memcached:
 
-quickstack::pacemaker::neutron::core_plugin: neutron.plugins.ml2.plugin.Ml2Plugin
+quickstack::pacemaker::neutron::amqp_host: "%{hiera('ampq_vip')}"
+quickstack::pacemaker::neutron::amqp_port: "%{hiera('ampq_port')}"
+quickstack::pacemaker::neutron::amqp_username: "%{hiera('ampq_username')}"
+quickstack::pacemaker::neutron::allow_overlapping_ips: 'true'
+quickstack::pacemaker::neutron::auth_host: "%{hiera('keystone_vip')}"
+quickstack::pacemaker::neutron::cisco_vswitch_plugin: 'neutron.plugins.cisco.n1kv.n1kv_neutron_plugin.N1kvNeutronPluginV2'
+quickstack::pacemaker::neutron::cisco_nexus_plugin: ''
+quickstack::pacemaker::neutron::database_max_retries: '-1'
 quickstack::pacemaker::neutron::enable_tunneling: 'true'
-quickstack::pacemaker::neutron::external_network_bridge: br-ex
+quickstack::pacemaker::neutron::enabled: 'true'
+quickstack::pacemaker::neutron::external_network_bridge: 'br-ex'
+quickstack::pacemaker::neutron::manage_service: true'
 quickstack::pacemaker::neutron::ml2_flat_networks: ['*']
 quickstack::pacemaker::neutron::ml2_mechanism_drivers: ['openvswitch', 'l2population']
 quickstack::pacemaker::neutron::ml2_network_vlan_ranges: ['yourphysnet:10:50']
@@ -162,17 +163,32 @@ quickstack::pacemaker::neutron::ml2_security_group: 'true'
 quickstack::pacemaker::neutron::ml2_tenant_network_types: ['vxlan', 'vlan', 'gre', 'flat']
 quickstack::pacemaker::neutron::ml2_tunnel_id_ranges: ['20:100']
 quickstack::pacemaker::neutron::ml2_type_drivers: ['local', 'flat', 'vlan', 'gre', 'vxlan']
-quickstack::pacemaker::neutron::ml2_vxlan_group: 224.0.0.1
+quickstack::pacemaker::neutron::ml2_vxlan_group: '224.0.0.1'
+quickstack::pacemaker::neutron::mysql_host:
+quickstack::pacemaker::neutron::network_device_mtu: ''
+quickstack::pacemaker::neutron::neutron_core_plugin:
+quickstack::pacemaker::neutron::neutron_priv_host: "%{hiera('neutron_vip_internal')}"
+quickstack::pacemaker::neutron::neutron_url:
+quickstack::pacemaker::neutron::neutron_conf_additional_params: "%{hiera('quickstack::params::neutron_conf_additional_params:')}"
+quickstack::pacemaker::neutron::nexus_config: {}
+quickstack::pacemaker::neutron::n1kv_vsm_ip: '0.0.0.0'
+quickstack::pacemaker::neutron::n1kv_vsm_password: "%{hiera('n1kv_vsm_password')}"
+quickstack::pacemaker::neutron::n1kv_plugin_additional_params:  "%{hiera('quickstack::params::n1kv_plugin_additional_params:')}"
+quickstack::pacemaker::neutron::nova_conf_additional_params: "%{hiera('quickstack::params::nova_conf_additional_params:')}"
 quickstack::pacemaker::neutron::ovs_bridge_mappings: ['ext-vlan:br-ex']
 quickstack::pacemaker::neutron::ovs_bridge_uplinks: ['br-ex:eth0']
 quickstack::pacemaker::neutron::ovs_tunnel_iface: "%{hiera('tunnel_iface')}"
 quickstack::pacemaker::neutron::ovs_tunnel_network: "%{hiera('tunnel_network')}"
 quickstack::pacemaker::neutron::ovs_tunnel_types: ['vxlan']
 quickstack::pacemaker::neutron::ovs_tunnel_types: []
-quickstack::pacemaker::neutron::ovs_vlan_ranges: ext-vlan:1000:2000
+quickstack::pacemaker::neutron::ovs_vlan_ranges: 'ext-vlan:1000:2000'
 quickstack::pacemaker::neutron::ovs_vxlan_udp_port: '4789'
-quickstack::pacemaker::neutron::tenant_network_type: vlan
+quickstack::pacemaker::neutron::rpc_backend: 'neutron.openstack.common.rpc.impl_kombu'
+quickstack::pacemaker::neutron::security_group_api: 'neutron'
+quickstack::pacemaker::neutron::tenant_network_type: 'vlan'
 quickstack::pacemaker::neutron::tunnel_id_ranges: 1:1000
+quickstack::pacemaker::neutron::verbose: 'false'
+quickstack::pacemaker::neutron::veth_mtu: ''
 
 quickstack::pacemaker::nova::auto_assign_floating_ip: 'true'
 quickstack::pacemaker::nova::default_floating_pool: nova
@@ -186,7 +202,7 @@ quickstack::pacemaker::params::admin_email: "%{hiera('admin_email')}"
 quickstack::pacemaker::params::amqp_group: amqp
 quickstack::pacemaker::params::amqp_port: '5672'
 quickstack::pacemaker::params::amqp_provider: "%{hiera('amqp_provider')}"
-quickstack::pacemaker::params::amqp_username: openstack
+quickstack::pacemaker::params::amqp_username: "%{hiera('amqp_username')}"
 quickstack::pacemaker::params::amqp_vip: "%{hiera('amqp_vip')}"
 quickstack::pacemaker::params::ceilometer_admin_vip: "%{hiera('ceilometer_vip_admin')}"
 quickstack::pacemaker::params::ceilometer_group: ceilometer
@@ -209,6 +225,7 @@ quickstack::pacemaker::params::cinder_private_vip: "%{hiera('cinder_vip_internal
 quickstack::pacemaker::params::cinder_public_vip: "%{hiera('cinder_vip_public')}"
 quickstack::pacemaker::params::cluster_control_ip: "%{hiera('cluster_control_ip')}"
 quickstack::pacemaker::params::db_group: 'db'
+quickstack::pacemaker::params::db_host: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::db_vip: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::glance_admin_vip: "%{hiera('glance_vip_admin')}"
 quickstack::pacemaker::params::glance_group: glance
@@ -252,11 +269,14 @@ quickstack::pacemaker::params::lb_backend_server_names:
   - "%{hiera('server3_name')}"
 quickstack::pacemaker::params::loadbalancer_group: 'loadbalancer'
 quickstack::pacemaker::params::loadbalancer_vip: "%{hiera('loadbalancer_vip')}"
+quickstack::pacemaker::params::mysql_host: "%{hiera('db_vip')}"
+quickstack::pacemaker::params::mysql_vip: "%{hiera('db_vip')}"
 quickstack::pacemaker::params::neutron: "%{hiera('neutron')}"
 quickstack::pacemaker::params::neutron_admin_vip: "%{hiera('neutron_vip_admin')}"
 quickstack::pacemaker::params::neutron_group: 'neutron'
 quickstack::pacemaker::params::neutron_private_vip: "%{hiera('neutron_vip_internal')}"
 quickstack::pacemaker::params::neutron_public_vip: "%{hiera('neutron_vip_public')}"
+quickstack::pacemaker::params::nosql_vip: "%{hiera('nosql_vip')}"
 quickstack::pacemaker::params::nova_admin_vip: "%{hiera('nova_vip_admin')}"
 quickstack::pacemaker::params::nova_group: 'nova'
 quickstack::pacemaker::params::nova_private_vip: "%{hiera('nova_vip_internal')}"
@@ -274,3 +294,44 @@ quickstack::pacemaker::rabbitmq::inet_dist_listen: '35672'
 quickstack::pacemaker::swift::swift_internal_vip: "%{hiera('swift_vip_internal')}"
 quickstack::pacemaker::swift::swift_storage_device: 'device1'
 quickstack::pacemaker::swift::swift_storage_ips: ["%{hiera('swift_storage1_ip')}"]
+
+quickstack::params::db_ssl: 'false'
+quickstack::params::db_ssl_ca: "%{hiera('db_ca')}"
+quickstack::params::debug: 'false'
+quickstack::params::enabled: 'true'
+quickstack::params::memcached_port: '11211'
+quickstack::params::verbose: 'true'
+quickstack::params::cinder_backend_rbd: 'false'
+quickstack::params::glance_backend_rbd: 'false'
+
+# Added for neutron AIO support
+quickstack::params::amqp_ca: "%{hiera('amqp_ca')}"
+quickstack::params::amqp_cert: "%{hiera('amqp_cert')}"
+quickstack::params::amqp_key: "%{hiera('amqp_key')}"
+quickstack::params::amqp_password: "%{hiera('amqp_password')}"
+quickstack::params::amqp_provider: "%{hiera('amqp_provider')}"
+quickstack::params::amqp_username: "%{hiera('amqp_username')}"
+quickstack::params::amqp_vip: "%{hiera('amqp_vip')}"
+quickstack::params::amqp_port: '5672'
+quickstack::params::amqp_ssl_port: '5671'
+quickstack::params::keystone_vip_admin: "%{hiera('keystone_vip_admin')}"
+quickstack::params::keystone_vip_internal: "%{hiera('keystone_vip_internal')}"
+quickstack::params::keystone_vip_public: "%{hiera('keystone_vip_public')}"
+quickstack::params::mysql_ca: "%{hiera('mysql_ca')}"
+quickstack::params::mysql_cert: "%{hiera('mysql_cert')}"
+quickstack::params::mysql_key: "%{hiera('mysql_key')}"
+
+quickstack::params::mysql_vip: "%{hiera('db_vip')}"
+quickstack::params::db_host: "%{hiera('db_vip')}"
+quickstack::params::mysql_host: "%{hiera('db_vip')}"
+
+# quickstack::params::nova_conf_additional_params: { 'quota_instances' => 'default',
+#                                    'quota_cores' => 'default',
+#                                    'quota_ram' => 'default',
+#                                    'quota_floating_ips' => 'default',
+#                                    'quota_fixed_ips' => 'default',
+#                                    'quota_driver' => 'default',
+#                                    }
+quickstack::params::region: "%{hiera('region')}"
+quickstack::params::ssl: 'false'
+#quickstack::params::service_plugins: [ 'dhcp', 'l3' ]

--- a/puppet/modules/quickstack/data/classes.yaml
+++ b/puppet/modules/quickstack/data/classes.yaml
@@ -24,7 +24,6 @@ quickstack::params::scenarii:
     roles:
     - HA-controller
     - PCS-neutron
-    - neutron-network-agents
 
   HA-AIO:
     desc: "HA All in One (1), HA Controllers, Neutron network agents, Compute"
@@ -52,14 +51,14 @@ quickstack::params::scenarii:
     - quickstack::pacemaker::horizon
     - quickstack::pacemaker::galera
 
-  neutron-client-ML2-OVS:
+  network-client-ML2-OVS:
     desc: "Neutron network layer, ML2 plugin, OVS agent"
     classes:
     - quickstack::network::base
     - quickstack::network::plugins::ml2
     - quickstack::network::agents::ovs
 
-  neutron-network-agents:
+  network-agents:
     desc: "Neutron network agents"
     classes:
     - quickstack::network::agents::dhcp
@@ -67,14 +66,19 @@ quickstack::params::scenarii:
     - quickstack::network::agents::lbaas
     - quickstack::network::services::fwaas
     roles:
-    - neutron-client-ML2-OVS
+    - network-client-ML2-OVS
 
-  PCS-neutron:
+  PCS-network:
     desc: "Pacemaker Neutron"
     classes:
     - quickstack::pacemaker::network
     roles:
-    - neutron-client-ML2-OVS
+    - network-client-ML2-OVS
+
+  PCS-neutron:
+    desc: "Pacemaker Neutron"
+    classes:
+    - quickstack::pacemaker::neutron
 
   legacy-controller-NHA:
     desc: "NHA Controller (1)"

--- a/puppet/modules/quickstack/data/classes.yaml
+++ b/puppet/modules/quickstack/data/classes.yaml
@@ -55,24 +55,24 @@ quickstack::params::scenarii:
   neutron-client-ML2-OVS:
     desc: "Neutron network layer, ML2 plugin, OVS agent"
     classes:
-    - quickstack::neutron
-    - quickstack::neutron::plugins::ml2
-    - quickstack::neutron::agents::ovs
+    - quickstack::network::base
+    - quickstack::network::plugins::ml2
+    - quickstack::network::agents::ovs
 
   neutron-network-agents:
     desc: "Neutron network agents"
     classes:
-    - quickstack::neutron::agents::dhcp
-    - quickstack::neutron::agents::l3
-    - quickstack::neutron::agents::lbass
-    - quickstack::neutron::services::fwaas
+    - quickstack::network::agents::dhcp
+    - quickstack::network::agents::l3
+    - quickstack::network::agents::lbaas
+    - quickstack::network::services::fwaas
     roles:
     - neutron-client-ML2-OVS
 
   PCS-neutron:
     desc: "Pacemaker Neutron"
     classes:
-    - quickstack::pacemaker::neutron
+    - quickstack::pacemaker::network
     roles:
     - neutron-client-ML2-OVS
 

--- a/puppet/modules/quickstack/data/defaults.yaml
+++ b/puppet/modules/quickstack/data/defaults.yaml
@@ -1,52 +1,39 @@
 ---
 scenario: 'HA'
 
+## Infra
+# Top
 admin_email: 'admin@example.com'
 
-amqp_provider: 'rabbitmq'
+# AMQP
 amqp: 'true'
-cinder: 'false'
+amqp_vip: "%{hiera('network_admin')}.200"
+amqp_username: 'Openstack'
+amqp_password: "%{hiera('password')}"
+amqp_provider: 'rabbitmq'
+
+# DBMS
+db_vip: "%{hiera('network_admin')}.201"
+dbms: 'mysql'
+mysql: 'true'
+
+## Openstack
+region: 'RegionOne'
+
+## Switches
+ceilometer: 'true'
+cinder: 'true'
+debug: 'true'
 glance: 'true'
-fencing: 'disabled'
+heat_cfn: 'true'
 heat: 'true'
 horizon: 'true'
+keystonerc: 'true'
 keystone: 'true'
-mysql: 'true'
 neutron: 'true'
 nova: 'true'
-swift: 'false'
-
-network_admin: '192.168.1'
-network_internal: '192.168.2'
-network_public: '192.168.3'
-
-private_iface: 'eth2'
-private_ip: ''
-private_network: "%{hiera('network_internal')}.0"
-public_network: "%{hiera('network_public')}.0"
-tunnel_iface: 'eth2'
-tunnel_network: ''
-
-server1_name: 'controller1'
-server1_ip: "%{hiera('network_admin')}.11"
-server2_name: 'controller2'
-server2_ip: "%{hiera('network_admin')}.12"
-server3_name: 'controller3'
-server3_ip: "%{hiera('network_admin')}.13"
-
-storage1_ip: "%{hiera('network_internal')}.14"
-storage2_ip: "%{hiera('network_internal')}.15"
-storage3_ip: "%{hiera('network_internal')}.16"
-
-cluster_control_ip: "%{hiera('server1_ip')}"
-swift_storage1_ip: "%{hiera('storage1_ip')}"
-glance_device: "%{hiera('storage2_ip')}:/mnt/glance"
-nfs_share1: "%{hiera('storage3_ip')}:/mnt/cinder"
-
-# Infra VIPs
-amqp_vip: "%{hiera('network_admin')}.200"
-db_vip: "%{hiera('network_admin')}.201"
-loadbalancer_vip: "%{hiera('network_admin')}.202"
+swift: 'true'
+ssl: 'true'
 
 # Openstack VIPs
 ceilometer_vip: '203'
@@ -57,9 +44,44 @@ heat_vip: '207'
 horizon_vip: '208'
 keystone_vip: '209'
 neutron_vip: '210'
-nova_vip: '211'
-swift_vip: '212'
+nosql_vip: '211'
+nova_vip: '212'
+swift_vip: '213'
 
+# HA
+fencing: 'disabled'
+cluster_control_ip: "%{hiera('server1_ip')}"
+loadbalancer_vip: "%{hiera('network_admin')}.202"
+server1_name: 'controller1'
+server1_ip: "%{hiera('network_internal')}.11"
+server2_name: 'controller2'
+server2_ip: "%{hiera('network_internal')}.12"
+server3_name: 'controller3'
+server3_ip: "%{hiera('network_internal')}.13"
+
+# Network
+network_admin: '192.168.1'
+network_internal: '192.168.2'
+network_public: '192.168.3'
+private_iface: 'eth2'
+private_ip: ''
+private_network: "%{hiera('network_internal')}.0"
+public_network: "%{hiera('network_public')}.0"
+tunnel_iface: 'eth2'
+tunnel_network: ''
+
+# Storage VIPs
+storage1_ip: "%{hiera('network_internal')}.14"
+storage2_ip: "%{hiera('network_internal')}.15"
+storage3_ip: "%{hiera('network_internal')}.16"
+swift_storage1_ip: "%{hiera('storage1_ip')}"
+
+# Storage defaults
+glance_backend: 'file'
+glance_device: "%{hiera('storage2_ip')}:/mnt/glance"
+nfs_share1: "%{hiera('storage3_ip')}:/mnt/cinder"
+
+# Openstack services - VIP mapping
 ceilometer_vip_admin: "%{hiera('network_admin')}.%{hiera('ceilometer_vip')}"
 ceilometer_vip_internal: "%{hiera('network_internal')}.%{hiera('ceilometer_vip')}"
 ceilometer_vip_public: "%{hiera('network_public')}.%{hiera('ceilometer_vip')}"
@@ -90,3 +112,20 @@ nova_vip_public: "%{hiera('network_public')}.%{hiera('nova_vip')}"
 swift_vip_admin: "%{hiera('network_admin')}.%{hiera('swift_vip')}"
 swift_vip_internal: "%{hiera('network_internal')}.%{hiera('swift_vip')}"
 swift_vip_public: "%{hiera('network_admin')}.%{hiera('swift_vip')}"
+
+# SSL
+ca: '/etc/pki/CA/cacert.pem'
+
+amqp_ca: "%{hiera('ca')}"
+amqp_cert: '/etc/pki/tls/certs/amqp.crt'
+amqp_key: '/etc/pki/tls/private/amqp.key'
+db_ca: "%{hiera('ca')}"
+db_cert: '/etc/pki/tls/certs/db.crt'
+db_key: '/etc/pki/tls/private/db.key'
+horizon_ca: "%{hiera('ca')}"
+horizon_cert: '/etc/pki/tls/certs/horizon.crt'
+horizon_key: '/etc/pki/tls/private/horizon.key'
+mysql_ca: "%{hiera('ca')}"
+mysql_cert: '/etc/pki/tls/certs/mysql.crt'
+mysql_key: '/etc/pki/tls/private/mysql.key'
+

--- a/puppet/modules/quickstack/data/defaults.yaml
+++ b/puppet/modules/quickstack/data/defaults.yaml
@@ -60,6 +60,8 @@ server3_name: 'controller3'
 server3_ip: "%{hiera('network_internal')}.13"
 
 # Network
+allow_overlapping_ips: 'true'
+external_network_bridge: 'br-ex'
 network_admin: '192.168.1'
 network_internal: '192.168.2'
 network_public: '192.168.3'
@@ -81,7 +83,7 @@ glance_backend: 'file'
 glance_device: "%{hiera('storage2_ip')}:/mnt/glance"
 nfs_share1: "%{hiera('storage3_ip')}:/mnt/cinder"
 
-# Openstack services - VIP mapping
+# Openstack services VIP - network mapping
 ceilometer_vip_admin: "%{hiera('network_admin')}.%{hiera('ceilometer_vip')}"
 ceilometer_vip_internal: "%{hiera('network_internal')}.%{hiera('ceilometer_vip')}"
 ceilometer_vip_public: "%{hiera('network_public')}.%{hiera('ceilometer_vip')}"
@@ -112,20 +114,3 @@ nova_vip_public: "%{hiera('network_public')}.%{hiera('nova_vip')}"
 swift_vip_admin: "%{hiera('network_admin')}.%{hiera('swift_vip')}"
 swift_vip_internal: "%{hiera('network_internal')}.%{hiera('swift_vip')}"
 swift_vip_public: "%{hiera('network_admin')}.%{hiera('swift_vip')}"
-
-# SSL
-ca: '/etc/pki/CA/cacert.pem'
-
-amqp_ca: "%{hiera('ca')}"
-amqp_cert: '/etc/pki/tls/certs/amqp.crt'
-amqp_key: '/etc/pki/tls/private/amqp.key'
-db_ca: "%{hiera('ca')}"
-db_cert: '/etc/pki/tls/certs/db.crt'
-db_key: '/etc/pki/tls/private/db.key'
-horizon_ca: "%{hiera('ca')}"
-horizon_cert: '/etc/pki/tls/certs/horizon.crt'
-horizon_key: '/etc/pki/tls/private/horizon.key'
-mysql_ca: "%{hiera('ca')}"
-mysql_cert: '/etc/pki/tls/certs/mysql.crt'
-mysql_key: '/etc/pki/tls/private/mysql.key'
-

--- a/puppet/modules/quickstack/data/defaults.yaml
+++ b/puppet/modules/quickstack/data/defaults.yaml
@@ -67,7 +67,7 @@ network_internal: '192.168.2'
 network_public: '192.168.3'
 private_iface: 'eth2'
 private_ip: ''
-private_network: "%{hiera('network_internal')}.0"
+private_network: ''
 public_network: "%{hiera('network_public')}.0"
 tunnel_iface: 'eth2'
 tunnel_network: ''

--- a/puppet/modules/quickstack/data/secrets.yaml
+++ b/puppet/modules/quickstack/data/secrets.yaml
@@ -1,71 +1,63 @@
 ---
-password: 'testpw'
-key1: 'AQAfHBdUKLnUFxAAtO7WPKQZ8QfEoGqH0CLd7A=='
-key2: 'AQAfHBdUsFPTHhAAfqVqPq31FFCvyyO7oaOQXw=='
+password1: 'testpw'
+secret1: 'AQAfHBdUKLnUFxAAtO7WPKQZ8QfEoGqH0CLd7A=='
+uuid1: '3a06f6b1-60f9-4f50-bb0b-521c67c79030'
+uuid2: '47d858b1-0d60-4ba2-9aa8-075deac7f26f'
 
-quickstack::nova_network::compute::nova_db_password: "%{hiera('password')}"
+amqp_password: "%{hiera('password1')}"
+ceilometer_metering_secret: "%{hiera('password1')}"
+ceilometer_user_password: "%{hiera('password1')}"
+ceph_fsid: "%{hiera('uuid1')}"
+ceph_images_key: "%{hiera('secret1')}"
+ceph_volumes_key: "%{hiera('secret1')}"
+cinder_eqlx_chap_password: ['']
+cinder_db_password: "%{hiera('password1')}"
+cinder_rbd_secret_uuid: '3b519746-4021-4f72-957e-5b9d991723be'
+cinder_san_password: ['']
+cinder_user_password: "%{hiera('password1')}"
+fence_ipmilan_password: "%{hiera('password1')}"
+fence_xvm_key_file_password: "%{hiera('password1')}"
+galera_monitor_password: "%{hiera('password1')}"
+galera_wsrep_sst_password: "%{hiera('password1')}"
+glance_db_password: "%{hiera('password1')}"
+glance_swift_store_key: "%{hiera('secret1')}"
+glance_user_password: "%{hiera('password1')}"
+heat_auth_encryption_key: "%{hiera('password1')}"
+heat_cfn_user_password: "%{hiera('password1')}"
+heat_db_password: "%{hiera('password1')}"
+heat_user_password: "%{hiera('password1')}"
+horizon_secret_key: "%{hiera('password1')}"
+keystone_db_password: "%{hiera('password1')}"
+keystone_admin_password: "%{hiera('password1')}"
+keystone_admin_token: "%{hiera('password1')}"
+keystone_user_password: "%{hiera('password1')}"
+mysql_root_password: "%{hiera('password1')}"
+neutron_db_password: "%{hiera('password1')}"
+neutron_metadata_proxy_secret: "%{hiera('password1')}"
+neutron_user_password: "%{hiera('password1')}"
+n1kv_vsm_password: "%{hiera('password1')}"
+nova_db_password: "%{hiera('password1')}"
+nova_user_password: "%{hiera('password1')}"
+rbd_secret_uuid: "%{hiera('uuid2')}"
+swift_shared_secret: "%{hiera('password1')}"
+swift_user_password: "%{hiera('password1')}"
 
-quickstack::ceph::config::images_key: "%{hiera('key1')}"
-quickstack::ceph::config::volumes_key: "%{hiera('key2')}"
 
-quickstack::pacemaker::cinder::eqlx_chap_password: ['']
-quickstack::pacemaker::cinder::rbd_secret_uuid: '3b519746-4021-4f72-957e-5b9d991723be'
-quickstack::pacemaker::cinder::san_password: ['']
-
-quickstack::pacemaker::common::fence_ipmilan_password: ''
-quickstack::pacemaker::common::fence_xvm_key_file_password: "%{hiera('password')}"
-
-quickstack::pacemaker::galera::galera_monitor_password: "%{hiera('password')}"
-quickstack::pacemaker::galera::mysql_root_password: "%{hiera('password')}"
-quickstack::pacemaker::galera::wsrep_sst_password: "%{hiera('password')}"
-
-quickstack::pacemaker::glance::swift_store_key: ''
-
-quickstack::pacemaker::horizon::secret_key: "%{hiera('password')}"
-
-quickstack::pacemaker::keystone::admin_password: "%{hiera('password')}"
-quickstack::pacemaker::keystone::admin_token: "%{hiera('password')}"
-
-quickstack::pacemaker::nova::neutron_metadata_proxy_secret: "%{hiera('password')}"
-
-quickstack::pacemaker::params::amqp_password: "%{hiera('password')}"
-quickstack::pacemaker::params::ceilometer_user_password: "%{hiera('password')}"
-quickstack::pacemaker::params::ceph_images_key: "%{hiera('key1')}"
-quickstack::pacemaker::params::ceph_volumes_key: "%{hiera('key2')}"
-quickstack::pacemaker::params::cinder_db_password: "%{hiera('password')}"
-quickstack::pacemaker::params::cinder_user_password: "%{hiera('password')}"
-quickstack::pacemaker::params::glance_db_password: "%{hiera('password')}"
-quickstack::pacemaker::params::glance_user_password: "%{hiera('password')}"
-quickstack::pacemaker::params::heat_auth_encryption_key: "%{hiera('password')}"
-quickstack::pacemaker::params::heat_cfn_user_password: "%{hiera('password')}"
-quickstack::pacemaker::params::heat_db_password: "%{hiera('password')}"
-quickstack::pacemaker::params::heat_user_password: "%{hiera('password')}"
-quickstack::pacemaker::params::keystone_db_password: "%{hiera('password')}"
-quickstack::pacemaker::params::keystone_user_password: "%{hiera('password')}"
-quickstack::pacemaker::params::neutron_db_password: "%{hiera('password')}"
-quickstack::pacemaker::params::neutron_metadata_proxy_secret: "%{hiera('password')}"
-quickstack::pacemaker::params::neutron_user_password: "%{hiera('password')}"
-quickstack::pacemaker::params::nova_db_password: "%{hiera('password')}"
-quickstack::pacemaker::params::nova_user_password: "%{hiera('password')}"
-quickstack::pacemaker::params::swift_user_password: "%{hiera('password')}"
-
-quickstack::pacemaker::swift::swift_shared_secret: "%{hiera('password')}"
-
-# quickstack::params::ceilometer_metering_secret: "%{hiera('password')}"
-# quickstack::params::ceilometer_user_password: "%{hiera('password')}"
-
+# SSL
 ca: '/etc/pki/CA/cacert.pem'
 
 amqp_ca: "%{hiera('ca')}"
 amqp_cert: '/etc/pki/tls/certs/amqp.crt'
 amqp_key: '/etc/pki/tls/private/amqp.key'
 
+db_ca: "%{hiera('ca')}"
+db_cert: '/etc/pki/tls/certs/db.crt'
+db_key: '/etc/pki/tls/private/db.key'
+
 horizon_ca: "%{hiera('ca')}"
 horizon_cert: '/etc/pki/tls/certs/horizon.crt'
 horizon_key: '/etc/pki/tls/private/horizon.key'
 
-db_ca: "%{hiera('ca')}"
-db_cert: '/etc/pki/tls/certs/db.crt'
-db_key: '/etc/pki/tls/private/db.key'
-db_cert: ''
-db_key: ''
+mysql_ca: "%{hiera('ca')}"
+mysql_cert: '/etc/pki/tls/certs/mysql.crt'
+mysql_key: '/etc/pki/tls/private/mysql.key'

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/amqp_port.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/amqp_port.rb
@@ -1,0 +1,17 @@
+module Puppet::Parser::Functions
+    newfunction(:amqp_port, :type => :rvalue, :doc => <<-EOS
+This returns the amqp port for standard or ssl services
+EOS
+) do |arguments|
+    Puppet::Parser::Functions.autoloader.loadall
+    raise(Puppet::ParseError, "amqp_port(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    ssl = arguments[0] ||= false
+    if ssl
+      '5671'
+    else
+      '5672'
+    end
+  end
+end

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/opposite_state.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/opposite_state.rb
@@ -1,0 +1,16 @@
+module Puppet::Parser::Functions
+    newfunction(:opposite_state, :type => :rvalue, :doc => <<-EOS
+Returns opposite state of first argument
+EOS
+) do |arguments|
+
+    raise(Puppet::ParseError, "neutron_enabled(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    if arguments[0] =~ /true/i or arguments[0] == true
+      false
+    else
+      true
+    end
+  end
+end

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/qpid_protocol.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/qpid_protocol.rb
@@ -1,0 +1,17 @@
+module Puppet::Parser::Functions
+    newfunction(:qpid_protocol, :type => :rvalue, :doc => <<-EOS
+This returns the qpid protocol depending on ssl
+EOS
+) do |arguments|
+    Puppet::Parser::Functions.autoloader.loadall
+    raise(Puppet::ParseError, "qpid_protocol(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    ssl = arguments[0] ||= false
+    if ssl
+      'ssl'
+    else
+      'tcp'
+    end
+  end
+end

--- a/puppet/modules/quickstack/lib/puppet/parser/functions/url_ssl.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/url_ssl.rb
@@ -1,0 +1,23 @@
+module Puppet::Parser::Functions
+    newfunction(:url_ssl, :type => :rvalue, :doc => <<-EOS
+Returns url for ssl CA if CA certificate provided
+EOS
+) do |arguments|
+    Puppet::Parser::Functions.autoloader.loadall
+    raise(Puppet::ParseError, "url_ssl(): Wrong number of arguments " +
+      "given (#{arguments.size} for 2)") if arguments.size < 2
+
+    ssl    = arguments[0] ||= false
+    ssl_ca = arguments[1] ||= ''
+
+    if ssl
+      if ssl_ca != ''
+        "?ssl_ca=#{ssl_ca}"
+      else
+        raise(Puppet::ParseError, "url_ssl(): No CA certificate for SSL mode")
+      end
+    else
+      ''
+    end
+  end
+end

--- a/puppet/modules/quickstack/manifests/firewall/network/tunnels.pp
+++ b/puppet/modules/quickstack/manifests/firewall/network/tunnels.pp
@@ -1,0 +1,14 @@
+class quickstack::firewall::network::tunnels (
+  $tunnel_types_details,
+) {
+
+  include quickstack::firewall::common
+
+  $default = {
+    'ensure' => present,
+    'action' => 'accept'
+  }
+
+    # Todo: add function to filter out unused tunnels types
+  create_resources ('firewall', $tunnel_types_details, $default)
+}

--- a/puppet/modules/quickstack/manifests/keystone/endpoints.pp
+++ b/puppet/modules/quickstack/manifests/keystone/endpoints.pp
@@ -288,18 +288,6 @@ class quickstack::keystone::endpoints (
       contain cinder::keystone::auth
     }
 
-    if $neutron {
-      class { 'neutron::keystone::auth':
-        password         => $neutron_user_password,
-        public_address   => $neutron_public_real,
-        public_protocol  => $public_protocol,
-        admin_address    => $neutron_admin_real,
-        internal_address => $neutron_internal_real,
-        region           => $region,
-      }
-      contain neutron::keystone::auth
-    }
-
     if $ceilometer {
 
       if ! $ceilometer_user_password {

--- a/puppet/modules/quickstack/manifests/network/agents/dhcp.pp
+++ b/puppet/modules/quickstack/manifests/network/agents/dhcp.pp
@@ -1,0 +1,15 @@
+#
+class quickstack::network::agents::dhcp (
+) inherits quickstack::network::params {
+
+  # Logical ID for the a network node to deploy several Active/Passive services
+  # To Remove when adding neutron-scale feature
+  neutron_config {
+    'DEFAULT/host': value => 'neutron-n-0';
+  }
+
+  class { '::neutron::agents::dhcp':
+    enabled        => opposite_state("$pcs_setup_neutron"),
+    manage_service => opposite_state("$pcs_setup_neutron"),
+  }
+}

--- a/puppet/modules/quickstack/manifests/network/agents/l3.pp
+++ b/puppet/modules/quickstack/manifests/network/agents/l3.pp
@@ -1,0 +1,10 @@
+#
+class quickstack::network::agents::l3 (
+) inherits quickstack::network::params {
+
+  class { '::neutron::agents::l3':
+    external_network_bridge => $external_network_bridge,
+    enabled        => opposite_state("$pcs_setup_neutron"),
+    manage_service => opposite_state("$pcs_setup_neutron"),
+  }
+}

--- a/puppet/modules/quickstack/manifests/network/agents/lbaas.pp
+++ b/puppet/modules/quickstack/manifests/network/agents/lbaas.pp
@@ -1,0 +1,4 @@
+#
+class quickstack::network::agents::lbaas {
+  class { '::neutron::agents::lbaas': }
+}

--- a/puppet/modules/quickstack/manifests/network/agents/metadata.pp
+++ b/puppet/modules/quickstack/manifests/network/agents/metadata.pp
@@ -1,0 +1,12 @@
+#
+class quickstack::network::agents::metadata ()
+) inherits quickstack::network::params {
+  class { '::neutron::agents::metadata':
+    auth_password  => $neutron_user_password,
+    auth_url       => "http://${auth_host}:35357/v2.0",
+    enabled        => opposite_state("$pcs_setup_neutron"),
+    manage_service => opposite_state("$pcs_setup_neutron"),
+    metadata_ip    => $neutron_vip_admin,
+    shared_secret  => $neutron_metadata_proxy_secret,
+  }
+}

--- a/puppet/modules/quickstack/manifests/network/agents/ovs.pp
+++ b/puppet/modules/quickstack/manifests/network/agents/ovs.pp
@@ -1,0 +1,25 @@
+#
+class quickstack::network::agents::ovs (
+$bridge_mappings,
+$bridge_uplinks,
+$enable_tunneling,
+) inherits quickstack::network::params {
+
+  $local_ip = find_ip("$tunnel_network",
+                    ["$tunnel_iface","$external_network_bridge"],
+                    "")
+
+  class { '::neutron::agents::ovs':
+    bridge_mappings  => $bridge_mappings,
+    bridge_uplinks   => $bridge_uplinks,
+    enabled          => opposite_state("$pcs_setup_neutron"),
+    enable_tunneling => str2bool_i("$enable_tunneling"),
+    local_ip         => $local_ip,
+    manage_service   => opposite_state("$pcs_setup_neutron"),
+    tunnel_types     => $tunnel_types,
+    vxlan_udp_port   => $vxlan_udp_port,
+    veth_mtu         => $veth_mtu,
+  }
+  ->
+  class {'quickstack::firewall::network::tunnels':}
+}

--- a/puppet/modules/quickstack/manifests/network/base.pp
+++ b/puppet/modules/quickstack/manifests/network/base.pp
@@ -1,0 +1,35 @@
+#
+# == Class: quickstack::neutron
+#
+# Configure neutron base
+#
+# === Parameters
+#
+class quickstack::network::base (
+  $allow_overlapping_ips,
+) inherits quickstack::network::params {
+
+  $amqp_port = amqp_port(str2bool_i("$ssl"))
+  $qpid_protocol = qpid_protocol(str2bool_i("$ssl"))
+  $url_ssl = url_ssl($ssl, $mysql_ca)
+  $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_vip}/neutron${url_ssl}"
+
+  class { '::neutron':
+    allow_overlapping_ips => str2bool_i("$allow_overlapping_ips"),
+    bind_host             => $neutron_host_priv,
+    core_plugin           => $neutron_core_plugin,
+    rpc_backend           => amqp_backend('neutron', $amqp_provider),
+    qpid_hostname         => $amqp_vip,
+    qpid_port             => $amqp_port,
+    qpid_protocol         => $qpid_protocol,
+    qpid_username         => $amqp_username,
+    qpid_password         => $amqp_password,
+    rabbit_host           => $amqp_vip,
+    rabbit_port           => $amqp_port,
+    rabbit_user           => $amqp_username,
+    rabbit_password       => $amqp_password,
+    rabbit_use_ssl        => $ssl,
+    verbose               => $neutron_verbose,
+    network_device_mtu    => $network_device_mtu,
+  }
+}

--- a/puppet/modules/quickstack/manifests/network/nova.pp
+++ b/puppet/modules/quickstack/manifests/network/nova.pp
@@ -1,0 +1,17 @@
+#
+# == Class: quickstack::network::nova
+#
+# Configure neutron for nova network
+#
+# === Parameters
+#
+class quickstack::network::nova (
+) inherits quickstack::network::params {
+
+  class { '::nova::network::neutron':
+    neutron_admin_password => $neutron_user_password,
+    neutron_url            => "http://${neutron_vip_internal}:9696",
+    neutron_admin_auth_url => "http://${keystone_vip_internal}:35357/v2.0",
+    security_group_api     => $security_group_api,
+  }
+}

--- a/puppet/modules/quickstack/manifests/network/params.pp
+++ b/puppet/modules/quickstack/manifests/network/params.pp
@@ -1,0 +1,20 @@
+class quickstack::network::params (
+  $external_network_bridge,
+  $n1kv_plugin_additional_params,
+  $network_device_mtu,
+  $neutron_conf_additional_params,
+  $neutron_database_max_retries,
+  $neutron_metadata_proxy_secret,
+  $neutron_user_password,
+  $neutron_verbose,
+  $neutron_vip_admin,
+  $neutron_vip_internal,
+  $neutron_vip_public,
+  $pcs_setup_neutron,
+  $tunnel_iface,
+  $tunnel_network,
+  $tunnel_types,
+  $veth_mtu,
+  $vxlan_udp_port,
+) inherits quickstack::params {
+}

--- a/puppet/modules/quickstack/manifests/network/plugins/ml2.pp
+++ b/puppet/modules/quickstack/manifests/network/plugins/ml2.pp
@@ -1,0 +1,41 @@
+class quickstack::network::plugins::ml2 (
+  $flat_networks,
+  $mechanism_drivers,
+  $network_vlan_ranges,
+  $security_group,
+  $tenant_network_types,
+  $tunnel_id_ranges,
+  $type_drivers,
+  $vxlan_group,
+  $vni_ranges,
+) inherits quickstack::network::params {
+
+ if $neutron_core_plugin == 'neutron.plugins.ml2.plugin.Ml2Plugin' {
+  #  neutron_config {
+  #    'DEFAULT/service_plugins':
+  #      value => join(['neutron.services.l3_router.l3_router_plugin.L3RouterPlugin',]),
+  #  }
+  #  ->
+    class { '::neutron::plugins::ml2':
+      type_drivers          => $type_drivers,
+      tenant_network_types  => $tenant_network_types,
+      mechanism_drivers     => $mechanism_drivers,
+
+      flat_networks         => $flat_networks,
+      network_vlan_ranges   => $network_vlan_ranges,
+      tunnel_id_ranges      => $tunnel_id_ranges,
+      vxlan_group           => $vxlan_group,
+      vni_ranges            => $vni_ranges,
+      enable_security_group => str2bool_i("$security_group"),
+      require               => Class['neutron'],
+    }
+
+    # If cisco nexus is part of ml2 mechanism drivers,
+    # setup Mech Driver Cisco Neutron plugin class.
+    if ('cisco_nexus' in $mechanism_drivers) {
+      class { 'neutron::plugins::ml2::cisco::nexus':
+        nexus_config => $nexus_config,
+      }
+    }
+  }
+}

--- a/puppet/modules/quickstack/manifests/network/plugins/ovs.pp
+++ b/puppet/modules/quickstack/manifests/network/plugins/ovs.pp
@@ -1,0 +1,18 @@
+class quickstack::network::plugins::ovs (
+  $sql_connection,
+  $l2_population,
+  $tenant_network_type,
+  $tunnel_id_ranges,
+  $vlan_ranges,
+) inherits quickstack::network::params {
+
+  class { '::neutron::plugins::ovs':
+    sql_connection      => $sql_connection,
+    tenant_network_type => $tenant_network_type,
+    network_vlan_ranges => $vlan_ranges,
+    tunnel_id_ranges    => $tunnel_id_ranges,
+    vxlan_udp_port      => $vxlan_udp_port,
+  }
+
+  neutron_plugin_ovs { 'AGENT/l2_population': value => "$l2_population"; }
+}

--- a/puppet/modules/quickstack/manifests/network/server.pp
+++ b/puppet/modules/quickstack/manifests/network/server.pp
@@ -1,0 +1,57 @@
+#
+# == Class: quickstack::network::server
+#
+# Configure neutron server (API)
+#
+class quickstack::network::server (
+  $public_protocol = 'http',
+) inherits quickstack::network::params {
+
+  $url_ssl = url_ssl($ssl, $mysql_ca)
+  $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_vip}/neutron${url_ssl}"
+
+  class { 'neutron::keystone::auth':
+    password         => $neutron_user_password,
+    public_address   => $neutron_vip_public,
+    public_protocol  => $public_protocol,
+    admin_address    => $neutron_vip_admin,
+    internal_address => $neutron_vip_internal,
+    region           => $region,
+  }
+
+  class { '::neutron::server':
+    auth_host            => $keystone_vip_internal,
+    auth_password        => $neutron_user_password,
+    auth_tenant          => $auth_tenant,
+    auth_user            => $auth_user,
+    connection           => $sql_connection,
+    database_max_retries => $neutron_database_max_retries,
+    enabled              => opposite_state("$pcs_setup_neutron"),
+    manage_service       => opposite_state("$pcs_setup_neutron"),
+    require              => Class['neutron'],
+  }
+  ->
+  # FIXME: This really should be handled by the neutron-puppet module, which has
+  # a review request open right now: https://review.openstack.org/#/c/50162/
+  # If and when that is merged (or similar), the below can be removed.
+ # exec { 'neutron-db-manage upgrade':
+ #   command     => 'neutron-db-manage --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head',
+ #   path        => '/usr/bin',
+ #   user        => 'neutron',
+ #   logoutput   => 'on_failure',
+ #   before      => Service['neutron-server'],
+ #   require     => [Neutron_config['database/connection'], Neutron_config['DEFAULT/core_plugin']],
+ # }
+ # File['/etc/neutron/plugin.ini'] -> Exec['neutron-db-manage upgrade']
+
+  class {'::quickstack::firewall::neutron':}
+
+  class {'::quickstack::neutron::plugins::neutron_config':
+    neutron_conf_additional_params => $neutron_conf_additional_params,
+  }
+
+  class {'::quickstack::neutron::plugins::nova_config':
+    nova_conf_additional_params => $nova_conf_additional_params,
+  }
+}
+

--- a/puppet/modules/quickstack/manifests/network/services/fwaas.pp
+++ b/puppet/modules/quickstack/manifests/network/services/fwaas.pp
@@ -1,0 +1,4 @@
+#
+class quickstack::network::services::fwaas {
+  class { '::neutron::services::fwaas': }
+}

--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -125,6 +125,17 @@ class quickstack::neutron::all (
   }
   File['/etc/neutron/plugin.ini'] -> Exec['neutron-db-manage upgrade']
 
+# This was moved out of keystone::endpoints and added here so the network replacement of neutron could work
+  class { 'neutron::keystone::auth':
+    password         => $neutron_user_password,
+    public_address   => $neutron_public_real,
+    public_protocol  => $public_protocol,
+    admin_address    => $neutron_admin_real,
+    internal_address => $neutron_internal_real,
+    region           => $region,
+  }
+  contain neutron::keystone::auth
+
   class { '::neutron::server':
     auth_host            => $auth_host,
     auth_password        => $neutron_user_password,

--- a/puppet/modules/quickstack/manifests/pacemaker/base.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/base.pp
@@ -1,0 +1,25 @@
+class quickstack::pacemaker::base (
+  ) inherits quickstack::pacemaker::params {
+
+  include quickstack::pacemaker::common
+  include quickstack::pacemaker::load_balancer
+  include quickstack::pacemaker::galera
+  include quickstack::pacemaker::qpid
+  include quickstack::pacemaker::keystone
+  include quickstack::pacemaker::swift
+  include quickstack::pacemaker::glance
+  include quickstack::pacemaker::nova
+  include quickstack::pacemaker::cinder
+  include quickstack::pacemaker::heat
+
+  Class['::quickstack::pacemaker::common'] ->
+  Class['::quickstack::pacemaker::load_balancer'] ->
+  Class['::quickstack::pacemaker::galera'] ->
+  Class['::quickstack::pacemaker::qpid'] ->
+  Class['::quickstack::pacemaker::keystone'] ->
+  Class['::quickstack::pacemaker::swift'] ->
+  Class['::quickstack::pacemaker::glance'] ->
+  Class['::quickstack::pacemaker::nova'] ->
+  Class['::quickstack::pacemaker::cinder'] ->
+  Class['::quickstack::pacemaker::heat']
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -40,7 +40,7 @@ class quickstack::pacemaker::common (
   $fence_xvm_port                 = "",
   $fence_xvm_manage_key_file      = "false",
   $fence_xvm_key_file_password    = "",
-) inherits quickstack::pacemaker::base {
+) inherits quickstack::pacemaker::params {
 
   include quickstack::pacemaker::base
 

--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -40,8 +40,9 @@ class quickstack::pacemaker::common (
   $fence_xvm_port                 = "",
   $fence_xvm_manage_key_file      = "false",
   $fence_xvm_key_file_password    = "",
-) {
-  include quickstack::pacemaker::params
+) inherits quickstack::pacemaker::base {
+
+  include quickstack::pacemaker::base
 
   if has_interface_with("ipaddress", map_params("cluster_control_ip")) {
     $setup_cluster = true

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -208,7 +208,7 @@ class quickstack::pacemaker::glance (
       include ::quickstack::pacemaker::ceph_config
       include ::quickstack::firewall::ceph_mon
 
-      Class['quickstack::firewall::ceph_mon'] -> 
+      Class['quickstack::firewall::ceph_mon'] ->
       Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
 
       Class['quickstack::pacemaker::ceph_config'] ->

--- a/puppet/modules/quickstack/manifests/pacemaker/network.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/network.pp
@@ -1,0 +1,171 @@
+class quickstack::pacemaker::network (
+) inherits quickstack::pacemaker::params {
+
+  include quickstack::pacemaker::common
+
+  Class['::quickstack::pacemaker::common'] ->
+  Class['::quickstack::pacemaker::network']
+
+  if (str2bool_i($include_neutron)) {
+    $ovs_nic = find_nic("$ovs_tunnel_network","$ovs_tunnel_iface","")
+
+    if (str2bool_i($include_mysql)) {
+      Exec['galera-online'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (str2bool_i($include_keystone)) {
+      Exec['all-keystone-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (str2bool_i($include_swift)) {
+      Exec['all-swift-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (str2bool_i($include_cinder)) {
+      Exec['all-cinder-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (str2bool_i($include_glance)) {
+      Exec['all-glance-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    if (str2bool_i($include_nova)) {
+      Exec['all-nova-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+    }
+    Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip'] ->
+#    Class[neutron::server::notifications] ->
+    Exec['pcs-neutron-server-set-up']
+
+    class {"::quickstack::load_balancer::neutron":
+      frontend_pub_host    => $neutron_public_vip,
+      frontend_priv_host    => $neutron_private_vip,
+      frontend_admin_host    => $neutron_admin_vip,
+      backend_server_names => $lb_backend_server_names,
+      backend_server_addrs => $lb_backend_server_addrs,
+    }
+
+    Class['::quickstack::pacemaker::common']
+    ->
+    quickstack::pacemaker::vips { "$neutron_group":
+      public_vip  => $neutron_public_vip,
+      private_vip => $neutron_private_vip,
+      admin_vip   => $neutron_admin_vip,
+    }
+    ->
+    exec {"i-am-neutron-vip-OR-neutron-is-up-on-vip":
+      timeout   => 3600,
+      tries     => 360,
+      try_sleep => 10,
+      command   => "/tmp/ha-all-in-one-util.bash i_am_vip $neutron_public_vip || /tmp/ha-all-in-one-util.bash property_exists neutron",
+      unless   => "/tmp/ha-all-in-one-util.bash i_am_vip $neutron_public_vip || /tmp/ha-all-in-one-util.bash property_exists neutron",
+    }
+    ->
+    class { 'quickstack::network::server':
+    }
+    ->
+    exec {"pcs-neutron-server-set-up":
+      command => "/usr/sbin/pcs property set neutron=running --force",
+    } ->
+    exec {"pcs-neutron-server-set-up-on-this-node":
+      command => "/tmp/ha-all-in-one-util.bash update_my_node_property neutron"
+    } ->
+    exec {"all-neutron-nodes-are-up":
+      timeout   => 3600,
+      tries     => 360,
+      try_sleep => 10,
+      command   => "/tmp/ha-all-in-one-util.bash all_members_include neutron",
+    }
+    ->
+    quickstack::pacemaker::resource::service {'neutron-server':
+      clone => true,
+      monitor_params => { 'start-delay' => '10s' },
+    }
+    ->
+    quickstack::pacemaker::resource::ocf {'neutron-ovs-cleanup':
+      resource_name => 'neutron:OVSCleanup',
+      clone         => true,
+    }
+    ->
+    quickstack::pacemaker::resource::ocf {'neutron-netns-cleanup':
+      resource_name => 'neutron:NetnsCleanup',
+      clone         => true,
+    }
+    ->
+    quickstack::pacemaker::resource::service {'neutron-openvswitch-agent':
+      group => "neutron-agents",
+      clone => false,
+      monitor_params => { 'start-delay' => '10s' },
+    }
+    ->
+    quickstack::pacemaker::resource::service {'neutron-dhcp-agent':
+      group => "neutron-agents",
+      clone => false,
+      monitor_params => { 'start-delay' => '10s' },
+    }
+    ->
+    quickstack::pacemaker::resource::service {'neutron-l3-agent':
+      group => "neutron-agents",
+      clone => false,
+      monitor_params => { 'start-delay' => '10s' },
+    }
+    ->
+    quickstack::pacemaker::resource::service {'neutron-metadata-agent':
+      group => "neutron-agents",
+      clone => false,
+      monitor_params => { 'start-delay' => '10s' },
+    }
+    ->
+    quickstack::pacemaker::constraint::base { 'neutron-ovs-to-netns-cleanup-constr' :
+      constraint_type => "order",
+      first_resource  => "neutron-ovs-cleanup-clone",
+      second_resource => "neutron-netns-cleanup-clone",
+      first_action    => "start",
+      second_action   => "start",
+    }
+    ->
+    quickstack::pacemaker::constraint::base { 'neutron-cleanup-to-agents-constr' :
+      constraint_type => "order",
+      first_resource  => "neutron-netns-cleanup-clone",
+      second_resource => "neutron-agents",
+      first_action    => "start",
+      second_action   => "start",
+    }
+    ->
+    quickstack::pacemaker::constraint::base { 'neutron-openvswitch-dhcp-constr' :
+      constraint_type => "order",
+      first_resource  => "neutron-openvswitch-agent",
+      second_resource => "neutron-dhcp-agent",
+      first_action    => "start",
+      second_action   => "start",
+    }
+    ->
+    quickstack::pacemaker::constraint::colocation { 'neutron-openvswitch-dhcp-colo' :
+      source => "neutron-dhcp-agent",
+      target => "neutron-openvswitch-agent",
+      score  => "INFINITY",
+    }
+    ->
+    quickstack::pacemaker::constraint::base { 'neutron-openvswitch-l3-constr' :
+      constraint_type => "order",
+      first_resource  => "neutron-openvswitch-agent",
+      second_resource => "neutron-l3-agent",
+      first_action    => "start",
+      second_action   => "start",
+    }
+    ->
+    quickstack::pacemaker::constraint::colocation { 'neutron-openvswitch-l3-colo' :
+      source => "neutron-l3-agent",
+      target => "neutron-openvswitch-agent",
+      score  => "INFINITY",
+    }
+    ->
+    quickstack::pacemaker::constraint::base { 'neutron-openvswitch-metadata-constr' :
+      constraint_type => "order",
+      first_resource  => "neutron-openvswitch-agent",
+      second_resource => "neutron-metadata-agent",
+      first_action    => "start",
+      second_action   => "start",
+    }
+    ->
+    quickstack::pacemaker::constraint::colocation { 'neutron-openvswitch-metadata-colo' :
+      source => "neutron-metadata-agent",
+      target => "neutron-openvswitch-agent",
+      score  => "INFINITY",
+    }
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -71,7 +71,7 @@ class quickstack::pacemaker::params (
   $keystone_db_password      = '',
   $keystone_user_password    = '',
   $neutron                   = 'false',
-  $neutron_metadata_proxy_secret,
+  $neutron_metadata_proxy_secret = '',
   $neutron_public_vip        = '',
   $neutron_private_vip       = '',
   $neutron_admin_vip         = '',

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -102,9 +102,6 @@ class quickstack::pacemaker::params (
   $swift_user_password       = '',
   $swift_group               = 'swift',
 ) {
-  $local_bind_addr = find_ip("$private_network",
-                            "$private_iface",
-                            "$private_ip")
   $pcmk_bind_addr = find_ip("$pcmk_network",
                             "$pcmk_iface",
                             "$pcmk_ip")

--- a/puppet/modules/quickstack/manifests/pacemaker/rsync/get.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rsync/get.pp
@@ -40,30 +40,30 @@ define quickstack::pacemaker::rsync::get (
   include '::quickstack::rsync::common'
 
   if $keyfile {
-    $Mykeyfile = $keyfile
+    $mykeyfile = $keyfile
   } else {
-    $Mykeyfile = "/home/${user}/.ssh/id_rsa"
+    $mykeyfile = "/home/${user}/.ssh/id_rsa"
   }
 
   if $user {
-    $MyUser = "-e 'ssh -i ${Mykeyfile} -l ${user}' ${user}@"
+    $myuser = "-e 'ssh -i ${mykeyfile} -l ${user}' ${user}@"
   }
 
   if $purge {
-    $MyPurge = '--delete'
+    $mypurge = '--delete'
   }
 
   if $exclude {
-    $MyExclude = "--exclude=${exclude}"
+    $myexclude = "--exclude=${exclude}"
   }
 
   if $path {
-    $MyPath = $path
+    $mypath = $path
   } else {
-    $MyPath = $name
+    $mypath = $name
   }
 
-  $rsync_options = "-${override_options} ${MyPurge} ${MyExclude} ${MyUser}${source} ${MyPath}"
+  $rsync_options = "-${override_options} ${mypurge} ${myexclude} ${myuser}${source} ${mypath}"
 
   exec { "rsync ${name}":
     command   => "rsync -q ${rsync_options}",


### PR DESCRIPTION
In order to achieve AIO (Fake HA) neutron manifests must be refactored
so compute node manifests can be played too.

This will also give more flexibility in regards of various scenarios
choices.

It requires PR#431 too.