### PR TITLE
puppet-keystone now requires tenant/password for identity_service.

### DIFF
--- a/puppet/modules/quickstack/manifests/keystone/endpoints.pp
+++ b/puppet/modules/quickstack/manifests/keystone/endpoints.pp
@@ -261,6 +261,8 @@ class quickstack::keystone::endpoints (
       internal_url => "http://${internal_real}:5000/v2.0",
       region       => $region,
       service_type => 'identity',
+      password     => $admin_password,
+      tenant       => $admin_tenant,
     }
 
     # Configure Glance endpoint in Keystone


### PR DESCRIPTION
As of the following commit in puppet-keystone:

4f5eba30d56eade6d517b1ff66b721a894aaff7d Restructures authentication for resource providers

We must pass tenant and password to avoid a puppet error.