### PR TITLE
BZ #1181796 - neutron resolvable hostname in /etc/hosts workaround

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -130,6 +130,14 @@ class quickstack::neutron::all (
   }
   File['/etc/neutron/plugin.ini'] -> Exec['neutron-db-manage upgrade']
 
+  # short-term workaround for BZ 1181592
+  package{'bind-utils': } ->
+  exec {'neutron-etc-hosts-workaround':
+    command => 'dig A $(hostname) | grep -A1 "ANSWER SEC" | tail -n 1 | awk \'{print $NF " " $1}\' | sed -e \'s/.$//g\' >>/etc/hosts',
+    unless => 'grep -P "\b$( hostname )\b" /etc/hosts',
+    path => ['/usr/bin','/bin'],
+  } -> Service['neutron-server']
+
   class { '::neutron::server':
     auth_host                => $auth_host,
     auth_password            => $neutron_user_password,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1181796

On neutron controllers (or network nodes),
add "127.0.0.1 $( hostname)" to /etc/hosts.