### PR TITLE
BZ #1247684 - Puppet Error 400 for cinder dell_sc multibackend.

### DIFF
--- a/puppet/modules/quickstack/manifests/dellsc/volume.pp
+++ b/puppet/modules/quickstack/manifests/dellsc/volume.pp
@@ -1,4 +1,4 @@
-define quickstack::dell_sc_iscsi::volume (
+define quickstack::dellsc::volume (
   $index,
   $backend_section_name_array,
   $backend_dell_sc_name_array,
@@ -41,7 +41,7 @@ define quickstack::dell_sc_iscsi::volume (
 
     #recurse
     $next = $index -1
-    quickstack::dellsc::dellsc_iscsi {$next:
+    quickstack::dellsc::volume {$next:
       index                          => $next,
       backend_section_name_array     => $backend_section_name_array,
       backend_dell_sc_name_array     => $backend_dell_sc_name_array,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1247684

The directory structure of dellsc::volume did not match the name of the define,
causing puppet to be unable to find the requested define.