### PR TITLE
BZ #1170113 - Make A/A neutron network services the default.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -6,7 +6,7 @@ class quickstack::pacemaker::neutron (
   $enable_tunneling           = false,
   $enabled                    = true,
   $external_network_bridge    = '',
-  $l3_ha                      = false,
+  $l3_ha                      = true,
   $ml2_type_drivers           = ['local', 'flat', 'vlan', 'gre', 'vxlan'],
   $ml2_tenant_network_types   = ['vxlan', 'vlan', 'gre', 'flat'],
   $ml2_mechanism_drivers      = ['openvswitch','l2population'],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1170113

No change in functionality, simply changes the default to A/A.