### PR TITLE
Use verify_on_create with pcmk_resource.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/resource/generic.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/generic.pp
@@ -7,9 +7,10 @@ define quickstack::pacemaker::resource::generic(
   $clone_opts           = undef,
   $group_opts           = undef,
   $resource_type        = "systemd",
-  $post_success_sleep   = 5,
-  $tries                = 4,
-  $try_sleep            = 30,
+  $tries                = 30,
+  $try_sleep            = 6,
+  $verify_on_create     = true,
+  $post_success_sleep   = undef,
 ) {
   include quickstack::pacemaker::params
 
@@ -30,9 +31,10 @@ define quickstack::pacemaker::resource::generic(
       op_params          => $operation_opts,
       clone_params       => $clone_opts,
       group_params       => $group_opts,
-      post_success_sleep => $post_success_sleep,
       tries              => $tries,
       try_sleep          => $try_sleep,
+      verify_on_create   => $verify_on_create,
+      post_success_sleep => $post_success_sleep,
     }
     -> anchor { "qprs end ${title}": }
   }

--- a/puppet/modules/quickstack/manifests/pacemaker/resource/ip.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/ip.pp
@@ -1,9 +1,13 @@
 define quickstack::pacemaker::resource::ip(
-  $ensure       = 'present',
-  $ip_address   = undef,
-  $cidr_netmask = 32,
-  $nic          = '',
-  $group_params = undef,
+  $ensure             = 'present',
+  $ip_address         = undef,
+  $cidr_netmask       = 32,
+  $nic                = '',
+  $group_params       = undef,
+  $tries              = 30,
+  $try_sleep          = 6,
+  $verify_on_create   = true,
+  $post_success_sleep = undef,
 ) {
   include quickstack::pacemaker::params
 
@@ -14,10 +18,14 @@ define quickstack::pacemaker::resource::ip(
     }
 
     pcmk_resource { "${title}-${ip_address}":
-      ensure          => $ensure,
-      resource_type   => 'IPaddr2',
-      resource_params => "ip=${ip_address} cidr_netmask=${cidr_netmask}${nic_option}",
-      group_params    => $group_params,
+      ensure             => $ensure,
+      resource_type      => 'IPaddr2',
+      resource_params    => "ip=${ip_address} cidr_netmask=${cidr_netmask}${nic_option}",
+      group_params       => $group_params,
+      tries              => $tries,
+      try_sleep          => $try_sleep,
+      verify_on_create   => $verify_on_create,
+      post_success_sleep => $post_success_sleep,
     }
   }
 }


### PR DESCRIPTION
To get around those rare cases where 'pcs resource create' doesn't
acutally succeed even if the exit status indicates success.

Depends on https://github.com/redhat-openstack/puppet-pacemaker/pull/54