### PR TITLE
BZ #1191519 - Set LimitNOFILE for galera.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -1,4 +1,5 @@
 class quickstack::pacemaker::galera (
+  $limit_no_file            ="16384",
   $max_connections         = "1024",
   $mysql_root_password     = '',
   $open_files_limit        = '-1',
@@ -168,7 +169,8 @@ class quickstack::pacemaker::galera (
     }
     ->
     quickstack::pacemaker::resource::galera {'galera':
-      gcomm_addrs => map_params("pcmk_server_names")
+      gcomm_addrs   => map_params("pcmk_server_names"),
+      limit_no_file => $limit_no_file,
     }
     ->
     # one last clustercheck to make sure service is up

--- a/puppet/modules/quickstack/manifests/pacemaker/resource/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/galera.pp
@@ -1,5 +1,7 @@
-define quickstack::pacemaker::resource::galera($timeout     = '300s',
-                                               $gcomm_addrs = [] ) {
+define quickstack::pacemaker::resource::galera( $timeout       = '300s',
+                                                $gcomm_addrs   = [],
+                                                $limit_no_file = '16384',
+) {
   include quickstack::pacemaker::params
 
   if has_interface_with("ipaddress", map_params("cluster_control_ip")){
@@ -9,7 +11,7 @@ define quickstack::pacemaker::resource::galera($timeout     = '300s',
 
     # once pcs verson >= 0.9.116 is available, we can simplify the below command to be a single
     # call to pcs without the "-f"
-    $create_cmd = "/usr/sbin/pcs cluster cib /tmp/galera-ra && /usr/sbin/pcs -f /tmp/galera-ra resource create galera galera enable_creation=true wsrep_cluster_address=\"$gcomm_addresses\" op promote timeout=300s on-fail=block --master meta master-max=3 ordered=true && /usr/sbin/pcs cluster cib-push /tmp/galera-ra"
+    $create_cmd = "/usr/sbin/pcs cluster cib /tmp/galera-ra && /usr/sbin/pcs -f /tmp/galera-ra resource create galera galera additional_parameters='--open-files-limit=${limit_no_file}' enable_creation=true wsrep_cluster_address=\"$gcomm_addresses\" op promote timeout=300s on-fail=block --master meta master-max=3 ordered=true && /usr/sbin/pcs cluster cib-push /tmp/galera-ra"
 
     anchor { "qprs start galera": }
     ->


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1191519

Some services, like nova-conductor or keystone, spawn by default 1 worker per
CPU, and each worker opens its own DB connection. Increasing the number of files
galera is allowed to open improves the ability to adjust deployments to scale to
larger hardware/more CPUs. This will result in less lost connections and greater
overall performance.