### PR TITLE
BZ #1175869 - Neutron haproxy config was broken.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -113,8 +113,8 @@ class quickstack::pacemaker::neutron (
       frontend_pub_host    => map_params("neutron_public_vip"),
       frontend_priv_host    => map_params("neutron_private_vip"),
       frontend_admin_host    => map_params("neutron_admin_vip"),
-      backend_server_names => $_lb_backend_server_names,
-      backend_server_addrs => $_lb_backend_server_addrs,
+      backend_server_names => $_backend_server_names,
+      backend_server_addrs => $_backend_server_addrs,
     }
 
     Class['::quickstack::pacemaker::common']


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1175869

A previous patch introduced a new internal variable used to populate the backend
server addrs and names.  This had a typo, which results in the wrong name and
only the current host being in haproxy config, which made all neutron cli calls
fail, as they were not routed properly.