### PR TITLE
BZ #1182811 - create cloned resources in two steps (workaround)

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/constraints.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraints.pp
@@ -227,7 +227,7 @@ class quickstack::pacemaker::constraints() {
       }     
     }
     if (str2bool_i(map_params('include_nosql'))) {
-      Quickstack::Pacemaker::Resource::Service['mongod'] ->
+      Quickstack::Pacemaker::Resource::Generic['mongod'] ->
       Quickstack::Pacemaker::Resource::Service['openstack-ceilometer-central'] ->
       quickstack::pacemaker::constraint::typical{ 'mongod-then-ceilometer-constr' :
         first_resource  => "mongod-clone",

--- a/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
@@ -91,13 +91,11 @@ class quickstack::pacemaker::nosql (
 
     Exec['all-nosql-nodes-are-up'] ->
 
-    quickstack::pacemaker::resource::service {'mongod':
-      options        => 'start timeout=10s',
-      monitor_params => { 'start-delay' => '10s' },
-      clone          => true,
+    quickstack::pacemaker::resource::generic {'mongod':
+      clone_opts     => ' ', # not undef, so --clone without clone options
     } ->
     anchor {'ha mongo ready':
-      require => Quickstack::Pacemaker::Resource::Service['mongod'],
+      require => Quickstack::Pacemaker::Resource::Generic['mongod'],
     }
     ->
     Anchor['pacemaker ordering constraints begin']

--- a/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/qpid.pp
@@ -110,8 +110,8 @@ class quickstack::pacemaker::qpid (
       try_sleep => 10,
       command   => "/tmp/ha-all-in-one-util.bash all_members_include qpid",
     } ->
-    quickstack::pacemaker::resource::service { 'qpidd':
-      clone   => true,
+    quickstack::pacemaker::resource::generic {'qpidd':
+      clone_opts     => ' ', # not undef, so --clone without clone options
     } ->
     Anchor['pacemaker ordering constraints begin']
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1182811

Create cloned resources with two commands to pcs.  This is because
doing it with one call to pcs sometimes results in an uncloned
resource and puppet reruns would not help.