### PR TITLE
BZ #1240826 - Increase the default max_connections for galera.

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/galera.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/galera.pp
@@ -1,6 +1,6 @@
 class quickstack::pacemaker::galera (
   $limit_no_file            ="16384",
-  $max_connections         = "1024",
+  $max_connections         = "4096",
   $mysql_root_password     = '',
   $open_files_limit        = '-1',
   $galera_monitor_username = 'monitor_user',


### PR DESCRIPTION
This parameter was already configurable, but the BZ is requesting
a larger default value that is more likely to be a sane default for
a production environment.