### PR TITLE
NetApp | Check if nfs_shares parameter is array or string

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder_volume.pp
+++ b/puppet/modules/quickstack/manifests/cinder_volume.pp
@@ -131,8 +131,11 @@ class quickstack::cinder_volume(
           $netapp_nfs_shares[0] == [''] ){
         $_netapp_nfs_shares_sanitized = undef
       }
+      elsif is_string($netapp_nfs_shares[0]) {
+        $_netapp_nfs_shares_sanitized = split($netapp_nfs_shares[0], ',')
+      }
       else {
-        $_netapp_nfs_shares_sanitized = split($netapp_nfs_shares[0][0], ',')
+        $_netapp_nfs_shares_sanitized = $netapp_nfs_shares[0]
       }
 
       class { '::cinder::volume::netapp':

--- a/puppet/modules/quickstack/manifests/netapp/volume.pp
+++ b/puppet/modules/quickstack/manifests/netapp/volume.pp
@@ -40,11 +40,15 @@ define quickstack::netapp::volume (
     # If NetApp nfs_shares parameter is empty ([]), set to undef.
     # Otherwise, it will be interpreted as a real value and interfere with
     # a non-NFS deployment
-    if ($netapp_nfs_shares == []){
+    if ($netapp_nfs_shares == [] or
+        $netapp_nfs_shares == [''] ){
       $_netapp_nfs_shares_sanitized = undef
     }
-    else {
+    elsif is_string($netapp_nfs_shares) {
       $_netapp_nfs_shares_sanitized = split($netapp_nfs_shares, ',')
+    }
+    else {
+      $_netapp_nfs_shares_sanitized = $netapp_nfs_shares
     }
 
     cinder::backend::netapp { $backend_netapp_name:


### PR DESCRIPTION
If the nfs_shares parameter is passed in as a string,
split it by comma and pass the array onto puppet-cinder.
If the parameter is already passed in as an array, just
pass it through