### PR TITLE
More robust setting of pcs properties.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/ceilometer.pp
@@ -141,7 +141,7 @@ class quickstack::pacemaker::ceilometer (
     }
     ->
     exec {"pcs-ceilometer-server-set-up":
-      command => "/usr/sbin/pcs property set ceilometer=running --force",
+      command => "/tmp/ha-all-in-one-util.bash set_property ceilometer running",
     }
     ->
     exec {"pcs-ceilometer-server-set-up-on-this-node":

--- a/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/cinder.pp
@@ -200,7 +200,7 @@ class quickstack::pacemaker::cinder(
     Service[openstack-cinder-api] ->
     Service[openstack-cinder-scheduler] ->
     exec {"pcs-cinder-server-set-up":
-      command => "/usr/sbin/pcs property set cinder=running --force",
+      command => "/tmp/ha-all-in-one-util.bash set_property cinder running",
     } ->
     exec {"pcs-cinder-server-set-up-on-this-node":
       command => "/tmp/ha-all-in-one-util.bash update_my_node_property cinder"

--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -20,16 +20,6 @@ class quickstack::pacemaker::galera (
   if (str2bool_i(map_params('include_mysql'))) {
     $galera_vip = map_params("db_vip")
 
-    # TODO: extract this into a helper function
-    if ($::pcs_setup_galera ==  undef or
-        !str2bool_i("$::pcs_setup_galera")) {
-      $_enabled = true
-      $_ensure = 'running'
-    } else {
-      $_enabled = false
-      $_ensure = undef
-    }
-
     # defined for galera.cnf template
     $wsrep_provider         = '/usr/lib64/galera/libgalera_smm.so'
     $wsrep_bind_address     = map_params("pcmk_bind_addr")
@@ -73,7 +63,7 @@ class quickstack::pacemaker::galera (
         command   => "/usr/sbin/pcs resource show haproxy-clone",
       } ->
       exec{'disable haproxy during init mysql setup':
-        # it's ok to run this on all nodes, additional calls are no-ops        
+        # it's ok to run this on all nodes, additional calls are no-ops
         command => '/usr/sbin/pcs resource disable haproxy'
       } ->
       class { 'mysql::server':
@@ -142,11 +132,11 @@ class quickstack::pacemaker::galera (
       ->
       Exec['pcs-mysqlinit-server-setup']
       Mysql_grant <| |> -> Exec["pcs-mysqlinit-server-setup"]
-      
+
       Exec["all-mysqlinit-nodes-are-up"] ->
       Exec['galera-online-cmd'] ->
       exec{'enable haproxy after galera-online':
-        # it's ok to run this on all nodes, additional calls are no-ops        
+        # it's ok to run this on all nodes, additional calls are no-ops
         command => '/usr/sbin/pcs resource enable haproxy'
       } ->
       Anchor['galera-online']
@@ -170,9 +160,6 @@ class quickstack::pacemaker::galera (
     }
 
     exec {"pcs-mysqlinit-server-setup":
-      command => "/usr/sbin/pcs property set mysqlinit=running --force",
-    } ->
-    exec {"pcs-mysqlinit-server-set-up-on-this-node":
       command => "/tmp/ha-all-in-one-util.bash update_my_node_property mysqlinit"
     } ->
     exec {"all-mysqlinit-nodes-are-up":

--- a/puppet/modules/quickstack/manifests/pacemaker/glance.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/glance.pp
@@ -147,7 +147,7 @@ class quickstack::pacemaker::glance (
     }
     ->
     exec {"pcs-glance-server-set-up":
-      command => "/usr/sbin/pcs property set glance=running --force",
+      command => "/tmp/ha-all-in-one-util.bash set_property glance running",
     } ->
     exec {"pcs-glance-server-set-up-on-this-node":
       command => "/tmp/ha-all-in-one-util.bash update_my_node_property glance"

--- a/puppet/modules/quickstack/manifests/pacemaker/heat.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/heat.pp
@@ -125,7 +125,7 @@ class quickstack::pacemaker::heat(
     }
     ->
     exec {"pcs-heat-server-set-up":
-      command => "/usr/sbin/pcs property set heat=running --force",
+      command => "/tmp/ha-all-in-one-util.bash set_property heat running",
     }
     ->
     exec {"pcs-heat-server-set-up-on-this-node":

--- a/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/horizon.pp
@@ -105,7 +105,7 @@ class quickstack::pacemaker::horizon (
     Service['httpd']
     ->
     exec {"pcs-horizon-server-set-up":
-      command => "/usr/sbin/pcs property set horizon=running --force",
+      command => "/tmp/ha-all-in-one-util.bash set_property horizon running",
     }
     ->
     exec {"pcs-horizon-server-set-up-on-this-node":

--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -245,7 +245,7 @@ class quickstack::pacemaker::keystone (
       keystone_private_vip => map_params("keystone_private_vip"),
     } ->
     exec {"pcs-keystone-server-set-up":
-      command => "/usr/sbin/pcs property set keystone=running --force",
+      command => "/tmp/ha-all-in-one-util.bash set_property keystone running",
     } ->
     exec {"pcs-keystone-server-set-up-on-this-node":
       command => "/tmp/ha-all-in-one-util.bash update_my_node_property keystone"

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -220,7 +220,7 @@ class quickstack::pacemaker::neutron (
     anchor {"neutron configuration anchor end": }
     ->
     exec {"pcs-neutron-server-set-up":
-      command => "/usr/sbin/pcs property set neutron=running --force",
+      command => "/tmp/ha-all-in-one-util.bash set_property neutron running",
     } ->
     exec {"pcs-neutron-server-set-up-on-this-node":
       command => "/tmp/ha-all-in-one-util.bash update_my_node_property neutron"

--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -107,7 +107,7 @@ class quickstack::pacemaker::nova (
     }
     ->
     exec {"pcs-nova-server-set-up":
-      command => "/usr/sbin/pcs property set nova=running --force",
+      command => "/tmp/ha-all-in-one-util.bash set_property nova running",
     } ->
     exec {"pcs-nova-server-set-up-on-this-node":
       command => "/tmp/ha-all-in-one-util.bash update_my_node_property nova"

--- a/puppet/modules/quickstack/manifests/pacemaker/swift.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/swift.pp
@@ -84,7 +84,7 @@ class quickstack::pacemaker::swift (
       command => "/usr/sbin/pcs property set swift=running --force",
     } ->
     exec {"pcs-swift-server-set-up-on-this-node":
-      command => "/tmp/ha-all-in-one-util.bash update_my_node_property swift"
+      command => "/tmp/ha-all-in-one-util.bash set_property swift running",
     } ->
     exec {"all-swift-nodes-are-up":
       timeout   => 3600,

--- a/puppet/modules/quickstack/templates/ha-all-in-one-util.erb
+++ b/puppet/modules/quickstack/templates/ha-all-in-one-util.erb
@@ -24,6 +24,23 @@ property_exists() {
 get_property_value() {
   echo $(get_property $1) | /bin/grep $1 | perl -p -e 's/^.*\: //'
 }
+property_value_is() {
+  property=$1
+  element=$2
+  property_exists $1 || return 1
+  propval=$(get_property_value $1)
+  [ "x$propval" = "x$element" ]
+}
+set_property_verified() {
+  property=$1
+  value=$2
+  property_value_is $property $value
+  while [ $? -ne 0 ]; do
+    /usr/sbin/pcs property set $property=$value --force
+    sleep 1
+    property_value_is $property $value
+  done
+}
 
 property_includes() {
   propval=$(get_property_value $1)
@@ -122,6 +139,10 @@ case "$1" in
      ;;
   "all_members_include")
      all_members_include $2
+     ;;
+  # any pcs property (so not a "node property" sub command)
+  "set_property")
+     set_property_verified $2 $3
      ;;
   "info")
      info


### PR DESCRIPTION
Once in a great while, setting a pcs property seems to succeed (according to the exit code of pcs) but doesn't "take" across the cluster.  This patch works around that by verifying the property was set with an additional pcs query and retrying if need be.

Puppet output includes:

    Debug: Exec[pcs-keystone-server-set-up](provider=posix): Executing '/tmp/ha-all-in-one-util.bash set_property keystone running'
    Debug: Exec[pcs-glance-server-set-up](provider=posix): Executing '/tmp/ha-all-in-one-util.bash set_property glance running'
    Debug: Exec[pcs-nova-server-set-up](provider=posix): Executing '/tmp/ha-all-in-one-util.bash set_property nova running'
    Debug: Exec[pcs-cinder-server-set-up](provider=posix): Executing '/tmp/ha-all-in-one-util.bash set_property cinder running'
    Debug: Exec[pcs-neutron-server-set-up](provider=posix): Executing '/tmp/ha-all-in-one-util.bash set_property neutron running'
    Debug: Exec[pcs-heat-server-set-up](provider=posix): Executing '/tmp/ha-all-in-one-util.bash set_property heat running'
    Debug: Exec[pcs-horizon-server-set-up](provider=posix): Executing '/tmp/ha-all-in-one-util.bash set_property horizon running'
    Debug: Exec[pcs-ceilometer-server-set-up](provider=posix): Executing '/tmp/ha-all-in-one-util.bash set_property ceilometer running'

Pacemaker properties show as expected:

    # pcs property show
    Cluster Properties:
     ceilometer: running
     cinder: running
     cluster-infrastructure: corosync
     cluster-name: openstackHA
     dc-version: 1.1.12-a14efad
     glance: running
     have-watchdog: false
     heat: running
     horizon: running
     keystone: running
     lb-c1a1: memcached,haproxy,mysqlinit,rabbitmq-conf,rabbitmq-run,keystone,glance,nova,cinder,neutron,heat,horizon,nosql,ceilometer
     lb-c1a2: memcached,haproxy,mysqlinit,rabbitmq-conf,rabbitmq-run,keystone,glance,nova,cinder,neutron,heat,horizon,nosql,ceilometer
     lb-c1a3: memcached,haproxy,mysqlinit,rabbitmq-conf,rabbitmq-run,keystone,glance,nova,cinder,neutron,heat,horizon,nosql,ceilometer
     neutron: running
     nosql: running
     nova: running
     stonith-enabled: false

