### PR TITLE
WIP: add pacemaker constraints needed for reboots

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -172,7 +172,6 @@ class quickstack::neutron::all (
       n1kv_vsm_ip                  => $n1kv_vsm_ip,
       n1kv_vsm_password            => $n1kv_vsm_password,
       n1kv_plugin_additional_params => $n1kv_plugin_additional_params,
-      n1kv_os_ha                  => 'true',
       neutron_core_plugin          => $neutron_core_plugin,
       neutron_db_password          => $neutron_db_password,
       neutron_user_password        => $neutron_user_password,

--- a/puppet/modules/quickstack/manifests/neutron/plugins/cisco.pp
+++ b/puppet/modules/quickstack/manifests/neutron/plugins/cisco.pp
@@ -46,7 +46,7 @@ class quickstack::neutron::plugins::cisco (
                                      http_pool_size => '4',
                                      http_timeout => '120',
                                      firewall_driver => 'neutron.agent.firewall.NoopFirewallDriver',
-                                     enable_sync_on_start => 'True'
+                                     enable_sync_on_start => 'True',
                                      restrict_policy_profiles => 'False',
                                    },
   $neutron_db_password          = $quickstack::params::neutron_db_password,
@@ -54,7 +54,6 @@ class quickstack::neutron::plugins::cisco (
   $nexus_config                 = $quickstack::params::nexus_config,
   $nexus_credentials            = $quickstack::params::nexus_credentials,
   $neutron_core_plugin          = '',
-  $n1kv_os_ha                   = 'false',
   # ovs config
   $ovs_vlan_ranges              = $quickstack::params::ovs_vlan_ranges,
   $provider_vlan_auto_create    = $quickstack::params::provider_vlan_auto_create,
@@ -106,29 +105,27 @@ class quickstack::neutron::plugins::cisco (
       vswitch_plugin    => $cisco_vswitch_plugin,
     }
 
-    if $n1kv_os_ha == 'false' {
-      $listen_ssl                  = str2bool_i("$ssl")
-      $neutron_defaults     	   = {'enable_lb' => false, 'enable_firewall' => false, 'enable_quotas' => true, 'enable_security_group' => true, 'enable_vpn' => false, 'profile_support' => 'None' }
-      $neutron_options         	   = {'enable_lb' => true, 'enable_firewall' => true, 'enable_quotas' => false, 'enable_security_group' => false, 'enable_vpn' => true, 'profile_support' => 'cisco' }
-      $secret_key                  = $horizon_secret_key
-      $keystone_host               = $controller_priv_host
-      $fqdn                        = ["$controller_pub_host", "$::fqdn", "$::hostname", 'localhost']
-      $openstack_endpoint_type	   = undef
-      $compress_offline		   = True
-      $file_upload_temp_dir	   = '/tmp'
-      $available_regions       	   = undef
-      $hypervisor_options 	   = {'can_set_mount_point' => false, 'can_set_password' => true }
-      $hypervisor_defaults 	   = {'can_set_mount_point' => $can_set_mount_point, 'can_set_password'  => false }
-      file {'/usr/share/openstack-dashboard/openstack_dashboard/local/local_settings.py':
-        content => template('/usr/share/openstack-puppet/modules/horizon/templates/local_settings.py.erb')
-      } ~> Service['httpd']
+    $listen_ssl                  = str2bool_i("$ssl")
+    $neutron_defaults     	   = {'enable_lb' => false, 'enable_firewall' => false, 'enable_quotas' => true, 'enable_security_group' => true, 'enable_vpn' => false, 'profile_support' => 'None' }
+    $neutron_options         	   = {'enable_lb' => true, 'enable_firewall' => true, 'enable_quotas' => false, 'enable_security_group' => false, 'enable_vpn' => true, 'profile_support' => 'cisco' }
+    $secret_key                  = $horizon_secret_key
+    $keystone_host               = $controller_priv_host
+    $fqdn                        = ["$controller_pub_host", "$::fqdn", "$::hostname", 'localhost']
+    $openstack_endpoint_type	   = undef
+    $compress_offline		   = True
+    $file_upload_temp_dir	   = '/tmp'
+    $available_regions       	   = undef
+    $hypervisor_options 	   = {'can_set_mount_point' => false, 'can_set_password' => true }
+    $hypervisor_defaults 	   = {'can_set_mount_point' => $can_set_mount_point, 'can_set_password'  => false }
+    file {'/usr/share/openstack-dashboard/openstack_dashboard/local/local_settings.py':
+      content => template('/usr/share/openstack-puppet/modules/horizon/templates/local_settings.py.erb')
+    } ~> Service['httpd']
 
-      $disable_router    = 'False'
-      Neutron_plugin_cisco<||> ->
-      file {'/usr/share/openstack-dashboard/openstack_dashboard/enabled/_40_router.py':
-        content => template('quickstack/_40_router.py.erb')
-      } ~> Service['httpd']
-    }
+    $disable_router    = 'False'
+    Neutron_plugin_cisco<||> ->
+    file {'/usr/share/openstack-dashboard/openstack_dashboard/enabled/_40_router.py':
+      content => template('quickstack/_40_router.py.erb')
+    } ~> Service['httpd']
 
     $default_policy_profile      = $n1kv_plugin_additional_params[default_policy_profile]
     $network_node_policy_profile = $n1kv_plugin_additional_params[network_node_policy_profile]

--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -192,5 +192,7 @@ class quickstack::pacemaker::ceilometer (
       first_action    => "start",
       second_action   => "start",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -28,7 +28,7 @@ class quickstack::pacemaker::ceilometer (
     }
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-ceilometer-vip-OR-ceilometer-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-ceilometer-vip-OR-ceilometer-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-ceilometer-vip-OR-ceilometer-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -180,7 +180,8 @@ class quickstack::pacemaker::cinder(
       source => "openstack-cinder-scheduler-clone",
       target => "openstack-cinder-api-clone",
       score => "INFINITY",
-    }
+    } ->
+    Anchor['pacemaker ordering constraints begin']
 
     if str2bool_i("$volume") {
       # FIXME(jistr): remove the host override

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -79,7 +79,7 @@ class quickstack::pacemaker::cinder(
 
     Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip'] -> Exec<| title =='cinder-manage db_sync'|> -> Exec['pcs-cinder-server-set-up']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/constraint/colocation.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraint/colocation.pp
@@ -1,6 +1,6 @@
 define quickstack::pacemaker::constraint::colocation ($source,
                                           $target,
-                                          $score,
+                                          $score='INFINITY',
                                           $ensure=present) {
   include quickstack::pacemaker::params
 

--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -161,6 +161,8 @@ class quickstack::pacemaker::galera (
       environment => ["AVAILABLE_WHEN_READONLY=0"],
       command => '/usr/bin/clustercheck >/dev/null',
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
 
     # in the bootstrap case, make sure pacemaker galera resource
     # has been created before the final "galera-online" check

--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -65,6 +65,16 @@ class quickstack::pacemaker::galera (
     # if bootstrap, set up mariadb on all nodes
     if str2bool_i($::galera_bootstrap_ok) {
       Class ['::quickstack::firewall::galera'] ->
+      exec {"haproxy resource exists":
+        timeout   => 3600,
+        tries     => 360,
+        try_sleep => 10,
+        command   => "/usr/sbin/pcs resource show haproxy-clone",
+      } ->
+      exec{'disable haproxy during init mysql setup':
+        # it's ok to run this on all nodes, additional calls are no-ops        
+        command => '/usr/sbin/pcs resource disable haproxy'
+      } ->
       class { 'mysql::server':
         #manage_config_file => false,
         #config_file => $mysql_server_config_file,
@@ -117,6 +127,14 @@ class quickstack::pacemaker::galera (
       ->
       Exec['pcs-mysqlinit-server-setup']
       Mysql_grant <| |> -> Exec["pcs-mysqlinit-server-setup"]
+      
+      Exec["all-mysqlinit-nodes-are-up"] ->
+      Exec['galera-online-cmd'] ->
+      exec{'enable haproxy after galera-online':
+        # it's ok to run this on all nodes, additional calls are no-ops        
+        command => '/usr/sbin/pcs resource enable haproxy'
+      } ->
+      Anchor['galera-online']
     }
     Class ['::quickstack::firewall::galera'] ->
     file { '/etc/my.cnf.d/galera.cnf':
@@ -154,13 +172,15 @@ class quickstack::pacemaker::galera (
     }
     ->
     # one last clustercheck to make sure service is up
-    exec {"galera-online":
+    exec {"galera-online-cmd":
       timeout   => 3600,
       tries     => 60,
       try_sleep => 60,
       environment => ["AVAILABLE_WHEN_READONLY=0"],
       command => '/usr/bin/clustercheck >/dev/null',
     }
+    ->
+    anchor{'galera-online':}
     ->
     Anchor['pacemaker ordering constraints begin']
 
@@ -174,7 +194,7 @@ class quickstack::pacemaker::galera (
         try_sleep => 60,
         command    => '/usr/sbin/pcs resource show galera && /bin/sleep 60',
       } ->
-      Exec['galera-online']
+      Exec['galera-online-cmd']
     }
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -203,6 +203,9 @@ class quickstack::pacemaker::glance (
       target => "openstack-glance-registry-clone",
       score => "INFINITY",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
+
     if ($backend == 'rbd') {
       include ::quickstack::ceph::client_packages
       include ::quickstack::pacemaker::ceph_config

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -49,7 +49,7 @@ class quickstack::pacemaker::glance (
     Exec['pcs-glance-server-set-up']
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-glance-vip-OR-glance-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -51,7 +51,7 @@ class quickstack::pacemaker::heat(
     Exec['i-am-heat-vip-OR-heat-is-up-on-vip'] -> Exec<| title == 'heat-dbsync' |>
     -> Exec['pcs-heat-server-set-up']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -34,7 +34,7 @@ class quickstack::pacemaker::horizon (
 
     Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip'] -> Service['httpd']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -174,6 +174,8 @@ class quickstack::pacemaker::keystone (
       clone   => true,
       options => 'start-delay=10s',
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
     # TODO: Consider if we should pre-emptively purge any directories keystone has
     # created in /tmp
 

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -55,7 +55,7 @@ class quickstack::pacemaker::keystone (
     Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip'] -> Keystone_service<| |> -> Exec['pcs-keystone-server-set-up']
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
     }
 
     class {"::quickstack::load_balancer::keystone":

--- a/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
@@ -10,6 +10,7 @@ class quickstack::pacemaker::load_balancer {
     public_vip  => $loadbalancer_vip,
     private_vip => $loadbalancer_vip,
     admin_vip   => $loadbalancer_vip,
+    haproxy_constraint => false,
   } ->
 
   Service['haproxy'] ->
@@ -25,5 +26,9 @@ class quickstack::pacemaker::load_balancer {
   } ->
   quickstack::pacemaker::resource::service {'haproxy':
     clone => true,
-  }
+  } ->
+  Anchor['pacemaker ordering constraints begin']
+
+  Quickstack::Pacemaker::Resource::Service['haproxy'] ->
+  Quickstack::Pacemaker::Vips<| title != "$loadbalancer_group" |>
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
@@ -19,6 +19,6 @@ class quickstack::pacemaker::memcached {
   quickstack::pacemaker::resource::service { 'memcached':
     clone   => true,
     options => 'start-delay=10s',
-  }
-
+  } ->
+  Anchor['pacemaker ordering constraints begin']
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -276,5 +276,7 @@ class quickstack::pacemaker::neutron (
       target => "neutron-openvswitch-agent",
       score  => "INFINITY",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -73,7 +73,7 @@ class quickstack::pacemaker::neutron (
       $_enabled = false
     }
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
@@ -99,5 +99,7 @@ class quickstack::pacemaker::nosql (
     anchor {'ha mongo ready':
       require => Quickstack::Pacemaker::Resource::Service['mongod'],
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
@@ -23,7 +23,7 @@ class quickstack::pacemaker::nosql (
     }
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Anchor['nosql cluster start']
+      Anchor['galera-online'] -> Anchor['nosql cluster start']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Anchor['nosql cluster start']

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -190,5 +190,7 @@ class quickstack::pacemaker::nova (
       target => "openstack-nova-conductor-clone",
       score => "INFINITY",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -34,7 +34,7 @@ class quickstack::pacemaker::nova (
     }
     Exec['i-am-nova-vip-OR-nova-is-up-on-vip'] -> Exec['nova-db-sync']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -119,6 +119,7 @@ class quickstack::pacemaker::params (
   include quickstack::pacemaker::nova
   include quickstack::pacemaker::cinder
   include quickstack::pacemaker::heat
+  include quickstack::pacemaker::constraints
 
   Class['::quickstack::pacemaker::common'] ->
   Class['::quickstack::pacemaker::load_balancer'] ->
@@ -129,5 +130,7 @@ class quickstack::pacemaker::params (
   Class['::quickstack::pacemaker::glance'] ->
   Class['::quickstack::pacemaker::nova'] ->
   Class['::quickstack::pacemaker::cinder'] ->
-  Class['::quickstack::pacemaker::heat']
+  Class['::quickstack::pacemaker::heat'] ->
+  Class['::quickstack::pacemaker::constraints']
+
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
@@ -85,6 +85,11 @@ class quickstack::pacemaker::qpid (
                                'stick' => 'on dst'},
     }
 
+    if (str2bool_i(map_params('include_mysql'))) {
+      # avoid race condition with galera setup
+      Exec['galera-online'] -> Exec['all-qpid-nodes-are-up']
+    }
+
     Class['::quickstack::firewall::amqp'] ->
     Class['::qpid::server'] ->
     Class['::quickstack::pacemaker::common'] ->
@@ -107,6 +112,7 @@ class quickstack::pacemaker::qpid (
     } ->
     quickstack::pacemaker::resource::service { 'qpidd':
       clone   => true,
-    }
+    } ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
@@ -87,7 +87,7 @@ class quickstack::pacemaker::qpid (
 
     if (str2bool_i(map_params('include_mysql'))) {
       # avoid race condition with galera setup
-      Exec['galera-online'] -> Exec['all-qpid-nodes-are-up']
+      Anchor['galera-online'] -> Exec['all-qpid-nodes-are-up']
     }
 
     Class['::quickstack::firewall::amqp'] ->

--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -72,7 +72,7 @@ class quickstack::pacemaker::rabbitmq (
 
     if (str2bool_i(map_params('include_mysql'))) {
       # avoid race condition with galera setup
-      Exec['galera-online'] -> Exec['all-rabbitmq-nodes-are-up']
+      Anchor['galera-online'] -> Exec['all-rabbitmq-nodes-are-up']
     }
 
     Class['::quickstack::firewall::amqp'] ->
@@ -153,7 +153,7 @@ class quickstack::pacemaker::rabbitmq (
       }
       if (str2bool_i(map_params('include_mysql'))) {
         # avoid race condition with galera setup
-        Exec['galera-online'] -> Exec['i-am-first-rabbitmq-node-OR-rabbitmq-is-up-on-first-node']
+        Anchor['galera-online'] -> Exec['i-am-first-rabbitmq-node-OR-rabbitmq-is-up-on-first-node']
       }
     }
   }

--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -70,6 +70,11 @@ class quickstack::pacemaker::rabbitmq (
       extra_listen_options => {'option' => ['tcpka','tcplog']},
     }
 
+    if (str2bool_i(map_params('include_mysql'))) {
+      # avoid race condition with galera setup
+      Exec['galera-online'] -> Exec['all-rabbitmq-nodes-are-up']
+    }
+
     Class['::quickstack::firewall::amqp'] ->
     Class['::quickstack::pacemaker::common'] ->
     # below creates just one vip (not three)
@@ -85,7 +90,6 @@ class quickstack::pacemaker::rabbitmq (
       unless  => '/usr/sbin/rabbitmqctl list_policies | grep -q HA',
       require => Class['::rabbitmq::service'],
     } ->
-    Class['::quickstack::load_balancer::amqp'] ->
 
     exec {"pcs-rabbitmq-server-set-up":
       command => "/usr/sbin/pcs property set rabbitmq=running --force",
@@ -105,7 +109,8 @@ class quickstack::pacemaker::rabbitmq (
     quickstack::pacemaker::resource::service { 'rabbitmq-server':
       monitor_params => {"start-delay" => "35s"},
       clone          => true,
-    }
+    } ->
+    Anchor['pacemaker ordering constraints begin']
 
     $_nodes = map_params('lb_backend_server_addrs')
     $first_node = $_nodes[0]
@@ -145,6 +150,10 @@ class quickstack::pacemaker::rabbitmq (
         unless    => "/tmp/ha-all-in-one-util.bash property_exists rabbitmq",
         require   => Quickstack::Pacemaker::Vips ["$amqp_group"],
         before    => Class['::rabbitmq'],
+      }
+      if (str2bool_i(map_params('include_mysql'))) {
+        # avoid race condition with galera setup
+        Exec['galera-online'] -> Exec['i-am-first-rabbitmq-node-OR-rabbitmq-is-up-on-first-node']
       }
     }
   }

--- a/puppet/modules/quickstack/manifests/pacemaker/resource/ip.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/ip.pp
@@ -8,13 +8,18 @@ define quickstack::pacemaker::resource::ip($ip_address,
   include quickstack::pacemaker::params
 
   if has_interface_with("ipaddress", map_params("cluster_control_ip")){
-    ::pacemaker::resource::ip{ "$name": 
-                            ip_address     => $ip_address,
-                            cidr_netmask   => $cidr_netmask,
-                            nic            => $nic,
-                            group          => $group,
-                            interval       => $interval,
-                            monitor_params => $monitor_params,
-                            ensure         => $ensure }
+    $nic_option = $nic ? {
+        ''      => '',
+        default => " nic=$nic"
+    }
+  
+    pcmk_resource { "$title-${ip_address}":
+      ensure          => $ensure,
+      resource_type   => 'IPaddr2',
+      resource_params => "ip=${ip_address} cidr_netmask=${cidr_netmask}${nic_option}",
+      group           => $group,
+      interval        => $interval,
+      monitor_params  => $monitor_params,
+    }
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -107,5 +107,7 @@ class quickstack::pacemaker::swift (
       first_action    => "start",
       second_action   => "start",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/vips.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/vips.pp
@@ -2,25 +2,65 @@ define quickstack::pacemaker::vips(
   $public_vip,
   $private_vip,
   $admin_vip,
-  $pcmk_group = $title,
+  $pcmk_group         = $title,
+  $haproxy_constraint = true,
   ) {
 
   Exec['stonith-setup-complete'] ->
-  quickstack::pacemaker::resource::ip { "ip-${pcmk_group}_${public_vip}":
+  quickstack::pacemaker::resource::ip { "ip-${pcmk_group}-pub":
     ip_address => "$public_vip",
+  }
+  if $haproxy_constraint {
+    Quickstack::Pacemaker::Resource::Service['haproxy'] ->
+    quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-pub-const" :
+      first_resource  => "haproxy-clone",
+      second_resource => "ip-${pcmk_group}-pub-${public_vip}",
+    }
+    Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-pub"] ->
+    Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-pub-const"]
   }
 
   if ( $public_vip != $private_vip ) {
     Exec['stonith-setup-complete'] ->
-    quickstack::pacemaker::resource::ip { "ip-${pcmk_group}_${private_vip}":
+    quickstack::pacemaker::resource::ip { "ip-${pcmk_group}-prv":
       ip_address => "$private_vip",
+    } ->
+    quickstack::pacemaker::constraint::colocation { "ip-${pcmk_group}-pub-prv-colo" :
+      source => "ip-${pcmk_group}-prv-${private_vip}",
+      target => "ip-${pcmk_group}-pub-${public_vip}",
+    }
+    if $haproxy_constraint {
+      Quickstack::Pacemaker::Resource::Service['haproxy'] ->
+      quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-prv-const" :
+        first_resource  => "haproxy-clone",
+        second_resource => "ip-${pcmk_group}-prv-${private_vip}",
+      }
+      Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-pub"] ->
+      Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-prv"] ->
+      Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-prv-const"] ->
+      Quickstack::Pacemaker::Constraint::Colocation["ip-${pcmk_group}-pub-prv-colo"]
     }
   }
 
   if ( ($admin_vip != $private_vip) and ($admin_vip != $public_vip) ) {
     Exec['stonith-setup-complete'] ->
-    quickstack::pacemaker::resource::ip { "ip-${pcmk_group}_${admin_vip}":
+    quickstack::pacemaker::resource::ip { "ip-${pcmk_group}-adm":
       ip_address => "$admin_vip",
+    } ->
+    quickstack::pacemaker::constraint::colocation { "ip-${pcmk_group}-pub-adm-colo" :
+      source => "ip-${pcmk_group}-adm-${admin_vip}",
+      target => "ip-${pcmk_group}-pub-${public_vip}",
+    }
+    if $haproxy_constraint {
+      Quickstack::Pacemaker::Resource::Service['haproxy'] ->
+      quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-adm-const" :
+        first_resource  => "haproxy-clone",
+        second_resource => "ip-${pcmk_group}-adm-${admin_vip}",
+      }
+      Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-pub"] ->
+      Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-adm"] ->
+      Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-adm-const"] ->
+      Quickstack::Pacemaker::Constraint::Colocation["ip-${pcmk_group}-pub-adm-colo"]
     }
   }
 }

--- a/puppet/modules/quickstack/templates/ha-all-in-one-util.erb
+++ b/puppet/modules/quickstack/templates/ha-all-in-one-util.erb
@@ -6,7 +6,7 @@ keystone_private_vip=<%= scope.lookupvar("::quickstack::pacemaker::params::keyst
 # These functions adapted from similar logic in jayg's rysnc.pp variables
 get_resource_ip_output() {
   # trailing space is on purpose below to avoid matching Failed actions
-  echo $(/usr/sbin/pcs status | /bin/grep -P "ip-$1\s")
+  echo $(/usr/sbin/pcs status | /bin/grep -P "ip-\S*$1\s")
 }
 which_cluster_ip() {
   line=$(get_resource_ip_output $1)


### PR DESCRIPTION
This is still an early WIP.

An additional enhancement has been added where pacemaker IP resources are named like:

     ip-horizon-adm-192.168.201.95      (ocf::heartbeat:IPaddr2):       Started pcmk-c1a1
     ip-horizon-priv-192.168.201.94     (ocf::heartbeat:IPaddr2):       Started pcmk-c1a2
     ip-horizon-pub-192.168.7.100       (ocf::heartbeat:IPaddr2):       Started pcmk-c1a2

for sanity (e.g., instead of just ip-1.2.3.4).  I thought about removing the actual IP address from the resource name altogether (e.g. ip-horizon-pub) but A) I'm not sure this is really a huge win because it is nice seeing the IP in pcs status and B) a pretty large refactor to ha-all-in-one-util.bash would be needed.

The idea right now is to use quickstack::pacemaker::constraint::haproxy_vips as the way to define constraints between haproxy and the vips (pretty much every vip has a constraint on haproxy, so following the pattern we already use for vips makes sense here).  All other non-vip inter-service ordering constraints will live in quickstack::pacemaker::constraints.