### PR TITLE
BZ #1182176: honor the quickstack::pacemaker::ceilometer::verbose param

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -102,6 +102,7 @@ class quickstack::pacemaker::ceilometer (
       qpid_protocol              => map_params(''),
       service_enable             => $_enabled,
       service_ensure             => $_ensure,
+      verbose                    => $verbose,
     }
     ->
     exec {"pcs-ceilometer-server-set-up":


### PR DESCRIPTION
BZ #1182176: take account of quickstack::pacemaker::ceilometer::verbose parameter

https://bugzilla.redhat.com/1182176

Previously the verbose parameter to quickstack::pacemaker::ceilometer
puppet class was ignored.

Now it is properly propogated to the quickstack::ceilometer::control
class, so that it actually impacts on the deployed ceilometer config.