### PR TITLE
BZ #1195476: Fix non-NFS NetApp deployments

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder_volume.pp
+++ b/puppet/modules/quickstack/manifests/cinder_volume.pp
@@ -123,6 +123,18 @@ class quickstack::cinder_volume(
         eqlx_chap_password => $eqlx_chap_password[0],
       }
     } elsif str2bool_i("$backend_netapp") {
+
+      # If NetApp nfs_shares parameter is empty ([]), set to undef.
+      # Otherwise, it will be interpreted as a real value and interfere with
+      # a non-NFS deployment
+      if ($netapp_nfs_shares[0] == [] or
+          $netapp_nfs_shares[0] == [''] ){
+        $_netapp_nfs_shares_sanitized = undef
+      }
+      else {
+        $_netapp_nfs_shares_sanitized = $netapp_nfs_shares[0]
+      }
+
       class { '::cinder::volume::netapp':
         netapp_server_hostname   => $netapp_hostname[0],
         netapp_login             => $netapp_login[0],
@@ -131,7 +143,7 @@ class quickstack::cinder_volume(
         netapp_storage_family    => $netapp_storage_family[0],
         netapp_transport_type    => $netapp_transport_type[0],
         netapp_storage_protocol  => $netapp_storage_protocol[0],
-        nfs_shares               => $netapp_nfs_shares[0],
+        nfs_shares               => $_netapp_nfs_shares_sanitized,
         nfs_shares_config        => $netapp_nfs_shares_config[0],
         netapp_volume_list       => $netapp_volume_list[0],
         netapp_vfiler            => $netapp_vfiler[0],

--- a/puppet/modules/quickstack/manifests/netapp/volume.pp
+++ b/puppet/modules/quickstack/manifests/netapp/volume.pp
@@ -39,6 +39,16 @@ define quickstack::netapp::volume (
     $netapp_sa_password       = $netapp_sa_password_array[$index]
     $netapp_storage_pools     = $netapp_storage_pools_array[$index]
 
+    # If NetApp nfs_shares parameter is empty ([]), set to undef.
+    # Otherwise, it will be interpreted as a real value and interfere with
+    # a non-NFS deployment
+    if ($netapp_nfs_shares == []){
+      $_netapp_nfs_shares_sanitized = undef
+    }
+    else {
+      $_netapp_nfs_shares_sanitized = $netapp_nfs_shares
+    }
+
     cinder::backend::netapp { $backend_section_name:
       volume_backend_name       => $backend_netapp_name,
       netapp_server_hostname    => $netapp_hostname,
@@ -48,7 +58,7 @@ define quickstack::netapp::volume (
       netapp_storage_family     => $netapp_storage_family,
       netapp_transport_type     => $netapp_transport_type,
       netapp_storage_protocol   => $netapp_storage_protocol,
-      nfs_shares                => $netapp_nfs_shares,
+      nfs_shares                => $_netapp_nfs_shares_sanitized,
       nfs_shares_config         => $netapp_nfs_shares_config,
       netapp_volume_list        => $netapp_volume_list,
       netapp_vfiler             => $netapp_vfiler,


### PR DESCRIPTION
The netapp_nfs_shares parameter is set to [], which is interpreted
as a true value by puppet-cinder.  This causes it to create an
NFS shares file, which causes an error in the deployment.

This fix changes any netapp_nfs_shares values to undef before they
are passed into puppet-cinder.