### PR TITLE
BZ #1186459 - config uses rabbit_hosts and rabbit_ha_queues instead of rabbit vip / haproxy

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer/control.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer/control.pp
@@ -4,6 +4,7 @@ class quickstack::ceilometer::control(
   $amqp_port                  = '5672',
   $amqp_username,
   $amqp_password,
+  $rabbit_hosts               = undef,
   $auth_host                  = '127.0.0.1',
   $bind_address               = '0.0.0.0',
   $ceilometer_metering_secret,
@@ -48,6 +49,7 @@ class quickstack::ceilometer::control(
     rabbit_port     => $amqp_port,
     rabbit_userid   => $amqp_username,
     rabbit_password => $amqp_password,
+    rabbit_hosts    => $rabbit_hosts,
     rpc_backend     => amqp_backend('ceilometer', $amqp_provider),
     verbose         => str2bool_i("$verbose"),
   }

--- a/puppet/modules/quickstack/manifests/cinder.pp
+++ b/puppet/modules/quickstack/manifests/cinder.pp
@@ -21,6 +21,7 @@ class quickstack::cinder(
   $qpid_heartbeat = '60',
   $qpid_protocol  = 'tcp',
   $rabbit_use_ssl = false,
+  $rabbit_hosts   = undef,
 
   $enabled        = true,
   $manage_service = true,
@@ -45,6 +46,11 @@ class quickstack::cinder(
     }
   }
 
+  if $rabbit_hosts {
+    cinder_config { 'DEFAULT/rabbit_host': ensure => absent }
+    cinder_config { 'DEFAULT/rabbit_port': ensure => absent }
+  }
+
   if str2bool_i("$db_ssl") {
     $sql_connection = "mysql://${db_user}:${db_password}@${db_host}/${db_name}?ssl_ca=${db_ssl_ca}"
   } else {
@@ -64,6 +70,7 @@ class quickstack::cinder(
     rabbit_userid   => $amqp_username,
     rabbit_password => $amqp_password_safe_for_cinder,
     rabbit_use_ssl  => $rabbit_use_ssl,
+    rabbit_hosts    => $rabbit_hosts,
     sql_connection  => $sql_connection,
     verbose         => str2bool_i("$verbose"),
     use_syslog      => str2bool_i("$use_syslog"),

--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -45,6 +45,7 @@ class quickstack::compute_common (
   $private_network              = '',
   $private_iface                = '',
   $private_ip                   = '',
+  $rabbit_hosts                 = undef,
   $rbd_user                     = 'volumes',
   $rbd_secret_uuid              = '',
   $network_device_mtu           = $quickstack::params::network_device_mtu,
@@ -155,6 +156,11 @@ class quickstack::compute_common (
     $nova_sql_connection = "mysql://nova:${nova_db_password}@${mysql_host}/nova"
   }
 
+  if $rabbit_hosts {
+    nova_config { 'DEFAULT/rabbit_host': ensure => absent }
+    nova_config { 'DEFAULT/rabbit_port': ensure => absent }
+  }
+
   class { '::nova':
     sql_connection     => $nova_sql_connection,
     image_service      => 'nova.image.glance.GlanceImageService',
@@ -170,6 +176,7 @@ class quickstack::compute_common (
     rabbit_userid      => $amqp_username,
     rabbit_password    => $amqp_password,
     rabbit_use_ssl     => $ssl,
+    rabbit_hosts       => $rabbit_hosts,
     verbose            => $verbose,
   }
 
@@ -202,6 +209,7 @@ class quickstack::compute_common (
       qpid_username   => $amqp_username,
       qpid_password   => $amqp_password,
       rabbit_host     => $amqp_host,
+      rabbit_hosts    => $rabbit_hosts,
       rabbit_port     => $real_amqp_port,
       rabbit_userid   => $amqp_username,
       rabbit_password => $amqp_password,

--- a/puppet/modules/quickstack/manifests/glance.pp
+++ b/puppet/modules/quickstack/manifests/glance.pp
@@ -40,6 +40,7 @@ class quickstack::glance (
   $amqp_password            = '',
   $amqp_provider            = 'rabbitmq',
   $rabbit_use_ssl           = false,
+  $rabbit_hosts             = undef,
 ) {
 
   # Configure the db string
@@ -54,6 +55,11 @@ class quickstack::glance (
   $show_image_direct_url = $backend ? {
     'rbd' => true,
     default => false,
+  }
+
+  if $rabbit_hosts {
+    glance_api_config { 'DEFAULT/rabbit_host': ensure => absent }
+    glance_api_config { 'DEFAULT/rabbit_port': ensure => absent }
   }
 
   # Install and configure glance-api
@@ -122,6 +128,7 @@ class quickstack::glance (
       rabbit_host     => $amqp_host,
       rabbit_port     => $amqp_port,
       rabbit_use_ssl  => $rabbit_use_ssl,
+      rabbit_hosts    => $rabbit_hosts,
     }
   }
 

--- a/puppet/modules/quickstack/manifests/heat.pp
+++ b/puppet/modules/quickstack/manifests/heat.pp
@@ -18,6 +18,7 @@ class quickstack::heat(
   $amqp_password           = '',
   $amqp_provider           = 'rabbitmq',
   $rabbit_use_ssl          = false,
+  $rabbit_hosts            = undef,
 
   $cfn_host                = '127.0.0.1',
   $cloudwatch_host         = '127.0.0.1',
@@ -71,6 +72,7 @@ class quickstack::heat(
     rabbit_userid     => $amqp_username,
     rabbit_password   => $amqp_password,
     rabbit_use_ssl    => $rabbit_use_ssl,
+    rabbit_hosts      => $rabbit_hosts,
     use_syslog        => str2bool_i("$use_syslog"),
     log_facility      => $log_facility,
     verbose           => $verbose,

--- a/puppet/modules/quickstack/manifests/keystone/common.pp
+++ b/puppet/modules/quickstack/manifests/keystone/common.pp
@@ -45,6 +45,7 @@ class quickstack::keystone::common (
   $admin_token,
   $amqp_host                   = 'localhost',
   $amqp_port                   = '5672',
+  $rabbit_hosts                = undef,
   $bind_host                   = '0.0.0.0',
   $db_host                     = '127.0.0.1',
   $db_name                     = 'keystone',
@@ -75,6 +76,11 @@ class quickstack::keystone::common (
     fail("db_type ${db_type} is not supported")
   }
 
+  if $rabbit_hosts {
+    keystone_config { 'DEFAULT/rabbit_host': ensure => absent }
+    keystone_config { 'DEFAULT/rabbit_port': ensure => absent }
+  }
+
   class { '::keystone':
     admin_token      => $admin_token,
     bind_host        => $bind_host,
@@ -85,6 +91,7 @@ class quickstack::keystone::common (
     log_facility     => $log_facility,
     rabbit_host      => $amqp_host,
     rabbit_port      => $amqp_port,
+    rabbit_hosts     => $rabbit_hosts,
     service_provider => $service_provider,
     sql_connection   => $sql_conn,
     token_driver     => $token_driver,

--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -77,6 +77,7 @@ class quickstack::neutron::all (
   $amqp_ssl_port                 = '5671',
   $amqp_username                 = '',
   $amqp_password                 = '',
+  $rabbit_hosts                  = undef,
   $rpc_backend                   = 'neutron.openstack.common.rpc.impl_kombu',
   $security_group_api            = 'neutron',
   $tenant_network_type           = 'vlan',
@@ -96,6 +97,11 @@ class quickstack::neutron::all (
     $sql_connection = "mysql://neutron:${neutron_db_password}@${mysql_host}/neutron"
   }
 
+  if $rabbit_hosts {
+    neutron_config { 'DEFAULT/rabbit_host': ensure => absent }
+    neutron_config { 'DEFAULT/rabbit_port': ensure => absent }
+  }
+
   class { '::neutron':
     allow_overlapping_ips   => str2bool_i("$allow_overlapping_ips"),
     bind_host               => $neutron_priv_host,
@@ -113,6 +119,7 @@ class quickstack::neutron::all (
     rabbit_user             => $amqp_username,
     rabbit_password         => $amqp_password,
     rabbit_use_ssl          => $ssl,
+    rabbit_hosts            => $rabbit_hosts,
     verbose                 => $verbose,
     network_device_mtu      => $network_device_mtu,
   }

--- a/puppet/modules/quickstack/manifests/nova.pp
+++ b/puppet/modules/quickstack/manifests/nova.pp
@@ -113,6 +113,7 @@ class quickstack::nova (
   $amqp_port                    = '5672',
   $amqp_username                = '',
   $amqp_password                = '',
+  $rabbit_hosts                 = undef,
   $auth_host                    = 'localhost',
   $auto_assign_floating_ip      = 'true',
   $bind_address                 = '0.0.0.0',
@@ -159,10 +160,16 @@ class quickstack::nova (
       rabbit_host        => $amqp_hostname,
       rabbit_userid      => $amqp_username,
       rabbit_password    => $amqp_password,
+      rabbit_hosts       => $rabbit_hosts,
     }
 
     nova_config { 'DEFAULT/default_floating_pool':
       value => $default_floating_pool;
+    }
+
+    if $rabbit_hosts {
+      nova_config { 'DEFAULT/rabbit_host': ensure => absent }
+      nova_config { 'DEFAULT/rabbit_port': ensure => absent }
     }
 
     if $max_retries {

--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -90,6 +90,7 @@ class quickstack::pacemaker::ceilometer (
       amqp_port                  => map_params('amqp_port'),
       amqp_username              => map_params('amqp_username'),
       amqp_password              => map_params('amqp_password'),
+      rabbit_hosts               => map_params("rabbitmq_hosts"),
       auth_host                  => map_params("keystone_admin_vip"),
       bind_address               => map_params("local_bind_addr"),
       ceilometer_metering_secret => "$ceilometer_metering_secret",

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -166,6 +166,7 @@ class quickstack::pacemaker::cinder(
       amqp_username  => map_params('amqp_username'),
       amqp_password  => map_params('amqp_password'),
       qpid_heartbeat => $qpid_heartbeat,
+      rabbit_hosts   => map_params("rabbitmq_hosts"),
       use_syslog     => $use_syslog,
       log_facility   => $log_facility,
       debug          => $debug,

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -143,6 +143,7 @@ class quickstack::pacemaker::glance (
       amqp_username            => map_params("amqp_username"),
       amqp_password            => map_params("amqp_password"),
       amqp_provider            => map_params("amqp_provider"),
+      rabbit_hosts             => map_params("rabbitmq_hosts"),
     }
     ->
     exec {"pcs-glance-server-set-up":

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -109,6 +109,7 @@ class quickstack::pacemaker::heat(
       amqp_username           => map_params("amqp_username"),
       amqp_password           => map_params("amqp_password"),
       amqp_provider           => map_params("amqp_provider"),
+      rabbit_hosts            => map_params("rabbitmq_hosts"),
       cfn_host                => map_params("heat_cfn_admin_vip"),
       cloudwatch_host         => map_params("heat_admin_vip"),
       use_syslog              => $use_syslog,

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -98,6 +98,7 @@ class quickstack::pacemaker::keystone (
       admin_token  => "$admin_token",
       amqp_host    => map_params("amqp_vip"),
       amqp_port    => map_params("amqp_port"),
+      rabbit_hosts => map_params("rabbitmq_hosts"),
       bind_host    => map_params("local_bind_addr"),
       db_host      => map_params("db_vip"),
       db_name      => "$db_name",

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -181,6 +181,7 @@ class quickstack::pacemaker::neutron (
       amqp_port                      => map_params("amqp_port"),
       amqp_username                  => map_params("amqp_username"),
       amqp_password                  => map_params("amqp_password"),
+      rabbit_hosts                   => map_params("rabbitmq_hosts"),
       tenant_network_type            => $tenant_network_type,
       security_group_api             => $security_group_api,
       nexus_config                   => $nexus_config,

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -104,6 +104,7 @@ class quickstack::pacemaker::nova (
       amqp_port                     => map_params("amqp_port"),
       amqp_username                 => map_params("amqp_username"),
       amqp_password                 => map_params("amqp_password"),
+      rabbit_hosts                  => map_params("rabbitmq_hosts"),
       rpc_backend                   => amqp_backend('nova', map_params('amqp_provider')),
       scheduler_host_subset_size    => $scheduler_host_subset_size,
       verbose                       => $verbose,

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -98,6 +98,7 @@ class quickstack::pacemaker::params (
   $amqp_group                = 'amqp',
   $amqp_username             = '',
   $amqp_password             = '',
+  $rabbitmq_use_addrs_not_vip = true,
   $swift_public_vip          = '',
   $swift_user_password       = '',
   $swift_group               = 'swift',
@@ -108,6 +109,14 @@ class quickstack::pacemaker::params (
   $pcmk_bind_addr = find_ip("$pcmk_network",
                             "$pcmk_iface",
                             "$pcmk_ip")
+  $_rabbitmq_use_addrs_not_vip = str2bool_i($rabbitmq_use_addrs_not_vip)
+
+  # a list, e.g [ "backend1:5671", "backend2:5671" ]
+  $rabbitmq_hosts = $_rabbitmq_use_addrs_not_vip ? {
+    false => undef,
+    true  => split(inline_template('<%= @lb_backend_server_addrs.map {
+      |x| x+":"+@amqp_port }.join(",")%>'),",")
+  }
 
   include quickstack::pacemaker::common
   include quickstack::pacemaker::load_balancer


### PR DESCRIPTION
Adds the parameter, $rabbitmq_use_addrs_not_vip to quickstack::pacemaker::params.  If true, openstack config files should reference rabbit backend addresses directly.  If false, use the rabbit VIP and haproxy (same as before).

The  $rabbitmq_use_addrs_not_vip == true case:

    [root@c1a1 ~]# grep -vP '^#' /etc/*/*.conf | grep rabbit_hos
    /etc/ceilometer/ceilometer.conf:rabbit_hosts=192.168.200.10:5672,192.168.200.20:5672,192.168.200.30:5672
    /etc/cinder/cinder.conf:rabbit_hosts=192.168.200.10:5672,192.168.200.20:5672,192.168.200.30:5672
    /etc/glance/glance-api.conf:rabbit_hosts=192.168.200.10:5672,192.168.200.20:5672,192.168.200.30:5672
    /etc/heat/heat.conf:rabbit_hosts=192.168.200.10:5672,192.168.200.20:5672,192.168.200.30:5672
    /etc/keystone/keystone.conf:rabbit_hosts=192.168.200.10:5672,192.168.200.20:5672,192.168.200.30:5672
    /etc/neutron/neutron.conf:rabbit_hosts=192.168.200.10:5672,192.168.200.20:5672,192.168.200.30:5672
    /etc/nova/nova.conf:rabbit_hosts=192.168.200.10:5672,192.168.200.20:5672,192.168.200.30:5672

    [root@c1a1 ~]# grep -vP '^#' /etc/*/*.conf | grep rabbit_ha
    /etc/ceilometer/ceilometer.conf:rabbit_ha_queues=True
    /etc/cinder/cinder.conf:rabbit_ha_queues=True
    /etc/glance/glance-api.conf:rabbit_ha_queues=True
    /etc/heat/heat.conf:rabbit_ha_queues=True
    /etc/keystone/keystone.conf:rabbit_ha_queues=True
    /etc/neutron/neutron.conf:rabbit_ha_queues=True
    /etc/nova/nova.conf:rabbit_ha_queues=True

The  $rabbitmq_use_addrs_not_vip == false case:

    [root@c1a1 ~]# grep -vP '^#' /etc/*/*.conf | grep rabbit_ha
    /etc/ceilometer/ceilometer.conf:rabbit_ha_queues=False
    /etc/cinder/cinder.conf:rabbit_ha_queues=False
    /etc/glance/glance-api.conf:rabbit_ha_queues=False
    /etc/heat/heat.conf:rabbit_ha_queues=False
    /etc/keystone/keystone.conf:rabbit_ha_queues=False
    /etc/neutron/neutron.conf:rabbit_ha_queues=False
    /etc/nova/nova.conf:rabbit_ha_queues=False

    [root@c1a1 ~]# grep -vP '^#' /etc/*/*.conf | grep rabbit_host
    /etc/ceilometer/ceilometer.conf:rabbit_host=192.168.201.13
    /etc/ceilometer/ceilometer.conf:rabbit_hosts=192.168.201.13:5672
    /etc/cinder/cinder.conf:rabbit_host=192.168.201.13
    /etc/cinder/cinder.conf:rabbit_hosts=192.168.201.13:5672
    /etc/glance/glance-api.conf:rabbit_host=192.168.201.13
    /etc/glance/glance-api.conf:rabbit_hosts=192.168.201.13:5672
    /etc/heat/heat.conf:rabbit_host=192.168.201.13
    /etc/heat/heat.conf:rabbit_hosts=192.168.201.13:5672
    /etc/keystone/keystone.conf:rabbit_host=192.168.201.13
    /etc/keystone/keystone.conf:rabbit_hosts=192.168.201.13:5672
    /etc/neutron/neutron.conf:rabbit_host=192.168.201.13
    /etc/neutron/neutron.conf:rabbit_hosts=192.168.201.13:5672
    /etc/nova/nova.conf:rabbit_host=192.168.201.13
    /etc/nova/nova.conf:rabbit_hosts=192.168.201.13:5672
