### PR TITLE
BZ #1292555 - Remove operator access from command

### DIFF
--- a/puppet/modules/quickstack/manifests/pacemaker/resource/generic.pp
+++ b/puppet/modules/quickstack/manifests/pacemaker/resource/generic.pp
@@ -23,7 +23,7 @@ define quickstack::pacemaker::resource::generic(
     }
 
     if $operation_opts != undef {
-      $_operation_opts = "op ${operation_opts}"
+      $_operation_opts = "${operation_opts}"
     } else {
       $_operation_opts = ""
     }


### PR DESCRIPTION
Remove operator access to set $_operation_opts when $operation_opts is defined.