### PR TITLE
BZ #1209099 -  Set l2_pop correctly for ovs on control nodes.

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/all.pp
+++ b/puppet/modules/quickstack/manifests/neutron/all.pp
@@ -240,6 +240,13 @@ class quickstack::neutron::all (
                       "")
     }
 
+    if str2bool_i("$l3_ha") {
+      $_ovs_l2_population = 'False'
+    } else {
+      $_ovs_l2_population = 'True'
+    }
+    neutron_plugin_ovs {'AGENT/l2_population': value => "$_ovs_l2_population"; }
+
     class { '::neutron::agents::ovs':
       bridge_mappings  => $ovs_bridge_mappings,
       bridge_uplinks   => $ovs_bridge_uplinks,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1209099

l2_population should be set to True in ovs_neutron_plugin.ini
on control nodes when l2pop is ON.