### PR TITLE
Enable Neutron quota support in Horizon to fix bz1254780

### DIFF
--- a/puppet/modules/quickstack/manifests/horizon.pp
+++ b/puppet/modules/quickstack/manifests/horizon.pp
@@ -60,7 +60,7 @@ class quickstack::horizon(
 
   $neutron_options   = {'enable_lb' => true,
                         'enable_firewall' => true,
-                        'enable_quotas' => false,
+                        'enable_quotas' => true,
                         'enable_security_group' => false,
                         'enable_vpn' => true,
                         'profile_support' => $_profile_support }


### PR DESCRIPTION
I'm not sure why quotas were disabled for Neutron in Horizon, but it breaks the UI in OSP7.

https://bugzilla.redhat.com/show_bug.cgi?id=1254780
