### PR TITLE
BZ #1192513 - Open firewall for ceilometer.

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer/control.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer/control.pp
@@ -108,4 +108,6 @@ class quickstack::ceilometer::control(
     command => "sleep $((\$RANDOM % 86400)) &&
                 ${::ceilometer::params::expirer_command}"
   }
+
+  class {'::quickstack::firewall::ceilometer':}
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1192513

We had a firewall rule, but neglected to enable it.