### PR TITLE
Fix Multi-Backend NetApp Deployment

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder_volume.pp
+++ b/puppet/modules/quickstack/manifests/cinder_volume.pp
@@ -132,7 +132,7 @@ class quickstack::cinder_volume(
         $_netapp_nfs_shares_sanitized = undef
       }
       else {
-        $_netapp_nfs_shares_sanitized = $netapp_nfs_shares[0]
+        $_netapp_nfs_shares_sanitized = split($netapp_nfs_shares[0][0], ',')
       }
 
       class { '::cinder::volume::netapp':
@@ -246,13 +246,11 @@ class quickstack::cinder_volume(
     if str2bool_i("$backend_netapp") {
 
       $count = size($backend_netapp_name)
-      $last = $count -1
-      $netapp_backends = produce_array_with_prefix("netapp",1,$count)  #Initialize with section headers
+      $last = $count - 1
 
       # FIXME: with newer parser we should use `each` (with index) instead
       quickstack::netapp::volume { $last:
         index => $last,
-        backend_section_name_array     => $netapp_backends,
         backend_netapp_name_array      => $backend_netapp_name,
         netapp_hostname_array          => $netapp_hostname,
         netapp_login_array             => $netapp_login,
@@ -303,7 +301,7 @@ class quickstack::cinder_volume(
       'glusterfs_backends',
       'nfs_backends',
       'eqlx_backends',
-      'netapp_backends',
+      'backend_netapp_name',
       'rbd_backends',
       'iscsi_backends')
     if $enabled_backends == [] {

--- a/puppet/modules/quickstack/manifests/netapp/volume.pp
+++ b/puppet/modules/quickstack/manifests/netapp/volume.pp
@@ -1,6 +1,5 @@
 define quickstack::netapp::volume (
   $index,
-  $backend_section_name_array,
   $backend_netapp_name_array,
   $netapp_hostname_array,
   $netapp_login_array,
@@ -21,7 +20,6 @@ define quickstack::netapp::volume (
 
   if($index >= 0)
   {
-    $backend_section_name     = $backend_section_name_array[$index]
     $backend_netapp_name      = $backend_netapp_name_array[$index]
     $netapp_hostname          = $netapp_hostname_array[$index]
     $netapp_login             = $netapp_login_array[$index]
@@ -46,11 +44,10 @@ define quickstack::netapp::volume (
       $_netapp_nfs_shares_sanitized = undef
     }
     else {
-      $_netapp_nfs_shares_sanitized = $netapp_nfs_shares
+      $_netapp_nfs_shares_sanitized = split($netapp_nfs_shares, ',')
     }
 
-    cinder::backend::netapp { $backend_section_name:
-      volume_backend_name       => $backend_netapp_name,
+    cinder::backend::netapp { $backend_netapp_name:
       netapp_server_hostname    => $netapp_hostname,
       netapp_login              => $netapp_login,
       netapp_password           => $netapp_password,
@@ -72,7 +69,6 @@ define quickstack::netapp::volume (
     $next = $index -1
     quickstack::netapp::volume {$next:
       index => $next,
-      backend_section_name_array      => $backend_section_name_array,
       backend_netapp_name_array       => $backend_netapp_name_array,
       netapp_hostname_array           => $netapp_hostname_array,
       netapp_login_array              => $netapp_login_array,

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -123,6 +123,11 @@ class quickstack::pacemaker::cinder(
       $_cinder_volume_resource_name = "cinder-volume"
     }
 
+    if (str2bool_i("$backend_netapp")) {
+      $_netapp_backend_count = size($netapp_hostname)
+      $_backend_netapp_name = produce_array_with_prefix("netapp", 1, $_netapp_backend_count)
+    }
+
     class {"::quickstack::load_balancer::cinder":
       frontend_pub_host    => map_params("cinder_public_vip"),
       frontend_priv_host   => map_params("cinder_private_vip"),
@@ -228,7 +233,7 @@ class quickstack::pacemaker::cinder(
         backend_iscsi          => $backend_iscsi,
         backend_iscsi_name     => $backend_iscsi_name,
         backend_netapp         => $backend_netapp,
-        backend_netapp_name    => $backend_netapp_name,
+        backend_netapp_name    => $_backend_netapp_name,
         backend_nfs            => $backend_nfs,
         backend_nfs_name       => $backend_nfs_name,
         backend_eqlx           => $backend_eqlx,
@@ -313,7 +318,7 @@ class quickstack::pacemaker::cinder(
         backend_iscsi          => $backend_iscsi,
         backend_iscsi_name     => $backend_iscsi_name,
         backend_netapp         => $backend_netapp,
-        backend_netapp_name    => $backend_netapp_name,
+        backend_netapp_name    => $_backend_netapp_name,
         backend_nfs            => $backend_nfs,
         backend_nfs_name       => $backend_nfs_name,
         backend_eqlx           => $backend_eqlx,

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -39,7 +39,6 @@ class quickstack::params (
   $cinder_backend_eqlx          = false,
   $cinder_backend_eqlx_name     = ['eqlx'],
   $cinder_backend_netapp        = false,
-  $cinder_backend_netapp_name   = ['netapp'],
   $cinder_multiple_backends     = false,
   $cinder_backend_rbd           = false,
   $cinder_backend_rbd_name      = 'rbd',
@@ -78,6 +77,7 @@ class quickstack::params (
   $cinder_netapp_controller_ips    = ['192.168.1.3'],
   $cinder_netapp_sa_password       = ['CHANGEME'],
   $cinder_netapp_storage_pools     = ['pool1'],
+  $cinder_backend_netapp_name      = produce_array_with_prefix("netapp", 1, size($cinder_netapp_hostname)),
   #  Cinder RBD
   $cinder_rbd_pool              = 'volumes',
   $cinder_rbd_ceph_conf         = '/etc/ceph/ceph.conf',


### PR DESCRIPTION
Currently, the $netapp_backend_name is not being overridden from its default
value of ['netapp']. This variable determines the cinder.conf backend
stanza names and it used in determining how many backends have been defined.

This causes resulting multi-backend deployments to have a cinder.conf stanza
of 'netapp' (even though 'enabled_backends=netapp1') as well as only including
the first defined backend:

In /etc/cinder/cinder.conf:
enabled_backends=netapp1
...
[netapp]
thres_avl_size_perc_start=20
...

This patch dynamically creates $backend_netapp_name as an array such as:
['netapp1', 'netapp2', 'netapp3'].