### PR TITLE
Fixed BZ1179892 Error 400 on SERVER: undefined method `to_a' for "eqlx1"

### DIFF
--- a/puppet/modules/quickstack/lib/puppet/parser/functions/produce_array_with_prefix.rb
+++ b/puppet/modules/quickstack/lib/puppet/parser/functions/produce_array_with_prefix.rb
@@ -18,7 +18,7 @@ EOS
         
        retval = []
        array.each do |i|
-         retval += (prefix+i.to_s).to_a
+         retval += (prefix+i.to_s).lines.to_a
        end
        return retval      
    end


### PR DESCRIPTION
In ruby v1.9 or greater, String no longer has a to_a method.
Older code probably used Ruby v1.8