### PR TITLE
BZ#1204881 Move clone_opts and operation_opts from instance attributes.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -133,9 +133,9 @@ class quickstack::pacemaker::ceilometer (
       "openstack-ceilometer-alarm-evaluator",
       "openstack-ceilometer-alarm-notifier",
       "openstack-ceilometer-notification"]:
-      clone_opts      => "interleave=true",
-      resource_params => 'start-delay=10s',
       #monitor_params  => {'start-delay'     => '10s'},
+      resource_params => "clone interleave=true",
+      operation_opts  => "monitor start-delay=10s",
     }
     ->
     # Delay doesnt support --clone in our version of pcs, just like ocf

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -119,7 +119,8 @@ class quickstack::pacemaker::cinder(
       # $_volume_clone_opts = "interleave=true"
       # $_cinder_volume_resource_name = "cinder-volume-clone"
     } else {
-      $_volume_clone_opts = undef
+      #$_volume_clone_opts = undef
+      $_volume_resource_params = undef
       $_cinder_volume_resource_name = "cinder-volume"
     }
 
@@ -192,12 +193,12 @@ class quickstack::pacemaker::cinder(
       command   => "/tmp/ha-all-in-one-util.bash all_members_include cinder",
     } ->
     quickstack::pacemaker::resource::generic {'cinder-api':
-      clone_opts    => "interleave=true",
       resource_name => "openstack-cinder-api",
+      resource_params => "clone interleave=true",
     } ->
     quickstack::pacemaker::resource::generic {'cinder-scheduler':
-      clone_opts    => "interleave=true",
       resource_name => "openstack-cinder-scheduler",
+      resource_params => "clone interleave=true",
     } ->
     quickstack::pacemaker::constraint::base { 'cinder-api-scheduler-constr' :
       constraint_type => "order",
@@ -284,9 +285,10 @@ class quickstack::pacemaker::cinder(
       quickstack::pacemaker::resource::generic {'cinder-volume':
         # FIXME(jayg): clone only if backend is nfs
         # https://bugs.launchpad.net/cinder/+bug/1322190
-        clone_opts      => $_volume_clone_opts,
         resource_name   => "openstack-cinder-volume",
-        resource_params => 'start-delay=10s',
+        #resource_params => 'start-delay=10s',
+        resource_params => '$_volume_resource_params',
+        operation_opts  => "monitor start-delay=10s",
       }
       ->
       quickstack::pacemaker::constraint::base { 'cinder-scheduler-volume-constr' :

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -159,12 +159,12 @@ class quickstack::pacemaker::glance (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include glance",
     } ->
     quickstack::pacemaker::resource::generic {'glance-registry':
-      clone_opts    => "interleave=true",
       resource_name => "openstack-glance-registry",
+      resource_params => "clone interleave=true",
     } ->
     quickstack::pacemaker::resource::generic {'glance-api':
-      clone_opts    => "interleave=true",
       resource_name => "openstack-glance-api",
+      resource_params => "clone interleave=true",
     }
 
     if str2bool_i("$pcmk_fs_manage") {

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -140,15 +140,15 @@ class quickstack::pacemaker::heat(
     }
     ->
     quickstack::pacemaker::resource::generic {'heat-api':
-      clone_opts      => "interleave=true",
       resource_name   => "openstack-heat-api",
-      resource_params => 'start-delay=10s',
+      resource_params => "clone interleave=true",
+      operation_opts  => "monitor start-delay=10s",
     }
     ->
     quickstack::pacemaker::resource::service {'openstack-heat-engine':
       group => "$heat_group",
       clone => false,
-      options => 'start-delay=10s',
+      monitor_params => { 'start-delay' => '10s' },
       interval => '60s',
     }
 
@@ -166,9 +166,9 @@ class quickstack::pacemaker::heat(
       Quickstack::Pacemaker::Resource::Service['openstack-heat-engine']
       ->
       quickstack::pacemaker::resource::generic {"heat-api-cfn":
-        clone_opts      => "interleave=true",
         resource_name   => "openstack-heat-api-cfn",
-        resource_params => 'start-delay=10s',
+        resource_params => "clone interleave=true",
+        operation_opts  => "monitor start-delay=10s",
       }
       ->
       quickstack::pacemaker::constraint::base { 'heat-api-cfn-constr' :
@@ -190,9 +190,9 @@ class quickstack::pacemaker::heat(
       Quickstack::Pacemaker::Resource::Service['openstack-heat-engine']
       ->
       quickstack::pacemaker::resource::generic {"heat-api-cloudwatch":
-        clone_opts      => "interleave=true",
         resource_name   => "openstack-heat-api-cloudwatch",
-        resource_params => "start-delay=10s",
+        resource_params => "clone interleave=true",
+        operation_opts  => "monitor start-delay=10s",
       }
       if str2bool_i($heat_cfn_enabled) {
         Quickstack::Pacemaker::Resource::Generic['heat-api-cfn'] ->

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -120,10 +120,10 @@ class quickstack::pacemaker::horizon (
     }
     ->
     quickstack::pacemaker::resource::generic {"horizon":
-      clone_opts            => "interleave=true",
       resource_name         => "$::horizon::params::http_service",
-      resource_params       => 'start-delay=10s',
+      resource_params       => 'clone interleave=true',
       #      monitor_params => {'start-delay'     => '20s'},
+      operation_opts  => "monitor start-delay=10s",
     }
   }
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -255,8 +255,8 @@ class quickstack::pacemaker::keystone (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include keystone",
     } ->
     quickstack::pacemaker::resource::generic {'keystone':
-      clone_opts    => "interleave=true",
       resource_name => "openstack-keystone",
+      resource_params => "clone interleave=true",
     }
     ->
     Anchor['pacemaker ordering constraints begin']

--- a/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/load_balancer.pp
@@ -24,7 +24,7 @@ class quickstack::pacemaker::load_balancer {
 
   } ->
   quickstack::pacemaker::resource::generic {'haproxy':
-    clone_opts => "interleave=true",
+    resource_params => "clone interleave=true",
   } ->
   Anchor['pacemaker ordering constraints begin']
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/memcached.pp
@@ -17,7 +17,7 @@ class quickstack::pacemaker::memcached {
     command   => "/tmp/ha-all-in-one-util.bash all_members_include memcached",
   } ->
   quickstack::pacemaker::resource::generic { 'memcached':
-    clone_opts => "interleave=true",
+    resource_params => "clone interleave=true",
   } ->
   Anchor['pacemaker ordering constraints begin']
 }

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -233,7 +233,7 @@ class quickstack::pacemaker::neutron (
     }
     ->
     quickstack::pacemaker::resource::generic {'neutron-server':
-      clone_opts       => "interleave=true",
+      resource_params => "clone interleave=true",
       operation_opts   => "start timeout=90",
       # monitor_params => { 'start-delay'     => '10s' },
     }
@@ -259,22 +259,22 @@ class quickstack::pacemaker::neutron (
     }
     ->
     quickstack::pacemaker::resource::generic {'neutron-openvswitch-agent':
-      clone_opts    => "interleave=true",
+      resource_params => "clone interleave=true",
       #      monitor_params => { 'start-delay' => '10s' },
     }
     ->
     quickstack::pacemaker::resource::generic {'neutron-dhcp-agent':
-      clone_opts    => "interleave=true",
+      resource_params => "clone interleave=true",
       # monitor_params => { 'start-delay' => '10s' },
     }
     ->
     quickstack::pacemaker::resource::generic {'neutron-l3-agent':
-      clone_opts    => "interleave=true",
+      resource_params => "clone interleave=true",
       # monitor_params => { 'start-delay' => '10s' },
     }
     ->
     quickstack::pacemaker::resource::generic {'neutron-metadata-agent':
-      clone_opts    => "interleave=true",
+      resource_params => "clone interleave=true",
       #monitor_params => { 'start-delay' => '10s' },
     }
     ->

--- a/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nosql.pp
@@ -92,7 +92,7 @@ class quickstack::pacemaker::nosql (
     Exec['all-nosql-nodes-are-up'] ->
 
     quickstack::pacemaker::resource::service {'mongod':
-      options        => 'start timeout=10s',
+      options        => 'op start timeout=10s',
       monitor_params => { 'start-delay' => '10s' },
       clone          => true,
     } ->

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -47,10 +47,12 @@ class quickstack::pacemaker::nova (
     }
 
     if ($scheduler_host_subset_size == '1') {
-      $sched_clone = ""
+      #$sched_clone = ""
+      $sched_resource_params = ""
       $_nova_scheduler_resource = "openstack-nova-scheduler"
     } else {
-      $sched_clone = "interleave=true"
+      #$sched_clone = "interleave=true"
+      $sched_resource_params = "clone interleave=true"
       $_nova_scheduler_resource = "openstack-nova-scheduler-clone"
     }
 
@@ -127,13 +129,13 @@ class quickstack::pacemaker::nova (
                               'openstack-nova-novncproxy',
                               'openstack-nova-api',
                               'openstack-nova-conductor' ]:
-      clone_opts      => "interleave=true",
-      resource_params => 'start-delay=10s',
+      resource_params => 'clone interleave=true',
+      operation_opts  => "monitor start-delay=10s",
     }
     ->
     quickstack::pacemaker::resource::generic {'openstack-nova-scheduler':
-      clone_opts      => $sched_clone,
-      resource_params => 'start-delay=10s',
+      resource_params => $sched_resource_params,
+      operation_opts  => "monitor start-delay=10s",
     }
     ->
     quickstack::pacemaker::constraint::base { 'nova-console-vnc-constr' :

--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -93,8 +93,8 @@ class quickstack::pacemaker::swift (
       command   => "/tmp/ha-all-in-one-util.bash all_members_include swift",
     } ->
     quickstack::pacemaker::resource::generic {'swift-proxy':
-      clone_opts    => "interleave=true",
       resource_name => "openstack-swift-proxy",
+      resource_params => "clone interleave=true",
     } ->
     quickstack::pacemaker::resource::service {'openstack-swift-object-expirer':
       group => "$swift_group",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1204881

Due to known issues with pcs in 7.0 clone_opts and operation_opts would
become instance attributes and thus not work as expected. The following
changes are made to ensure this does not happen :

`interleave=true` is now set as a clone option.
`start-delay=` is now set as a operation parameter.
`start timeout=` is also set as a operation parameter.

Signed-off-by: Lee Yarwood lyarwood@redhat.com
Co-Authored-By: John Ruemker jruemker@redhat.com
