### PR TITLE
BZ #1236180 - Missing redis-vip then ceilo-central pcs constraint.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/constraints.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraints.pp
@@ -219,6 +219,14 @@ class quickstack::pacemaker::constraints() {
     include quickstack::pacemaker::ceilometer
     if ($::quickstack::pacemaker::ceilometer::coordination_backend == 'redis') {
       $_ceilo_central_clone = 'ceilometer-central-clone'
+      $_redis_vip = map_params('redis_vip')
+      Quickstack::Pacemaker::Resource::Ip['ip-redis-pub'] ->
+      Quickstack::Pacemaker::Resource::Generic['ceilometer-central'] ->
+      quickstack::pacemaker::constraint::typical{ 'redis-vip-then-ceilo-central':
+        first_resource  => "ip-redis-pub-${_redis_vip}",
+        second_resource => $_ceilo_central_clone,
+        colocation      => false,
+      }
     } else {
       $_ceilo_central_clone = 'ceilometer-central'
     }


### PR DESCRIPTION
Matches the ref arch constraint: https://github.com/beekhof/osp-ha-deploy/blob/f73eec96ddd9c7f2c85dbb0348ff909f144631ec/pcmk/ceilometer.scenario#L92

Results in puppet output:

    Debug: Exec[Creating order constraint redis-vip-then-ceilo-central](provider=posix): Executing '/usr/sbin/pcs constraint order start ip-redis-pub-192.168.201.56 then start ceilometer-central-clone'
    Debug: Executing '/usr/sbin/pcs constraint order start ip-redis-pub-192.168.201.56 then start ceilometer-central-clone'
    Notice: /Stage[main]/Quickstack::Pacemaker::Constraints/Quickstack::Pacemaker::Constraint::Typical[redis-vip-then-ceilo-central]/Quickstack::Pacemaker::Constraint::Base[redis-vip-then-ceilo-central]/Pacemaker::Constraint::Base[redis-vip-then-ceilo-central]/Exec[Creating order constraint redis-vip-then-ceilo-central]/returns: executed successfully

Results in constraint:

    # pcs constraint | grep ip-redis | grep ceilo
    pcs constraint | grep ip-redis | grep ceilo
      start ip-redis-pub-192.168.201.56 then start ceilometer-central-clone (kind:Mandatory)


