### PR TITLE
BZ #1197860 - rbd/libvirt secret.xml requires /etc/nova

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -135,6 +135,7 @@ class quickstack::compute_common (
       'DEFAULT/rbd_secret_uuid':              value => $rbd_secret_uuid;
     }
 
+    Package['nova-common'] ->
     # the rest of this if block is borrowed from ::nova::compute::rbd
     # which we can't use due to a duplicate package declaration
     file { '/etc/nova/secret.xml':


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1197860

Make sure the /etc/nova dir exists (created by the
openstack-nova-common rpm) before setting /etc/nova/secret.xml.