### PR TITLE
BZ #1180158: Ceilometer workload partitioning with tooz & redis

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer/control.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer/control.pp
@@ -17,6 +17,7 @@ class quickstack::ceilometer::control(
   $service_enable             = true,
   $service_ensure             = 'running',
   $verbose                    = false,
+  $coordination_url           = undef,
 ) {
 
   validate_array($db_hosts)
@@ -69,8 +70,9 @@ class quickstack::ceilometer::control(
   }
 
   class { '::ceilometer::agent::central':
-    enabled        => $service_enable,
-    manage_service => $service_enable,
+    enabled          => $service_enable,
+    manage_service   => $service_enable,
+    coordination_url => $coordination_url,
   }
 
   class { '::ceilometer::alarm::notifier':
@@ -79,8 +81,9 @@ class quickstack::ceilometer::control(
   }
 
   class { '::ceilometer::alarm::evaluator':
-    enabled        => $service_enable,
-    manage_service => $service_enable,
+    enabled          => $service_enable,
+    manage_service   => $service_enable,
+    coordination_url => $coordination_url,
   }
 
   class { '::ceilometer::api':

--- a/puppet/modules/quickstack/manifests/db/redis.pp
+++ b/puppet/modules/quickstack/manifests/db/redis.pp
@@ -1,0 +1,29 @@
+# == Class: quickstack::db::redis
+#
+# Install redis
+#
+# === Parameters:
+#
+# [*bind_host*]
+#   (optional) Configure which IP address to listen on.
+#   Defaults to '127.0.0.1'
+#
+# [*port*]
+#   (optional) Configure which port to listen on.
+#   Defaults to '6379'
+
+
+class quickstack::db::redis(
+  $bind_host             = '127.0.0.1',
+  $port                  = '6379',
+  $slaveof               = undef,
+) {
+
+  class { '::redis':
+    bind       => $bind_host,
+    port       => $port,
+    appendonly => true,
+    daemonize  => false,
+    slaveof    => $slaveof,
+  }
+}

--- a/puppet/modules/quickstack/manifests/db/redis.pp
+++ b/puppet/modules/quickstack/manifests/db/redis.pp
@@ -11,11 +11,23 @@
 # [*port*]
 #   (optional) Configure which port to listen on.
 #   Defaults to '6379'
+#
+# [*monitoring_port*]
+#   (optional) Configure which port for sentinel to listen on.
+#   Defaults to '26379'
+#
+# [*monitoring_group*]
+#   (optional) Configure which group name for sentinel to use.
+#   Defaults to '26379'
+
 
 
 class quickstack::db::redis(
   $bind_host             = '127.0.0.1',
   $port                  = '6379',
+  $master_host           = '127.0.0.1',
+  $monitoring_port       = '26379',
+  $monitoring_group      = 'sentinel-group',
   $slaveof               = undef,
 ) {
 
@@ -25,5 +37,12 @@ class quickstack::db::redis(
     appendonly => true,
     daemonize  => false,
     slaveof    => $slaveof,
+  }
+
+  class { '::redis::sentinel':
+    master_name   => $monitoring_group,
+    redis_host    => $master_host,
+    redis_port    => $port,
+    sentinel_port => $monitoring_port,
   }
 }

--- a/puppet/modules/quickstack/manifests/firewall/redis.pp
+++ b/puppet/modules/quickstack/manifests/firewall/redis.pp
@@ -1,0 +1,12 @@
+class quickstack::firewall::redis(
+  $ports = ['6379'],
+) {
+
+  include quickstack::firewall::common
+
+  firewall { '001 redis incoming':
+    proto  => 'tcp',
+    dport  => $ports,
+    action => 'accept',
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -1,10 +1,12 @@
 class quickstack::pacemaker::ceilometer (
   $ceilometer_metering_secret,
-  $memcached_port            = '11211',
-  $db_port                   = '27017',
-  $verbose                   = 'false',
-  $coordination_backend      = 'redis',
-  $coordination_backend_port = '6379',
+  $memcached_port                = '11211',
+  $db_port                       = '27017',
+  $verbose                       = 'false',
+  $coordination_backend          = 'redis',
+  $coordination_backend_port     = '6379',
+  $coordination_monitoring_port  = '26379',
+  $coordination_monitoring_group = 'ceilometer-sentinel',
 ) {
 
   include quickstack::pacemaker::common
@@ -30,19 +32,24 @@ class quickstack::pacemaker::ceilometer (
     }
 
     if $coordination_backend == 'redis' {
-      $initial_master = $backend_ips[0]
-      $coordination_url = "redis://${initial_master}:${coordination_backend_port}"
+      $_initial_master = $backend_ips[0]
+      $_fallback_sentinels = split(inline_template('<%= @backend_ips.map {
+          |x| "&sentinel_fallback="+x+":"+@coordination_monitoring_port }.join(",")%>'),",")
+      $coordination_url = "redis://${_initial_master}:${coordination_monitoring_port}?sentinel=${coordination_monitoring_group}${_fallback_sentinels}"
 
-      if has_interface_with("ipaddress", $initial_master) {
+      if has_interface_with("ipaddress", $_initial_master) {
         $_slaveof = undef
       } else {
-        $_slaveof = "${initial_master} ${coordination_backend_port}"
+        $_slaveof = "${_initial_master} ${coordination_backend_port}"
       }
 
       class { '::quickstack::pacemaker::redis':
         bind_host => map_params("local_bind_addr"),
         port      => $coordination_backend_port,
-        slaveof   => $_slaveof,
+        master_host => $_initial_master,
+        monitoring_port => $coordination_monitoring_port,
+        monitoring_group => $coordination_monitoring_group,
+        slaveof  => $_slaveof,
       }
     } else {
       $coordination_url = undef

--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -1,8 +1,10 @@
 class quickstack::pacemaker::ceilometer (
   $ceilometer_metering_secret,
-  $memcached_port          = '11211',
-  $db_port                 = '27017',
-  $verbose                 = 'false',
+  $memcached_port            = '11211',
+  $db_port                   = '27017',
+  $verbose                   = 'false',
+  $coordination_backend      = 'redis',
+  $coordination_backend_port = '6379',
 ) {
 
   include quickstack::pacemaker::common
@@ -25,6 +27,25 @@ class quickstack::pacemaker::ceilometer (
     } else {
       $_enabled = false
       $_ensure = undef
+    }
+
+    if $coordination_backend == 'redis' {
+      $initial_master = $backend_ips[0]
+      $coordination_url = "redis://${initial_master}:${coordination_backend_port}"
+
+      if has_interface_with("ipaddress", $initial_master) {
+        $_slaveof = undef
+      } else {
+        $_slaveof = "${initial_master} ${coordination_backend_port}"
+      }
+
+      class { '::quickstack::pacemaker::redis':
+        bind_host => map_params("local_bind_addr"),
+        port      => $coordination_backend_port,
+        slaveof   => $_slaveof,
+      }
+    } else {
+      $coordination_url = undef
     }
 
     if (str2bool_i(map_params('include_mysql'))) {
@@ -102,6 +123,7 @@ class quickstack::pacemaker::ceilometer (
       qpid_protocol              => map_params(''),
       service_enable             => $_enabled,
       service_ensure             => $_ensure,
+      coordination_url           => $coordination_url,
     }
     ->
     exec {"pcs-ceilometer-server-set-up":

--- a/puppet/modules/quickstack/manifests/pacemaker/redis.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/redis.pp
@@ -1,0 +1,16 @@
+class quickstack::pacemaker::redis(
+  $bind_host             = '127.0.0.1',
+  $port                  = '6379',
+  $slaveof               = undef,
+) {
+
+  class {'::quickstack::firewall::redis':
+    ports => [$port],
+  }
+
+  class {'::quickstack::db::redis':
+    bind_host => $bind_host,
+    port      => $port,
+    slaveof   => $slaveof,
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/redis.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/redis.pp
@@ -1,16 +1,22 @@
 class quickstack::pacemaker::redis(
   $bind_host             = '127.0.0.1',
   $port                  = '6379',
+  $master_host           = '127.0.0.1',
+  $monitoring_port       = '26379',
+  $monitoring_group      = 'sentinel-group',
   $slaveof               = undef,
 ) {
 
   class {'::quickstack::firewall::redis':
-    ports => [$port],
+    ports => [$port, $monitoring_port],
   }
 
   class {'::quickstack::db::redis':
     bind_host => $bind_host,
     port      => $port,
+    master_host => $master_host,
+    monitoring_port => $monitoring_port,
+    monitoring_group => $monitoring_group,
     slaveof   => $slaveof,
   }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1180158

The quickstack::pacemaker:ceilometer puppet class now allows
redis to be specified as the backend for tooz, to be used for
workload partitioning in the ceilometer central agent and
alarm evaluator.

We do not create a pacemaker resource for redis, as this will
instead be self-monitored via the redis-sentinel service (via
a subsequent patch, once the support for sentinel in tooz is
packaged python-tooz).