### PR TITLE
BZ #1187831 - change from ["admin"] to admin heat_stack_owner failed.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/keystone.pp
@@ -128,7 +128,8 @@ class quickstack::pacemaker::keystone (
       Anchor['galera-online'] -> Exec['i-am-keystone-vip-OR-keystone-is-up-on-vip']
     }
     if (str2bool_i(map_params('include_heat'))) {
-      if (is_configured('heat')) {
+      $_is_control = has_interface_with("ipaddress", map_params("cluster_control_ip"))
+      if (is_configured('heat') and $_is_control) {
         $_extra_admin_roles = ['heat_stack_owner']
       } else {
         $_extra_admin_roles = []


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1187831

This makes sure the extra heat stack owner role is only passed in
both when heat is configured, and the running node is the control
node.  This should prevent 2 nodes from ever trying to add this role
at the same time.