### PR TITLE
BZ #1180708 - galera proxy should use 'on-marked-down shutdown-sessions'...

### DIFF
--- a/puppet/modules/quickstack/manifests/load_balancer/galera.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/galera.pp
@@ -17,13 +17,13 @@ class quickstack::load_balancer::galera (
     #listen_options       => { 'option' => [ "$log", 'httpchk' ],
     # FIXME replace below line with above line when clustercheck is available
     listen_options       => { 'option' => [ "tcpka" ],
-                              'timeout' => [ "client $timeout",
-                                             "server $timeout", ],
+                              'timeout' => ["client $timeout",
+                                            "server $timeout", ],
                               'stick-table' => 'type ip size 2',
                               'stick' => 'on dst', },
     # member_options       => [ 'check inter 1s', 'port 9200' ],
     # FIXME replace below line with above line when clustercheck is available
-    member_options       => [ 'check weight 1' ],
+    member_options       => [ 'check weight 1 on-marked-down shutdown-sessions' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
   }


### PR DESCRIPTION
....

https://bugzilla.redhat.com/show_bug.cgi?id=1180708

From the BZ:

This will cause all connections to a server to be closed if/when that backend
server goes down. This is highly desirable for a proxy with long-lived
connections and long timeouts. More information here:

http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.2-on-marked-down