### PR TITLE
BZ#1210303 Expose cpu and ram allocation ratio

### DIFF
--- a/puppet/modules/quickstack/manifests/nova.pp
+++ b/puppet/modules/quickstack/manifests/nova.pp
@@ -34,6 +34,10 @@
 #   (optional) Address to bind api service to.
 #   Defaults to  '0.0.0.0'.
 #
+# [*cpu_allocation_ratio*]
+#   (optional) CPU allocation ratio.
+#   Defaults to '16'.
+#
 # [*db_host*]
 #   (optional) Nova's database host.
 #   Defaults to 'localhost'.
@@ -95,6 +99,10 @@
 #   (optional) Seconds between connection keepalive heartbeats
 #   Defaults to '60'.
 #
+# [*ram_allocation_ratio*]
+#   (optional) RAM allocation ratio.
+#   Defaults to '1.5'.
+#
 # [*rpc_backend*]
 #   (optional) The rpc backend implementation to use.
 #   Defaults to 'nova.openstack.common.rpc.impl_kombu'.
@@ -136,6 +144,8 @@ class quickstack::nova (
   $qpid_heartbeat               = '60',
   $rpc_backend                  = 'nova.openstack.common.rpc.impl_kombu',
   $scheduler_host_subset_size   = '1',
+  $ram_allocation_ratio         = '1.5',
+  $cpu_allocation_ratio         = '16',
   $verbose                      = 'false',
 ) {
 
@@ -212,6 +222,8 @@ class quickstack::nova (
     }
     class {'::nova::scheduler::filter':
       scheduler_host_subset_size => $scheduler_host_subset_size,
+      ram_allocation_ratio       =>  $ram_allocation_ratio,
+      cpu_allocation_ratio       =>  $cpu_allocation_ratio,  
     }
     class {'::nova::cert':
       enabled => str2bool_i("$enabled"),

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -11,6 +11,8 @@ class quickstack::pacemaker::nova (
   $qpid_heartbeat             = '60',
   $rpc_backend                = 'nova.openstack.common.rpc.impl_kombu',
   $scheduler_host_subset_size = '30',
+  $ram_allocation_ratio         = '1.5',
+  $cpu_allocation_ratio         = '16',
   $verbose                    = 'false',
 ) {
 
@@ -107,6 +109,8 @@ class quickstack::pacemaker::nova (
       rabbit_hosts                  => map_params("rabbitmq_hosts"),
       rpc_backend                   => amqp_backend('nova', map_params('amqp_provider')),
       scheduler_host_subset_size    => $scheduler_host_subset_size,
+      ram_allocation_ratio          => $ram_allocation_ratio,
+      cpu_allocation_ratio          => $cpu_allocation_ratio,
       verbose                       => $verbose,
     }
     ->


### PR DESCRIPTION
This makes it possible to change cpu and ram allocation ratio in the nova::scheduler::filter class from the quickstack::nova class (and thus from the rhel-osp-installer GUI)