### PR TITLE
bz #1189480 - Rabbitmq cluster remains partitioned after short network p...

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/rabbitmq.pp
@@ -58,7 +58,8 @@ class quickstack::pacemaker::rabbitmq (
                                 {backlog, 128},
                                 {nodelay, true},
                                 {exit_on_close, false},
-                                {keepalive, true}]"
+                                {keepalive, true}]",
+        'cluster_partition_handling' => 'pause_minority'
       },
     }
 


### PR DESCRIPTION
...artition incident

https://bugzilla.redhat.com/show_bug.cgi?id=1189480

Set cluster_partition_handling to pause_minority, to enable the
cluster to auto-recover from partitioning.  Presently, a partitioned
cluster will remain partitioned until an administrator notices and
takes corrective action.