### PR TITLE
BZ #1199266 - Compute nodes should not rely on ceph command.

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -131,13 +131,11 @@ class quickstack::compute_common (
     ->
     exec { 'define-virsh-rbd-secret':
       command => '/usr/bin/virsh secret-define --file /etc/nova/secret.xml',
-      onlyif => "/usr/bin/ceph --connect-timeout 10 auth get-key client.${libvirt_images_rbd_pool} >/dev/null 2>&1",
       creates => '/etc/nova/virsh.secret',
     }
     ->
     exec { 'set-virsh-rbd-secret-key':
-      command => "/usr/bin/virsh secret-set-value --secret ${rbd_secret_uuid} --base64 \$(/usr/bin/ceph auth get-key client.${libvirt_images_rbd_pool})",
-      onlyif => "/usr/bin/ceph --connect-timeout 10 auth get-key client.${libvirt_images_rbd_pool} >/dev/null 2>&1",
+      command => "/usr/bin/virsh secret-set-value --secret ${rbd_secret_uuid} --base64 ${ceph_volumes_key}",
     }
   } else {
     nova_config {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1199266

Use the passed in ceph_volumes_key param instead of calling ceph, remove onlyif
calls to ceph on computes.