### PR TITLE
BZ #1192862 - Glance fails to start with Ceph backend (missing known_sto...

### DIFF
--- a/puppet/modules/quickstack/manifests/glance.pp
+++ b/puppet/modules/quickstack/manifests/glance.pp
@@ -52,6 +52,12 @@ class quickstack::glance (
 
   $_auth_url = "http://${keystone_host}:5000/v2.0"
 
+  if ($backend == 'file') {
+    $_backend = 'filesystem'
+  } else {
+    $_backend = $backend
+  }
+
   $show_image_direct_url = $backend ? {
     'rbd' => true,
     default => false,
@@ -75,6 +81,7 @@ class quickstack::glance (
     keystone_tenant       => 'services',
     keystone_user         => 'glance',
     keystone_password     => $user_password,
+    known_stores          => ["glance.store.${_backend}.Store"],
     sql_connection        => $sql_connection,
     sql_idle_timeout      => $sql_idle_timeout,
     use_syslog            => $use_syslog,


### PR DESCRIPTION
...res).

https://bugzilla.redhat.com/show_bug.cgi?id=1192862

We were not setting a known_store value, which for some backends (like rbd) is
required. We already have correct default_store, but this is needed as well.