### PR TITLE
BZ #1175869 - add constraints for safe reboots

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -28,7 +28,7 @@ class quickstack::pacemaker::ceilometer (
     }
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-ceilometer-vip-OR-ceilometer-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-ceilometer-vip-OR-ceilometer-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-ceilometer-vip-OR-ceilometer-is-up-on-vip']
@@ -190,5 +190,7 @@ class quickstack::pacemaker::ceilometer (
       first_action    => "start",
       second_action   => "start",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -79,7 +79,7 @@ class quickstack::pacemaker::cinder(
 
     Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip'] -> Exec<| title =='cinder-manage db_sync'|> -> Exec['pcs-cinder-server-set-up']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
@@ -188,7 +188,8 @@ class quickstack::pacemaker::cinder(
       source => "cinder-scheduler-clone",
       target => "cinder-api-clone",
       score => "INFINITY",
-    }
+    } ->
+    Anchor['pacemaker ordering constraints begin']
 
     if str2bool_i("$volume") {
       # FIXME(jistr): remove the host override
@@ -312,5 +313,6 @@ class quickstack::pacemaker::cinder(
       Class['quickstack::ceph::client_packages'] ->
       Exec['i-am-cinder-vip-OR-cinder-is-up-on-vip']
     }
+
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/constraint/base_services.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraint/base_services.pp
@@ -1,0 +1,41 @@
+# define pacemaker constraints on haproxy, memcached, galera
+
+define quickstack::pacemaker::constraint::base_services(
+  $target_resource = '',
+) {
+
+  include quickstack::pacemaker::common
+
+  quickstack::pacemaker::constraint::typical{ "haproxy-then-${target_resource}-constr" :
+    first_resource  => "haproxy-clone",
+    second_resource => $target_resource,
+    colocation      => false,
+  }
+  quickstack::pacemaker::constraint::typical{ "memcached-then-${target_resource}-constr" :
+    first_resource  => "memcached-clone",
+    second_resource => $target_resource,
+    colocation      => false,
+  }
+  if (str2bool_i(map_params('include_mysql'))) {
+    quickstack::pacemaker::constraint::typical{ "galera-then-${target_resource}-constr" :
+      first_resource  => "galera-master",
+      second_resource => $target_resource,
+      colocation      => false,
+    }
+  }
+  if (str2bool_i(map_params('include_amqp'))) {
+    if (map_params('amqp_provider') == 'rabbitmq') {
+      quickstack::pacemaker::constraint::typical{ "rabbitmq-then-${target_resource}-constr" :
+        first_resource  => "rabbitmq-server-clone",
+        second_resource => $target_resource,
+        colocation      => false,
+      }
+    } else {
+      quickstack::pacemaker::constraint::typical{ "qpidd-then-${target_resource}-constr" :
+        first_resource  => "qpidd-clone",
+        second_resource => $target_resource,
+        colocation      => false,
+      }
+    }
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/constraint/colocation.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraint/colocation.pp
@@ -1,6 +1,6 @@
 define quickstack::pacemaker::constraint::colocation ($source,
                                           $target,
-                                          $score,
+                                          $score='INFINITY',
                                           $ensure=present) {
   include quickstack::pacemaker::params
 

--- a/puppet/modules/quickstack/manifests/pacemaker/constraint/haproxy_vips.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraint/haproxy_vips.pp
@@ -1,0 +1,38 @@
+# A generic wrapper to start haproxy before a set of vips
+# Important for reboots
+
+define quickstack::pacemaker::constraint::haproxy_vips(
+  $public_vip,
+  $private_vip,
+  $admin_vip,
+  $pcmk_group = $title,
+  ) {
+
+  Quickstack::Pacemaker::Resource::Generic['haproxy'] ->
+  quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-pub-const" :
+    first_resource  => "haproxy-clone",
+    second_resource => "ip-${pcmk_group}-pub-${public_vip}",
+  }
+  Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-pub"] ->
+  Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-pub-const"]
+
+  if ( $public_vip != $private_vip ) {
+    Quickstack::Pacemaker::Resource::Generic['haproxy'] ->
+    quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-prv-const" :
+      first_resource  => "haproxy-clone",
+      second_resource => "ip-${pcmk_group}-prv-${private_vip}",
+    }
+    Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-prv"] ->
+    Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-prv-const"]
+  }
+
+  if ( ($admin_vip != $private_vip) and ($admin_vip != $public_vip) ) {
+    Quickstack::Pacemaker::Resource::Generic['haproxy'] ->
+    quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-adm-const" :
+      first_resource  => "haproxy-clone",
+      second_resource => "ip-${pcmk_group}-adm-${admin_vip}",
+    }
+    Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-adm"] ->
+    Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-adm-const"]
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/constraint/typical.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraint/typical.pp
@@ -1,0 +1,24 @@
+# just some syntatic sugar
+
+define quickstack::pacemaker::constraint::typical(
+  $first_resource  = '',
+  $second_resource = '',
+  $colocation      = true,
+) {
+
+  quickstack::pacemaker::constraint::base { $title :
+    constraint_type => "order",
+    first_resource  => $first_resource,
+    second_resource => $second_resource,
+    first_action    => "start",
+    second_action   => "start",
+  }
+
+  if $colocation {
+    Quickstack::Pacemaker::Constraint::Base[$title] ->
+    quickstack::pacemaker::constraint::colocation { "$title-colo" :
+      source => $second_resource,
+      target => $first_resource,
+    }
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/constraints.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraints.pp
@@ -1,0 +1,241 @@
+class quickstack::pacemaker::constraints() {
+
+  include quickstack::pacemaker::common
+
+  anchor {'pacemaker ordering constraints begin': }
+  -> Quickstack::Pacemaker::Constraint::Haproxy_vips<| |>
+
+  Anchor['pacemaker ordering constraints begin'] ->
+  Quickstack::Pacemaker::Constraint::Base_services <| |> ->
+  Anchor['pacemaker ordering constraints end']
+
+  if (str2bool_i(map_params('include_ceilometer'))) {
+    $ceilometer_public_vip  = map_params("ceilometer_public_vip")
+    $ceilometer_private_vip = map_params("ceilometer_private_vip")
+    $ceilometer_admin_vip   = map_params("ceilometer_admin_vip")
+    $pcmk_ceilometer_group = map_params("ceilometer_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$pcmk_ceilometer_group":
+      public_vip  => $ceilometer_public_vip,
+      private_vip => $ceilometer_private_vip,
+      admin_vip   => $ceilometer_admin_vip,
+    }
+  }
+
+  if (str2bool_i(map_params('include_cinder'))) {
+    $pcmk_cinder_group    = map_params("cinder_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$pcmk_cinder_group":
+      public_vip  => map_params("cinder_public_vip"),
+      private_vip => map_params("cinder_private_vip"),
+      admin_vip   => map_params("cinder_admin_vip"),
+    }
+  }
+
+  if (str2bool_i(map_params('include_mysql'))) {
+    quickstack::pacemaker::constraint::haproxy_vips { "galera":
+      public_vip  => map_params("db_vip"),
+      private_vip => map_params("db_vip"),
+      admin_vip   => map_params("db_vip"),
+    }
+  }
+
+  if (str2bool_i(map_params('include_glance'))) {
+    $pcmk_glance_group = map_params("glance_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$pcmk_glance_group":
+      public_vip  => map_params("glance_public_vip"),
+      private_vip => map_params("glance_private_vip"),
+      admin_vip   => map_params("glance_admin_vip"),
+    }
+  }
+
+  if (str2bool_i(map_params('include_heat'))) {
+    $heat_group              = map_params("heat_group")
+    $heat_cfn_group          = map_params("heat_cfn_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$heat_group":
+      public_vip  => map_params("heat_public_vip"),
+      private_vip => map_params("heat_private_vip"),
+      admin_vip   => map_params("heat_admin_vip"),
+    }
+    if str2bool_i($heat_cfn_enabled) {
+      quickstack::pacemaker::constraint::haproxy_vips {"$heat_cfn_group":
+        public_vip  => map_params("heat_cfn_public_vip"),
+        private_vip => map_params("heat_cfn_private_vip"),
+        admin_vip   => map_params("heat_cfn_admin_vip"),
+      }
+    }
+  }
+
+  if (str2bool_i(map_params('include_horizon'))) {
+    $pcmk_horizon_group = map_params("horizon_group")
+    $horizon_public_vip  = map_params("horizon_public_vip")
+    $horizon_private_vip = map_params("horizon_private_vip")
+    $horizon_admin_vip   = map_params("horizon_admin_vip")
+    quickstack::pacemaker::constraint::haproxy_vips { "$pcmk_horizon_group":
+      public_vip  => $horizon_public_vip,
+      private_vip => $horizon_private_vip,
+      admin_vip   => $horizon_admin_vip,
+    }
+  }
+
+  if (str2bool_i(map_params('include_keystone'))) {
+    $keystone_group = map_params("keystone_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$keystone_group":
+      public_vip  => map_params("keystone_public_vip"),
+      private_vip => map_params("keystone_private_vip"),
+      admin_vip   => map_params("keystone_admin_vip"),
+    }
+  }
+
+  if (str2bool_i(map_params('include_neutron'))) {
+    $neutron_group = map_params("neutron_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$neutron_group":
+      public_vip  => map_params("neutron_public_vip"),
+      private_vip => map_params("neutron_private_vip"),
+      admin_vip   => map_params("neutron_admin_vip"),
+    }
+  }
+
+  if (str2bool_i(map_params('include_nova'))) {
+    $pcmk_nova_group = map_params("nova_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$pcmk_nova_group":
+      public_vip  => map_params("nova_public_vip"),
+      private_vip => map_params("nova_private_vip"),
+      admin_vip   => map_params("nova_admin_vip"),
+    }
+  }
+
+  if (str2bool_i(map_params('include_amqp')) and
+      map_params('amqp_provider') == 'qpid') {
+    $amqp_group = map_params("amqp_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$amqp_group":
+      public_vip  => map_params("amqp_vip"),
+      private_vip => map_params("amqp_vip"),
+      admin_vip   => map_params("amqp_vip"),
+    }
+  }
+
+  if (str2bool_i(map_params('include_amqp')) and
+      map_params('amqp_provider') == 'rabbitmq') {
+    $amqp_group = map_params("amqp_group")
+    $amqp_vip = map_params("amqp_vip")
+    quickstack::pacemaker::constraint::haproxy_vips { "$amqp_group":
+      public_vip  => $amqp_vip,
+      private_vip => $amqp_vip,
+      admin_vip   => $amqp_vip,
+    }
+  }
+
+  if (str2bool_i(map_params('include_swift'))) {
+    include quickstack::pacemaker::swift
+    $swift_internal_vip = $::quickstack::pacemaker::swift::swift_internal_vip
+    $swift_group = map_params("swift_group")
+    quickstack::pacemaker::constraint::haproxy_vips { "$swift_group":
+      public_vip  => map_params("swift_public_vip"),
+      private_vip => $swift_internal_vip,
+      admin_vip   => $swift_internal_vip,
+    }
+  }
+
+
+  if (str2bool_i(map_params('include_keystone'))) {
+    quickstack::pacemaker::constraint::base_services{"base-then-keystone-constr" :
+      target_resource => "keystone-clone",
+    }
+  }
+
+  if (str2bool_i(map_params('include_glance'))) {
+    if (str2bool_i(map_params('include_keystone'))) {
+      quickstack::pacemaker::constraint::typical{ 'keystone-then-glance-constr' :
+        first_resource  => "keystone-clone",
+        second_resource => "glance-registry-clone",
+        colocation      => false,
+      }
+    } else {
+      quickstack::pacemaker::constraint::base_services{"base-then-glance-constr" :
+        target_resource => "glance-registry-clone",
+      }     
+    }
+  }
+
+  if (str2bool_i(map_params('include_cinder'))) {
+    if (str2bool_i(map_params('include_keystone'))) {
+      quickstack::pacemaker::constraint::typical{ 'keystone-then-cinder-constr' :
+        first_resource  => "keystone-clone",
+        second_resource => "cinder-api-clone",
+        colocation      => false,
+      }
+    } else {
+      quickstack::pacemaker::constraint::base_services{"base-then-cinder-constr" :
+        target_resource => "cinder-api-clone",
+      }     
+    }
+  }
+
+  if (str2bool_i(map_params('include_swift'))) {
+    if (str2bool_i(map_params('include_keystone'))) {
+      quickstack::pacemaker::constraint::typical{ 'keystone-then-swift-constr' :
+        first_resource  => "keystone-clone",
+        second_resource => "swift-proxy-clone",
+        colocation      => false,
+      }
+    } else {
+      quickstack::pacemaker::constraint::base_services{"base-then-swift-constr" :
+        target_resource => "swift-proxy-clone",
+      }     
+    }
+  }
+
+  if (str2bool_i(map_params('include_nova'))) {
+    if (str2bool_i(map_params('include_keystone'))) {
+      quickstack::pacemaker::constraint::typical{ 'keystone-then-nova-constr' :
+        first_resource  => "keystone-clone",
+        second_resource => "openstack-nova-consoleauth-clone",
+        colocation      => false,
+      }
+    } else {
+      quickstack::pacemaker::constraint::base_services{"base-then-nova-constr" :
+        target_resource => "openstack-nova-consoleauth-clone",
+      }     
+    }
+  }
+
+  if (str2bool_i(map_params('include_neutron'))) {
+    if (str2bool_i(map_params('include_keystone'))) {
+      quickstack::pacemaker::constraint::typical{ 'keystone-then-neutron-constr' :
+        first_resource  => "keystone-clone",
+        second_resource => "neutron-server-clone",
+        colocation      => false,
+      }
+    } else {
+      quickstack::pacemaker::constraint::base_services{"base-then-neutron-constr" :
+        target_resource => "neutron-server-clone",
+      }     
+    }
+  }
+
+  if (str2bool_i(map_params('include_ceilometer'))) {
+    if (str2bool_i(map_params('include_keystone'))) {
+      Quickstack::Pacemaker::Resource::Service['openstack-ceilometer-central'] ->
+      quickstack::pacemaker::constraint::typical{ 'keystone-then-ceilometer-constr' :
+        first_resource  => "keystone-clone",
+        second_resource => "openstack-ceilometer-central",
+        colocation      => false,
+      }
+    } else {
+      Quickstack::Pacemaker::Resource::Service['openstack-ceilometer-central'] ->
+      quickstack::pacemaker::constraint::base_services{"base-then-ceilo-constr" :
+        target_resource => "openstack-ceilometer-central",
+      }     
+    }
+    if (str2bool_i(map_params('include_nosql'))) {
+      Quickstack::Pacemaker::Resource::Service['mongod'] ->
+      Quickstack::Pacemaker::Resource::Service['openstack-ceilometer-central'] ->
+      quickstack::pacemaker::constraint::typical{ 'mongod-then-ceilometer-constr' :
+        first_resource  => "mongod-clone",
+        second_resource => "openstack-ceilometer-central",
+        colocation      => false,
+      }
+    }
+  }
+
+  anchor {'pacemaker ordering constraints end': }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -51,7 +51,7 @@ class quickstack::pacemaker::heat(
     Exec['i-am-heat-vip-OR-heat-is-up-on-vip'] -> Exec<| title == 'heat-dbsync' |>
     -> Exec['pcs-heat-server-set-up']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-heat-vip-OR-heat-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -34,7 +34,7 @@ class quickstack::pacemaker::horizon (
 
     Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip'] -> Service['httpd']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-horizon-vip-OR-horizon-is-up-on-vip']

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -55,7 +55,7 @@ class quickstack::pacemaker::keystone (
     Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip'] -> Keystone_service<| |> -> Exec['pcs-keystone-server-set-up']
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
     }
 
     class {"::quickstack::load_balancer::keystone":
@@ -176,6 +176,8 @@ class quickstack::pacemaker::keystone (
       clone_opts    => "interleave=true",
       resource_name => "openstack-keystone",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
     # TODO: Consider if we should pre-emptively purge any directories keystone has
     # created in /tmp
 

--- a/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
@@ -25,5 +25,6 @@ class quickstack::pacemaker::load_balancer {
   } ->
   quickstack::pacemaker::resource::generic {'haproxy':
     clone_opts => "interleave=true",
-  }
+  } ->
+  Anchor['pacemaker ordering constraints begin']
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
@@ -18,6 +18,6 @@ class quickstack::pacemaker::memcached {
   } ->
   quickstack::pacemaker::resource::generic { 'memcached':
     clone_opts => "interleave=true",
-  }
-
+  } ->
+  Anchor['pacemaker ordering constraints begin']
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -73,7 +73,7 @@ class quickstack::pacemaker::neutron (
       $_enabled = false
     }
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-neutron-vip-OR-neutron-is-up-on-vip']
@@ -325,5 +325,7 @@ class quickstack::pacemaker::neutron (
       target => "neutron-l3-agent-clone",
       score  => "INFINITY",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
@@ -23,7 +23,7 @@ class quickstack::pacemaker::nosql (
     }
 
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Anchor['nosql cluster start']
+      Anchor['galera-online'] -> Anchor['nosql cluster start']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Anchor['nosql cluster start']
@@ -99,5 +99,7 @@ class quickstack::pacemaker::nosql (
     anchor {'ha mongo ready':
       require => Quickstack::Pacemaker::Resource::Service['mongod'],
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -34,7 +34,7 @@ class quickstack::pacemaker::nova (
     }
     Exec['i-am-nova-vip-OR-nova-is-up-on-vip'] -> Exec['nova-db-sync']
     if (str2bool_i(map_params('include_mysql'))) {
-      Exec['galera-online'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
+      Anchor['galera-online'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_keystone'))) {
       Exec['all-keystone-nodes-are-up'] -> Exec['i-am-nova-vip-OR-nova-is-up-on-vip']
@@ -190,5 +190,7 @@ class quickstack::pacemaker::nova (
       target => "openstack-nova-conductor-clone",
       score => "INFINITY",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -119,6 +119,7 @@ class quickstack::pacemaker::params (
   include quickstack::pacemaker::nova
   include quickstack::pacemaker::cinder
   include quickstack::pacemaker::heat
+  include quickstack::pacemaker::constraints
 
   Class['::quickstack::pacemaker::common'] ->
   Class['::quickstack::pacemaker::load_balancer'] ->
@@ -129,5 +130,7 @@ class quickstack::pacemaker::params (
   Class['::quickstack::pacemaker::glance'] ->
   Class['::quickstack::pacemaker::nova'] ->
   Class['::quickstack::pacemaker::cinder'] ->
-  Class['::quickstack::pacemaker::heat']
+  Class['::quickstack::pacemaker::heat'] ->
+  Class['::quickstack::pacemaker::constraints']
+
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
@@ -85,6 +85,11 @@ class quickstack::pacemaker::qpid (
                                'stick' => 'on dst'},
     }
 
+    if (str2bool_i(map_params('include_mysql'))) {
+      # avoid race condition with galera setup
+      Anchor['galera-online'] -> Exec['all-qpid-nodes-are-up']
+    }
+
     Class['::quickstack::firewall::amqp'] ->
     Class['::qpid::server'] ->
     Class['::quickstack::pacemaker::common'] ->
@@ -107,6 +112,7 @@ class quickstack::pacemaker::qpid (
     } ->
     quickstack::pacemaker::resource::service { 'qpidd':
       clone   => true,
-    }
+    } ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/resource/ip.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/ip.pp
@@ -8,13 +8,18 @@ define quickstack::pacemaker::resource::ip($ip_address,
   include quickstack::pacemaker::params
 
   if has_interface_with("ipaddress", map_params("cluster_control_ip")){
-    ::pacemaker::resource::ip{ "$name": 
-                            ip_address     => $ip_address,
-                            cidr_netmask   => $cidr_netmask,
-                            nic            => $nic,
-                            group          => $group,
-                            interval       => $interval,
-                            monitor_params => $monitor_params,
-                            ensure         => $ensure }
+    $nic_option = $nic ? {
+        ''      => '',
+        default => " nic=$nic"
+    }
+  
+    pcmk_resource { "$title-${ip_address}":
+      ensure          => $ensure,
+      resource_type   => 'IPaddr2',
+      resource_params => "ip=${ip_address} cidr_netmask=${cidr_netmask}${nic_option}",
+      group           => $group,
+      interval        => $interval,
+      monitor_params  => $monitor_params,
+    }
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -108,5 +108,7 @@ class quickstack::pacemaker::swift (
       first_action    => "start",
       second_action   => "start",
     }
+    ->
+    Anchor['pacemaker ordering constraints begin']
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/vips.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/vips.pp
@@ -6,21 +6,31 @@ define quickstack::pacemaker::vips(
   ) {
 
   Exec['stonith-setup-complete'] ->
-  quickstack::pacemaker::resource::ip { "ip-${pcmk_group}_${public_vip}":
+  quickstack::pacemaker::resource::ip { "ip-${pcmk_group}-pub":
     ip_address => "$public_vip",
   }
 
   if ( $public_vip != $private_vip ) {
     Exec['stonith-setup-complete'] ->
-    quickstack::pacemaker::resource::ip { "ip-${pcmk_group}_${private_vip}":
+    Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-pub"] ->
+    quickstack::pacemaker::resource::ip { "ip-${pcmk_group}-prv":
       ip_address => "$private_vip",
+    } ->
+    quickstack::pacemaker::constraint::colocation { "ip-${pcmk_group}-pub-prv-colo" :
+      source => "ip-${pcmk_group}-prv-${private_vip}",
+      target => "ip-${pcmk_group}-pub-${public_vip}",
     }
   }
 
   if ( ($admin_vip != $private_vip) and ($admin_vip != $public_vip) ) {
     Exec['stonith-setup-complete'] ->
-    quickstack::pacemaker::resource::ip { "ip-${pcmk_group}_${admin_vip}":
+    Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-pub"] ->
+    quickstack::pacemaker::resource::ip { "ip-${pcmk_group}-adm":
       ip_address => "$admin_vip",
+    } ->
+    quickstack::pacemaker::constraint::colocation { "ip-${pcmk_group}-pub-adm-colo" :
+      source => "ip-${pcmk_group}-adm-${admin_vip}",
+      target => "ip-${pcmk_group}-pub-${public_vip}",
     }
   }
 }

--- a/puppet/modules/quickstack/templates/ha-all-in-one-util.erb
+++ b/puppet/modules/quickstack/templates/ha-all-in-one-util.erb
@@ -6,7 +6,7 @@ keystone_private_vip=<%= scope.lookupvar("::quickstack::pacemaker::params::keyst
 # These functions adapted from similar logic in jayg's rysnc.pp variables
 get_resource_ip_output() {
   # trailing space is on purpose below to avoid matching Failed actions
-  echo $(/usr/sbin/pcs status | /bin/grep -P "ip-$1\s")
+  echo $(/usr/sbin/pcs status | /bin/grep -P "ip-\S*$1\s")
 }
 which_cluster_ip() {
   line=$(get_resource_ip_output $1)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1175869

* add constraints between haproxy and vips
* colocate vips within a service (e.g., all three keystone vips
  should reside on the same node)
* add constraints between services (e.g. galera should start
  before keystone)
* friendlier vip names
* disable haproxy during initial setup of galera (just the first
  puppet run).