### PR TITLE
BZ #1220596 - Allow override of neutron load balancer timeouts.

### DIFF
--- a/puppet/modules/quickstack/manifests/load_balancer/neutron.pp
+++ b/puppet/modules/quickstack/manifests/load_balancer/neutron.pp
@@ -6,7 +6,9 @@ class quickstack::load_balancer::neutron (
   $backend_server_addrs,
   $api_port         = '9696',
   $api_mode         = 'tcp',
-  $api_log         = 'tcplog',
+  $api_log          = 'tcplog',
+  $timeout          = ['client 30s', 'server 30s',
+                      'http-request 30s'],
 ) {
 
   include quickstack::load_balancer::common
@@ -17,7 +19,9 @@ class quickstack::load_balancer::neutron (
                               $frontend_admin_host ],
     port                 => "$api_port",
     mode                 => "$api_mode",
-    listen_options       => { 'option' => [ "$api_log" ] },
+    listen_options       => { 'option'   => [ "$api_log" ],
+                              'timeout' => $timeout,
+                            },
     member_options       => [ 'check inter 1s' ],
     backend_server_addrs => $backend_server_addrs,
     backend_server_names => $backend_server_names,

--- a/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/neutron.pp
@@ -7,6 +7,8 @@ class quickstack::pacemaker::neutron (
   $enabled                    = true,
   $external_network_bridge    = '',
   $enable_vif_type_n1kv       = false,
+  $haproxy_timeout            = ['client 30s', 'server 30s',
+                                'http-request 30s'],
   $l3_ha                      = true,
   $ml2_type_drivers           = ['local', 'flat', 'vlan', 'gre', 'vxlan'],
   $ml2_tenant_network_types   = ['vxlan', 'vlan', 'gre', 'flat'],
@@ -140,10 +142,11 @@ class quickstack::pacemaker::neutron (
 
     class {"::quickstack::load_balancer::neutron":
       frontend_pub_host    => map_params("neutron_public_vip"),
-      frontend_priv_host    => map_params("neutron_private_vip"),
-      frontend_admin_host    => map_params("neutron_admin_vip"),
+      frontend_priv_host   => map_params("neutron_private_vip"),
+      frontend_admin_host  => map_params("neutron_admin_vip"),
       backend_server_names => $_backend_server_names,
       backend_server_addrs => $_backend_server_addrs,
+      timeout              => $haproxy_timeout,
     }
 
     Class['::quickstack::pacemaker::common']


### PR DESCRIPTION
This is an array of any timeouts the user wishes to set, so can
be expanded or collapsed.