### PR TITLE
  BZ #1149563 - Support for configuration of keyboard layout in nova

### DIFF
--- a/puppet/modules/quickstack/manifests/compute_common.pp
+++ b/puppet/modules/quickstack/manifests/compute_common.pp
@@ -59,6 +59,7 @@ class quickstack::compute_common (
   $network_device_mtu           = $quickstack::params::network_device_mtu,
   $ssl                          = $quickstack::params::ssl,
   $verbose                      = $quickstack::params::verbose,
+  $vnc_keymap                   = 'en-us',
 ) inherits quickstack::params {
 
   class {'quickstack::openstack_common': }
@@ -219,6 +220,7 @@ class quickstack::compute_common (
     vncproxy_host                 => $nova_host,
     vncserver_proxyclient_address => $compute_ip,
     network_device_mtu            => $network_device_mtu,
+    vnc_keymap                    => $vnc_keymap,
   }
 
   if str2bool_i("$ceilometer") {

--- a/puppet/modules/quickstack/manifests/neutron/compute.pp
+++ b/puppet/modules/quickstack/manifests/neutron/compute.pp
@@ -70,6 +70,7 @@ class quickstack::neutron::compute (
   $private_network              = '',
   $network_device_mtu           = undef,
   $veth_mtu                     = undef,
+  $vnc_keymap                   = 'en-us',
 ) inherits quickstack::params {
 
   if str2bool_i("$ssl") {
@@ -216,6 +217,7 @@ class quickstack::neutron::compute (
     private_ip                   => $private_ip,
     private_network              => $private_network,
     network_device_mtu           => $network_device_mtu,
+    vnc_keymap                   => $vnc_keymap,
   }
 
   class {'quickstack::neutron::firewall::gre':}

--- a/puppet/modules/quickstack/manifests/nova_network/compute.pp
+++ b/puppet/modules/quickstack/manifests/nova_network/compute.pp
@@ -66,6 +66,7 @@ class quickstack::nova_network::compute (
   $private_ip                   = '',
   $private_network              = '',
   $network_device_mtu           = undef,
+  $vnc_keymap                   = 'en-us',
 ) inherits quickstack::params {
 
   # Configure Nova
@@ -163,5 +164,6 @@ class quickstack::nova_network::compute (
     private_ip                   => $private_ip,
     private_network              => $private_network,
     network_device_mtu           => $network_device_mtu,
+    vnc_keymap                   => $vnc_keymap,
   }
 }


### PR DESCRIPTION
  https://bugzilla.redhat.com/show_bug.cgi?id=1149563

  The change of the vnc_keymap in /etc/nova/nova.conf via GUI is not supported now.
  This fix enables vnc_keymap to be set with GUI.