### PR TITLE
BZ #1189921 - More ordering fixes for haproxy/vip constraints.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/constraint/atypical.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraint/atypical.pp
@@ -1,0 +1,25 @@
+# just some syntatic sugar
+
+define quickstack::pacemaker::constraint::atypical(
+  $first_resource  = '',
+  $second_resource = '',
+  $colocation      = true,
+) {
+
+  quickstack::pacemaker::constraint::generic { $title :
+    constraint_type   => "order",
+    first_resource    => $first_resource,
+    second_resource   => $second_resource,
+    first_action      => "start",
+    second_action     => "start",
+    constraint_params => "kind=Optional",
+  }
+
+  if $colocation {
+    Quickstack::Pacemaker::Constraint::Generic[$title] ->
+    quickstack::pacemaker::constraint::colocation { "$title-colo" :
+      source => $first_resource,
+      target => $second_resource,
+    }
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/constraint/generic.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraint/generic.pp
@@ -1,0 +1,39 @@
+define quickstack::pacemaker::constraint::generic (
+  $constraint_type   = "order",
+  $first_resource    = undef,
+  $second_resource   = undef,
+  $first_action      = undef,
+  $second_action     = undef,
+  $score             = undef,
+  $constraint_params = undef,
+  $tries             = '4',
+) {
+  include quickstack::pacemaker::params
+
+  if has_interface_with("ipaddress", map_params("cluster_control_ip")){
+
+    if $constraint_params != undef {
+      $_constraint_params = "${constraint_params}"
+    } else {
+      $_constraint_params = ""
+    }
+
+    $pcs_command = "/usr/sbin/pcs constraint ${constraint_type} ${first_action} ${first_resource} then ${second_action} ${second_resource} ${_constraint_params}"
+
+    anchor { "qpct start $name": }
+    ->
+    # We may need/want to set log level here?
+    notify {"pcs command: ${title}":
+      message => "running: ${pcs_command}",
+    }
+    ->
+    exec {"create ${constraint_type} constraint ${title}":
+      command   => $pcs_command,
+      tries     => $tries,
+      try_sleep => 30,
+      unless    => "/usr/sbin/pcs constraint order show | grep ${first_resource} | grep ${second_resource}"
+    }
+    ->
+    anchor { "qpct end ${title}": }
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/constraint/haproxy_vips.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraint/haproxy_vips.pp
@@ -9,30 +9,30 @@ define quickstack::pacemaker::constraint::haproxy_vips(
   ) {
 
   Quickstack::Pacemaker::Resource::Generic['haproxy'] ->
-  quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-pub-const" :
+  quickstack::pacemaker::constraint::atypical{ "haproxy-${pcmk_group}-pub-const" :
     first_resource  => "ip-${pcmk_group}-pub-${public_vip}",
     second_resource => "haproxy-clone",
   }
   Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-pub"] ->
-  Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-pub-const"]
+  Quickstack::Pacemaker::Constraint::Atypical["haproxy-${pcmk_group}-pub-const"]
 
   if ( $public_vip != $private_vip ) {
     Quickstack::Pacemaker::Resource::Generic['haproxy'] ->
-    quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-prv-const" :
+    quickstack::pacemaker::constraint::atypical{ "haproxy-${pcmk_group}-prv-const" :
       first_resource  => "ip-${pcmk_group}-prv-${private_vip}",
       second_resource => "haproxy-clone",
     }
     Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-prv"] ->
-    Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-prv-const"]
+    Quickstack::Pacemaker::Constraint::Atypical["haproxy-${pcmk_group}-prv-const"]
   }
 
   if ( ($admin_vip != $private_vip) and ($admin_vip != $public_vip) ) {
     Quickstack::Pacemaker::Resource::Generic['haproxy'] ->
-    quickstack::pacemaker::constraint::typical{ "haproxy-${pcmk_group}-adm-const" :
+    quickstack::pacemaker::constraint::atypical{ "haproxy-${pcmk_group}-adm-const" :
       first_resource  => "ip-${pcmk_group}-adm-${admin_vip}",
       second_resource => "haproxy-clone",
     }
     Quickstack::Pacemaker::Resource::Ip["ip-${pcmk_group}-adm"] ->
-    Quickstack::Pacemaker::Constraint::Typical["haproxy-${pcmk_group}-adm-const"]
+    Quickstack::Pacemaker::Constraint::Atypical["haproxy-${pcmk_group}-adm-const"]
   }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1189921

Turns out the colocation for these is set up in the opposite order of every
other one we use, so need to rework how we call these.