### PR TITLE
BZ #1180158: Ceilometer workload partitioning with tooz & redis

### DIFF
--- a/puppet/modules/quickstack/manifests/ceilometer/control.pp
+++ b/puppet/modules/quickstack/manifests/ceilometer/control.pp
@@ -18,6 +18,7 @@ class quickstack::ceilometer::control(
   $service_enable             = true,
   $service_ensure             = 'running',
   $verbose                    = false,
+  $coordination_url           = undef,
 ) {
 
   validate_array($db_hosts)
@@ -71,8 +72,9 @@ class quickstack::ceilometer::control(
   }
 
   class { '::ceilometer::agent::central':
-    enabled        => $service_enable,
-    manage_service => $service_enable,
+    enabled          => $service_enable,
+    manage_service   => $service_enable,
+    coordination_url => $coordination_url,
   }
 
   class { '::ceilometer::alarm::notifier':
@@ -81,8 +83,9 @@ class quickstack::ceilometer::control(
   }
 
   class { '::ceilometer::alarm::evaluator':
-    enabled        => $service_enable,
-    manage_service => $service_enable,
+    enabled          => $service_enable,
+    manage_service   => $service_enable,
+    coordination_url => $coordination_url,
   }
 
   class { '::ceilometer::api':

--- a/puppet/modules/quickstack/manifests/db/redis.pp
+++ b/puppet/modules/quickstack/manifests/db/redis.pp
@@ -1,0 +1,31 @@
+# == Class: quickstack::db::redis
+#
+# Install redis
+#
+# === Parameters:
+#
+# [*bind_host*]
+#   (optional) Configure which IP address to listen on.
+#   Defaults to '127.0.0.1'
+#
+# [*port*]
+#   (optional) Configure which port to listen on.
+#   Defaults to '6379'
+#
+
+
+class quickstack::db::redis(
+  $bind_host             = '127.0.0.1',
+  $port                  = '6379',
+  $slaveof               = undef,
+) {
+
+  class { '::redis':
+    bind       => $bind_host,
+    port       => $port,
+    appendonly => true,
+    daemonize  => false,
+    slaveof    => $slaveof,
+  }
+
+}

--- a/puppet/modules/quickstack/manifests/firewall/redis.pp
+++ b/puppet/modules/quickstack/manifests/firewall/redis.pp
@@ -1,0 +1,12 @@
+class quickstack::firewall::redis(
+  $ports = ['6379'],
+) {
+
+  include quickstack::firewall::common
+
+  firewall { '001 redis incoming':
+    proto  => 'tcp',
+    dport  => $ports,
+    action => 'accept',
+  }
+}

--- a/puppet/modules/quickstack/manifests/pacemaker/params.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/params.pp
@@ -110,6 +110,8 @@ class quickstack::pacemaker::params (
   $swift_public_vip             = '',
   $swift_user_password          = '',
   $swift_group                  = 'swift',
+  $redis_group                  = 'redis',
+  $redis_vip                    = '',
 ) {
   $local_bind_addr = find_ip("$private_network",
                             "$private_iface",

--- a/puppet/modules/quickstack/manifests/pacemaker/redis.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/redis.pp
@@ -1,0 +1,38 @@
+class quickstack::pacemaker::redis(
+  $bind_host             = '127.0.0.1',
+  $port                  = '6379',
+  $slaveof               = undef,
+) {
+
+  $redis_group = map_params("redis_group")
+
+  class {'::quickstack::firewall::redis':
+    ports => [$port],
+  }
+
+  class {'::quickstack::db::redis':
+    bind_host => $bind_host,
+    port      => $port,
+    slaveof   => $slaveof,
+  }
+
+  quickstack::pacemaker::resource::generic {'redis':
+    resource_name => "redis",
+    resource_params => "wait_last_known_master=true --master meta notify=true ordered=true interleave=true",
+  } ->
+
+  quickstack::pacemaker::vips { $redis_group:
+      public_vip   => map_params('redis_vip'),
+      private_vip  => map_params('redis_vip'),
+      admin_vip    => map_params('redis_vip'),
+    } ->
+
+  exec {"pcs-constraint-order":
+      command => "/usr/sbin/pcs constraint order promote redis-master then start vip-redis",
+  } ->
+
+  exec {"pcs-constraint-colocation":
+      command => "/usr/sbin/pcs colocation add vip-redis with master redis-master",
+  }
+
+}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1180158

The quickstack::pacemaker:ceilometer puppet class now allows
redis to be specified as the backend for tooz, to be used for
workload partitioning in the ceilometer central agent and
alarm evaluator.

Also adds support for redis resource agents via pacemaker.
This essentially replaces the redis sentinel implemented in
earlier patches. The resource agent is implemented based on
https://github.com/davidvossel/phd/blob/master/scenarios/redis-active-passive.scenario#L37-L40