### PR TITLE
BZ #1199568 -  [HAProxy] Issues with bootstorms.

### DIFF
--- a/puppet/modules/quickstack/manifests/load_balancer/common.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/common.pp
@@ -13,7 +13,7 @@ class quickstack::load_balancer::common {
       'retries'      => '3',
       'option'       => [ 'tcplog', 'redispatch' ],
       'log'          => '127.0.0.1 local2 warning',
-      'timeout'      => [ 'connect 5s', 'client 30s', 'server 30s' ],
+      'timeout'      => [ 'connect 10s', 'client 60s', 'server 60s'],
     },
   }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1199568

Some default settings needed tweaking to better align with openstack upstream
recommendations, making large numbers of instances launch more consistently.
