### PR TITLE
BZ #1201363 -  Changes in ipmi fencing configuration.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/common.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/common.pp
@@ -36,7 +36,8 @@ class quickstack::pacemaker::common (
   $fence_ipmilan_hostlist         = "",
   $fence_ipmilan_host_to_address  = [],
   $fence_ipmilan_expose_lanplus   = "true",
-  $fence_ipmilan_lanplus_options  = "",
+  $fence_ipmilan_lanplus_options  = "1",
+  $fence_ipmilan_resource_params  = "cipher=1",
   $fence_xvm_port                 = "",
   $fence_xvm_manage_key_file      = "false",
   $fence_xvm_key_file_password    = "",
@@ -101,6 +102,7 @@ class quickstack::pacemaker::common (
       host_to_address => $fence_ipmilan_host_to_address,
       lanplus         => str2bool_i("$fence_ipmilan_expose_lanplus"),
       lanplus_options => $fence_ipmilan_lanplus_options,
+      resource_params => $fence_ipmilan_resource_params,
     }
   }
   elsif $fencing_type =~ /(?i-mx:^fence_xvm$)/ {

--- a/puppet/modules/quickstack/manifests/pacemaker/stonith/ipmilan.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/stonith/ipmilan.pp
@@ -5,8 +5,9 @@ class quickstack::pacemaker::stonith::ipmilan (
   $interval        = "60s",
   $ensure          = "present",
   $lanplus         = false,
-  $lanplus_options = '',
+  $lanplus_options = "",
   $pcmk_host_list  = "",
+  $resource_params = "",
   $host_to_address = [],
   ) {
 
@@ -53,12 +54,16 @@ class quickstack::pacemaker::stonith::ipmilan (
       ''      => '',
       default => "lanplus=\"${lanplus_options}\"",
     }
+    $_resource_params = $resource_params ? {
+      ''      => '',
+      default => "${resource_params}",
+    }
 
     package { "ipmitool":
       ensure => installed,
     } ->
     exec { "Creating stonith::ipmilan":
-      command => "/usr/sbin/pcs stonith create stonith-ipmilan-${real_address} fence_ipmilan ${pcmk_host_list_chunk} ipaddr=${real_address} ${username_chunk} ${password_chunk} ${lanplus_chunk} op monitor interval=${interval}",
+      command => "/usr/sbin/pcs stonith create stonith-ipmilan-${real_address} fence_ipmilan ${pcmk_host_list_chunk} ipaddr=${real_address} ${username_chunk} ${password_chunk} ${lanplus_chunk} ${_resource_params} op monitor interval=${interval}",
       unless  => "/usr/sbin/pcs stonith show stonith-ipmilan-${real_address} > /dev/null 2>&1",
       require => Class['pacemaker::corosync'],
     } ->


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1201363

The cipher parameter may need different values depending on the hardware inuse,
so expose a place to pass that, and other resource parameters in, making this
more flexible to deal with changes.