### PR TITLE
BZ1211080 horizon ssl termination

### DIFF
--- a/puppet/modules/quickstack/lib/facter/haproxy_cert_exist.rb
+++ b/puppet/modules/quickstack/lib/facter/haproxy_cert_exist.rb
@@ -1,0 +1,5 @@
+if FileTest.file?("/etc/ssl/horizon.pem")
+    Facter.add(:haproxy_cert_exist) do
+        setcode { true }
+    end
+end

--- a/puppet/modules/quickstack/manifests/load_balancer/horizon.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/horizon.pp
@@ -1,29 +1,69 @@
 class quickstack::load_balancer::horizon (
-  $frontend_pub_host,
-  $frontend_priv_host,
-  $frontend_admin_host,
-  $backend_server_names,
-  $backend_server_addrs,
-  $port = '80',
-  $mode = 'http',
-  $log = 'httplog',
+ $frontend_pub_host,
+ $frontend_priv_host,
+ $frontend_admin_host,
+ $backend_server_names,
+ $backend_server_addrs,
+ $backend_port = '80',
+ $mode = 'http',
+ $option = 'httplog'
 ) {
 
-  include quickstack::load_balancer::common
+ include quickstack::load_balancer::common
 
-  quickstack::load_balancer::proxy { 'horizon':
+  if str2bool("$::haproxy_cert_exist") {
+    quickstack::load_balancer::proxy { 'horizon':
     addr                 => [ $frontend_pub_host,
                               $frontend_priv_host,
                               $frontend_admin_host ],
-    port           => "$port",
-    mode           => "$mode",
+
+    port           => "443 ssl crt /etc/ssl/horizon.pem",
+    mode           => $mode,
     listen_options => {
-      'option'     => [ "$log" ],
+      'option'     => [ $option ],
       'cookie'     => 'SERVERID insert indirect nocache',
     },
     member_options       => [ 'check inter 1s' ],
     define_cookies       => true,
+    backend_port         => $backend_port,
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,
+    }
+
+    quickstack::load_balancer::proxy { 'horizon_http':
+    addr                 => [ $frontend_pub_host,
+                              $frontend_priv_host,
+                              $frontend_admin_host ],
+    port           => "80",
+    mode           => $mode,
+    listen_options => {
+      'option'     => [ $option ],
+      'reqadd'     => 'X-Forwarded-Proto:\ http',
+      'redirect'   => 'scheme https if !{ ssl_fc }',
+    },
+    member_options       => [ 'check inter 1s' ],
+    define_cookies       => true,
+    backend_port         => $backend_port,
+    backend_server_addrs => undef,
+    backend_server_names => undef,
+    }
+  }
+
+  else {
+   quickstack::load_balancer::proxy { 'horizon':
+   addr                 => [ $frontend_pub_host,
+                             $frontend_priv_host,
+                             $frontend_admin_host ],
+   port           => "80",
+   mode           => "$mode",
+   listen_options => {
+     'option'     => [ "$option" ],
+     'cookie'     => 'SERVERID insert indirect nocache',
+   },
+   member_options       => [ 'check inter 1s' ],
+   define_cookies       => true,
+   backend_server_addrs => $backend_server_addrs,
+   backend_server_names => $backend_server_names,
+   }
   }
 }


### PR DESCRIPTION
This patch will enable SSL termination at the load balancer if the file /etc/ssl/horizon.pem exists.