### PR TITLE
BZ #1236180 - Updated redis-vip then ceilo-central constraint

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/constraints.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/constraints.pp
@@ -219,13 +219,11 @@ class quickstack::pacemaker::constraints() {
     include quickstack::pacemaker::ceilometer
     if ($::quickstack::pacemaker::ceilometer::coordination_backend == 'redis') {
       $_ceilo_central_clone = 'ceilometer-central-clone'
-      $_redis_vip = map_params('redis_vip')
-      Quickstack::Pacemaker::Resource::Ip['ip-redis-pub'] ->
-      Quickstack::Pacemaker::Resource::Generic['ceilometer-central'] ->
-      quickstack::pacemaker::constraint::typical{ 'redis-vip-then-ceilo-central':
-        first_resource  => "ip-redis-pub-${_redis_vip}",
-        second_resource => $_ceilo_central_clone,
-        colocation      => false,
+      $redis_group = map_params("redis_group")
+      quickstack::pacemaker::constraint::haproxy_vips { "$redis_group":
+        public_vip  => map_params("redis_vip"),
+        private_vip => map_params("redis_vip"),
+        admin_vip   => map_params("redis_vip"),
       }
     } else {
       $_ceilo_central_clone = 'ceilometer-central'

--- a/puppet/modules/quickstack/manifests/pacemaker/redis.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/redis.pp
@@ -70,7 +70,7 @@ class quickstack::pacemaker::redis(
     timeout   => 3600,
     tries     => 360,
     try_sleep => 10,
-    command => "bash -c 'pcs constraint show | grep -qs \"ip-redis-pub-${_redis_vip} with redis-master\"'",
+    command => "bash -c 'pcs constraint show | grep -qs \"redis-master then start ip-redis-pub-${_redis_vip}\"'",
     path => ['/usr/sbin', '/usr/bin'],
   }
 
@@ -81,19 +81,4 @@ class quickstack::pacemaker::redis(
     backend_server_names => map_params("lb_backend_server_names"),
     backend_server_addrs => map_params("lb_backend_server_addrs"),
   }
-
-  if has_interface_with("ipaddress", map_params("cluster_control_ip")){
-    # using an exec here because of the "with master" clause which
-    # current colocation classes do not support.
-    Quickstack::Pacemaker::Constraint::Base['redis-master-then-vip-redis']
-    ->
-    exec{ 'redis-master-and-vip-colo':
-      command => "pcs constraint colocation add ip-redis-pub-${_redis_vip} with master redis-master",
-      unless => "bash -c 'pcs constraint show | grep -qs \"ip-redis-pub-${_redis_vip} with redis-master\"'",
-      path => ['/usr/sbin', '/usr/bin'],
-    }
-    ->
-    Exec['redis-master-is-up']
-  }
-
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1236180

The redis-vip then ceilo-central constraint should be Optional not
Mandator (so as to avoid a big cascade of resources being stopped if
the redis vip moves).

Also removes redis-vip colocation with redis-master.  Not necessary
since haproxy forwards from the VIP appropriately.