### PR TITLE
Pacemaker timeout=60 for nova-api,nova-conductor.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/nova.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/nova.pp
@@ -120,11 +120,17 @@ class quickstack::pacemaker::nova (
     }
     ->
     quickstack::pacemaker::resource::generic {
+      [ 'nova-api',
+        'nova-conductor' ]:
+      resource_name_prefix => 'openstack-',
+      clone_opts           => "interleave=true",
+      operation_opts       => 'start timeout=60',
+    }
+    ->
+    quickstack::pacemaker::resource::generic {
       [ 'nova-consoleauth',
         'nova-novncproxy',
-        'nova-api',
-        'nova-scheduler',
-        'nova-conductor' ]:
+        'nova-scheduler' ]:
       resource_name_prefix => 'openstack-',
       clone_opts           => "interleave=true",
     }


### PR DESCRIPTION
Tested.  Results in pcs resource create commands:

    Debug: try 1/30: /usr/sbin/pcs resource create nova-api systemd:openstack-nova-api op start timeout=60 --clone interleave=true
    Debug: try 1/30: /usr/sbin/pcs resource create nova-conductor systemd:openstack-nova-conductor op start timeout=60 --clone interleave=true
