### PR TITLE
BZ #1247684 Puppet Errors with cinder Dell SC multibackend

### DIFF
--- a/puppet/modules/quickstack/manifests/cinder_volume.pp
+++ b/puppet/modules/quickstack/manifests/cinder_volume.pp
@@ -253,7 +253,7 @@ class quickstack::cinder_volume(
       $last = $count -1
       $dell_sc_backends = produce_array_with_prefix('dell_sc',1,$count)  #Initialize with section headers
 
-      quickstack::dellsc::volume { $last:
+      quickstack::dell::sc_iscsi::volume { $last:
         index                          => $last,
         backend_section_name_array     => $dell_sc_backends,
         backend_dell_sc_name_array     => $backend_dell_sc_name,

--- a/puppet/modules/quickstack/manifests/cinder_volume_types.pp
+++ b/puppet/modules/quickstack/manifests/cinder_volume_types.pp
@@ -36,7 +36,7 @@ class quickstack::cinder_volume_types(
   }
 
   if str2bool_i($backend_dell_sc) {
-    $dell_sc_last_index = size($backend_dell_sc) - 1
+    $dell_sc_last_index = size($backend_dell_sc_name) - 1
 
     Exec['wait-for-cinder-api-being-reachable'] ->
     quickstack::cinder::multi_instance_type { "dell-sc-${dell_sc_last_index}":

--- a/puppet/modules/quickstack/manifests/dell/sc_iscsi/volume.pp
+++ b/puppet/modules/quickstack/manifests/dell/sc_iscsi/volume.pp
@@ -1,4 +1,4 @@
-define quickstack::dell_sc_iscsi::volume (
+define quickstack::dell::sc_iscsi::volume (
   $index,
   $backend_section_name_array,
   $backend_dell_sc_name_array,
@@ -37,11 +37,12 @@ define quickstack::dell_sc_iscsi::volume (
       dell_sc_ssn           => $dell_sc_ssn,
       dell_sc_api_port      => $dell_sc_api_port,
       dell_sc_server_folder => $dell_sc_server_folder,
+      dell_sc_volume_folder => $dell_sc_volume_folder,
     }
 
     #recurse
     $next = $index -1
-    quickstack::dellsc::dellsc_iscsi {$next:
+    quickstack::dell::sc_iscsi::volume {$next:
       index                          => $next,
       backend_section_name_array     => $backend_section_name_array,
       backend_dell_sc_name_array     => $backend_dell_sc_name_array,

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -36,8 +36,6 @@ class quickstack::params (
   $cinder_backend_iscsi_name    = 'iscsi',
   $cinder_backend_nfs           = false,
   $cinder_backend_nfs_name      = 'nfs',
-  $cinder_backend_dell_sc       = false,
-  $cinder_backend_dell_sc_name  = ['dell_sc'],
   $cinder_backend_eqlx          = false,
   $cinder_backend_eqlx_name     = ['eqlx'],
   $cinder_backend_netapp        = false,
@@ -53,16 +51,6 @@ class quickstack::params (
   # Cinder nfs
   $cinder_nfs_shares            = [ '192.168.0.4:/cinder' ],
   $cinder_nfs_mount_options     = '',
-  # Cinder Dell Storage Center ISCSI
-  $cinder_dell_sc_san_ip           = ['172.23.8.101'],
-  $cinder_dell_sc_san_login        = ['Admin'],
-  $cinder_dell_sc_san_password     = ['CHANGEME'],
-  $cinder_dell_sc_iscsi_ip_address = ['192.168.0.20'],
-  $cinder_dell_sc_iscsi_port       = [3260],
-  $cinder_dell_sc_ssn              = ['64702'],
-  $cinder_dell_sc_api_port         = [3033],
-  $cinder_dell_sc_server_folder    = ['server'],
-  $cinder_dell_sc_volume_folder    = ['volume'],
   # Cinder Dell EqualLogic
   $cinder_san_ip                = ['192.168.124.11'],
   $cinder_san_login             = ['grpadmin'],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1247684

The directory structure of dellsc::volume did not match the name of the define,
causing puppet to be unable to find the requested define.

And there was typo in evaluating the last index when defining types.