### PR TITLE
BZ #1209628 - Constraint error on netns and ovs-cleanup.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -210,15 +210,15 @@ class quickstack::pacemaker::neutron (
     ->
     quickstack::pacemaker::constraint::base { 'neutron-ovs-to-netns-cleanup-constr' :
       constraint_type => "order",
-      first_resource  => "neutron-ovs-cleanup",
-      second_resource => "neutron-netns-cleanup",
+      first_resource  => "neutron-ovs-cleanup-clone",
+      second_resource => "neutron-netns-cleanup-clone",
       first_action    => "start",
       second_action   => "start",
     }
     ->
     quickstack::pacemaker::constraint::base { 'neutron-cleanup-to-agents-constr' :
       constraint_type => "order",
-      first_resource  => "neutron-netns-cleanup",
+      first_resource  => "neutron-netns-cleanup-clone",
       second_resource => "neutron-agents",
       first_action    => "start",
       second_action   => "start",
@@ -267,14 +267,14 @@ class quickstack::pacemaker::neutron (
     }
     ->
     quickstack::pacemaker::constraint::colocation { 'neutron-netns-ovs-cleanup-colo' :
-      source => "neutron-netns-cleanup",
-      target => "neutron-ovs-cleanup",
+      source => "neutron-netns-cleanup-clone",
+      target => "neutron-ovs-cleanup-clone",
       score  => "INFINITY",
     }
     ->
     quickstack::pacemaker::constraint::colocation { 'neutron-agents-with-netns-cleanup-colo' :
       source => "neutron-agents",
-      target => "neutron-netns-cleanup",
+      target => "neutron-netns-cleanup-clone",
       score  => "INFINITY",
     }
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1209628

Previously, setting this constraint would cause a puppet error because these
two contraints are on cloned resources, but the referenced names did not include
the '-clone'.